### PR TITLE
docs(google_cloud_ai...): Adds examples

### DIFF
--- a/generated/google_cloud_ai_generativelanguage_v1beta/.sidekick.toml
+++ b/generated/google_cloud_ai_generativelanguage_v1beta/.sidekick.toml
@@ -69,6 +69,7 @@ import 'package:google_cloud_ai_generativelanguage_v1beta/generativelanguage.dar
 
 void main() async {
   // Pass your API key here if the GEMINI_API_KEY environment variable is not set.
+  // See https://ai.google.dev/gemini-api/docs/api-key
   final service = GenerativeService.fromApiKey();
 
   final request = GenerateContentRequest(
@@ -79,11 +80,11 @@ void main() async {
   );
 
   final result = await service.generateContent(request);
-  final textResponse = result.candidates?[0].content?.parts?[0].text;
-  if (textResponse == null) {
+  final parts = result.candidates?[0].content?.parts;
+  if (parts == null) {
     print('<No textual response>');
   } else {
-    print(textResponse);
+    print(parts.map((p) => p.text ?? '').join(''));
   }
 
   service.close();

--- a/generated/google_cloud_ai_generativelanguage_v1beta/README.md
+++ b/generated/google_cloud_ai_generativelanguage_v1beta/README.md
@@ -76,6 +76,7 @@ import 'package:google_cloud_ai_generativelanguage_v1beta/generativelanguage.dar
 
 void main() async {
   // Pass your API key here if the GEMINI_API_KEY environment variable is not set.
+  // See https://ai.google.dev/gemini-api/docs/api-key
   final service = GenerativeService.fromApiKey();
 
   final request = GenerateContentRequest(
@@ -86,11 +87,11 @@ void main() async {
   );
 
   final result = await service.generateContent(request);
-  final textResponse = result.candidates?[0].content?.parts?[0].text;
-  if (textResponse == null) {
+  final parts = result.candidates?[0].content?.parts;
+  if (parts == null) {
     print('<No textual response>');
   } else {
-    print(textResponse);
+    print(parts.map((p) => p.text ?? '').join(''));
   }
 
   service.close();

--- a/generated/google_cloud_ai_generativelanguage_v1beta/example/application_default_credentials.dart
+++ b/generated/google_cloud_ai_generativelanguage_v1beta/example/application_default_credentials.dart
@@ -1,0 +1,56 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:io';
+
+import 'package:google_cloud_ai_generativelanguage_v1beta/generativelanguage.dart';
+import 'package:googleapis_auth/auth_io.dart' as auth;
+
+void main() async {
+  // Connects to the Generative Language API using Application Default
+  // Connections (ADC).
+  //
+  // Before running this example, you need to authenticate with gcloud:
+  //
+  // ```
+  // $ gcloud auth application-default login \
+  //   --scopes=https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/generative-language.retriever
+  // ```
+  //
+  // See https://cloud.google.com/docs/authentication/application-default-credentials
+  final client = await auth.clientViaApplicationDefaultCredentials(
+    scopes: [
+      'https://www.googleapis.com/auth/cloud-platform',
+      'https://www.googleapis.com/auth/generative-language.retriever',
+    ],
+  );
+  final service = GenerativeService(client: client);
+
+  final request = GenerateContentRequest(
+    model: 'models/gemini-2.5-flash',
+    contents: [
+      Content(parts: [Part(text: "Explain how AI works in a few words")]),
+    ],
+  );
+
+  final result = await service.generateContent(request);
+  final parts = result.candidates?[0].content?.parts;
+  if (parts == null) {
+    print('<No textual response>');
+  } else {
+    print(parts.map((p) => p.text ?? '').join(''));
+  }
+
+  service.close();
+}

--- a/generated/google_cloud_ai_generativelanguage_v1beta/example/main.dart
+++ b/generated/google_cloud_ai_generativelanguage_v1beta/example/main.dart
@@ -1,0 +1,38 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:google_cloud_ai_generativelanguage_v1beta/generativelanguage.dart';
+
+void main() async {
+  // Pass your API key here if the GEMINI_API_KEY environment variable is not set.
+  // See https://ai.google.dev/gemini-api/docs/api-key
+  final service = GenerativeService.fromApiKey();
+
+  final request = GenerateContentRequest(
+    model: 'models/gemini-2.5-flash',
+    contents: [
+      Content(parts: [Part(text: "Explain how AI works in a few words")]),
+    ],
+  );
+
+  final result = await service.generateContent(request);
+  final parts = result.candidates?[0].content?.parts;
+  if (parts == null) {
+    print('<No textual response>');
+  } else {
+    print(parts.map((p) => p.text ?? '').join(''));
+  }
+
+  service.close();
+}

--- a/generated/google_cloud_ai_generativelanguage_v1beta/example/streamed_response.dart
+++ b/generated/google_cloud_ai_generativelanguage_v1beta/example/streamed_response.dart
@@ -1,0 +1,38 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:io';
+
+import 'package:google_cloud_ai_generativelanguage_v1beta/generativelanguage.dart';
+
+void main() async {
+  // Pass your API key here if the GEMINI_API_KEY environment variable is not set.
+  // See https://ai.google.dev/gemini-api/docs/api-key
+  final service = GenerativeService.fromApiKey();
+
+  final request = GenerateContentRequest(
+    model: 'models/gemini-2.5-flash',
+    contents: [
+      Content(parts: [Part(text: "Explain how AI works in extensive detail")]),
+    ],
+  );
+
+  await for (final result in service.streamGenerateContent(request)) {
+    final parts = result.candidates?[0].content?.parts;
+    if (parts != null) {
+      parts.forEach((p) => stdout.write(p.text ?? ''));
+    }
+  }
+  service.close();
+}


### PR DESCRIPTION
Adds three examples:
1. the simplest possible case
2. a streaming response
3. using application default credentials

Fixes https://github.com/googleapis/google-cloud-dart/issues/18