### PR TITLE
feat: Use correct issue tracker urls

### DIFF
--- a/.github/workflows/dart_checks.yaml
+++ b/.github/workflows/dart_checks.yaml
@@ -90,7 +90,7 @@ jobs:
       - name: Regenerate existing clients
         # The current head version of sidekick can be generated with:
         # GOPROXY=direct go list -m -u -f '{{.Version}}' github.com/googleapis/librarian@main
-        run: go run github.com/googleapis/librarian/cmd/sidekick@v0.3.1-0.20251013160330-f7a65558c218 refreshall -project-root .
+        run: go run github.com/googleapis/librarian/cmd/sidekick@v0.4.1-0.20251014194539-10493ed9a20e refreshall -project-root .
       - name: Generated Diff
         run: git diff --exit-code
 

--- a/.sidekick.toml
+++ b/.sidekick.toml
@@ -30,6 +30,7 @@ protobuf-subdir         = "src"
 version = "0.1.0"
 
 api-keys-environment-variables = "GOOGLE_API_KEY"
+issue-tracker-url = "https://github.com/googleapis/google-cloud-dart/issues"
 
 # Default package dependency versions.
 'package:googleapis_auth'  = '^2.0.0'

--- a/generated/google_cloud_ai_generativelanguage_v1beta/.sidekick.toml
+++ b/generated/google_cloud_ai_generativelanguage_v1beta/.sidekick.toml
@@ -20,6 +20,7 @@ service-config = 'google/ai/generativelanguage/v1beta/generativelanguage_v1beta.
 copyright-year = '2025'
 
 api-keys-environment-variables = "GOOGLE_API_KEY,GEMINI_API_KEY"
+repository-url = "https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_ai_generativelanguage_v1beta"
 
 readme-after-title-text = '''
 > [!TIP]

--- a/generated/google_cloud_ai_generativelanguage_v1beta/README.md
+++ b/generated/google_cloud_ai_generativelanguage_v1beta/README.md
@@ -25,7 +25,7 @@ The Google Cloud client library for the Generative Language API.
 >
 > Your feedback is valuable and will help us evolve this package. For general
 > feedback, suggestions, and comments, please file an issue in the
-> [bug tracker](/issues).
+> [bug tracker](https://github.com/googleapis/google-cloud-dart/issues).
 
 ## What's this?
 

--- a/generated/google_cloud_ai_generativelanguage_v1beta/pubspec.yaml
+++ b/generated/google_cloud_ai_generativelanguage_v1beta/pubspec.yaml
@@ -16,6 +16,8 @@
 
 name: google_cloud_ai_generativelanguage_v1beta
 description: The Google Cloud client library for the Generative Language API.
+repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_ai_generativelanguage_v1beta
+issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 version: 0.1.0
 
 environment:

--- a/generated/google_cloud_api/.sidekick.toml
+++ b/generated/google_cloud_api/.sidekick.toml
@@ -21,3 +21,4 @@ name-override = 'api'
 
 [codec]
 copyright-year = '2025'
+repository-url = "https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_api"

--- a/generated/google_cloud_api/README.md
+++ b/generated/google_cloud_api/README.md
@@ -16,7 +16,7 @@ The Google Cloud client library for the Service Config API.
 >
 > Your feedback is valuable and will help us evolve this package. For general
 > feedback, suggestions, and comments, please file an issue in the
-> [bug tracker](/issues).
+> [bug tracker](https://github.com/googleapis/google-cloud-dart/issues).
 
 ## What's this?
 

--- a/generated/google_cloud_api/pubspec.yaml
+++ b/generated/google_cloud_api/pubspec.yaml
@@ -16,6 +16,8 @@
 
 name: google_cloud_api
 description: The Google Cloud client library for the Service Config API.
+repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_api
+issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 version: 0.1.0
 
 environment:

--- a/generated/google_cloud_common/.sidekick.toml
+++ b/generated/google_cloud_common/.sidekick.toml
@@ -21,3 +21,4 @@ description-override = 'Additional metadata for operations.'
 
 [codec]
 copyright-year = '2025'
+repository-url = "https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_common"

--- a/generated/google_cloud_common/README.md
+++ b/generated/google_cloud_common/README.md
@@ -16,7 +16,7 @@ The Google Cloud client library for the Common Operation Metadata type.
 >
 > Your feedback is valuable and will help us evolve this package. For general
 > feedback, suggestions, and comments, please file an issue in the
-> [bug tracker](/issues).
+> [bug tracker](https://github.com/googleapis/google-cloud-dart/issues).
 
 ## What's this?
 

--- a/generated/google_cloud_common/pubspec.yaml
+++ b/generated/google_cloud_common/pubspec.yaml
@@ -16,6 +16,8 @@
 
 name: google_cloud_common
 description: The Google Cloud client library for the Common Operation Metadata type.
+repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_common
+issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 version: 0.1.0
 
 environment:

--- a/generated/google_cloud_functions_v2/.sidekick.toml
+++ b/generated/google_cloud_functions_v2/.sidekick.toml
@@ -18,3 +18,4 @@ service-config = 'google/cloud/functions/v2/cloudfunctions_v2.yaml'
 
 [codec]
 copyright-year = '2025'
+repository-url = "https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_functions_v2"

--- a/generated/google_cloud_functions_v2/README.md
+++ b/generated/google_cloud_functions_v2/README.md
@@ -16,7 +16,7 @@ The Google Cloud client library for the Cloud Functions API.
 >
 > Your feedback is valuable and will help us evolve this package. For general
 > feedback, suggestions, and comments, please file an issue in the
-> [bug tracker](/issues).
+> [bug tracker](https://github.com/googleapis/google-cloud-dart/issues).
 
 ## What's this?
 

--- a/generated/google_cloud_functions_v2/pubspec.yaml
+++ b/generated/google_cloud_functions_v2/pubspec.yaml
@@ -16,6 +16,8 @@
 
 name: google_cloud_functions_v2
 description: The Google Cloud client library for the Cloud Functions API.
+repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_functions_v2
+issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 version: 0.1.0
 
 environment:

--- a/generated/google_cloud_iam_v1/.sidekick.toml
+++ b/generated/google_cloud_iam_v1/.sidekick.toml
@@ -21,3 +21,4 @@ name-override = 'iam'
 
 [codec]
 copyright-year = '2025'
+repository-url = "https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_iam_v1"

--- a/generated/google_cloud_iam_v1/README.md
+++ b/generated/google_cloud_iam_v1/README.md
@@ -16,7 +16,7 @@ The Google Cloud client library for the IAM Meta API.
 >
 > Your feedback is valuable and will help us evolve this package. For general
 > feedback, suggestions, and comments, please file an issue in the
-> [bug tracker](/issues).
+> [bug tracker](https://github.com/googleapis/google-cloud-dart/issues).
 
 ## What's this?
 

--- a/generated/google_cloud_iam_v1/pubspec.yaml
+++ b/generated/google_cloud_iam_v1/pubspec.yaml
@@ -16,6 +16,8 @@
 
 name: google_cloud_iam_v1
 description: The Google Cloud client library for the IAM Meta API.
+repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_iam_v1
+issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 version: 0.1.0
 
 environment:

--- a/generated/google_cloud_language_v2/.sidekick.toml
+++ b/generated/google_cloud_language_v2/.sidekick.toml
@@ -18,3 +18,4 @@ service-config = 'google/cloud/language/v2/language_v2.yaml'
 
 [codec]
 copyright-year = '2025'
+repository-url = "https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_language_v2"

--- a/generated/google_cloud_language_v2/README.md
+++ b/generated/google_cloud_language_v2/README.md
@@ -16,7 +16,7 @@ The Google Cloud client library for the Cloud Natural Language API.
 >
 > Your feedback is valuable and will help us evolve this package. For general
 > feedback, suggestions, and comments, please file an issue in the
-> [bug tracker](/issues).
+> [bug tracker](https://github.com/googleapis/google-cloud-dart/issues).
 
 ## What's this?
 

--- a/generated/google_cloud_language_v2/pubspec.yaml
+++ b/generated/google_cloud_language_v2/pubspec.yaml
@@ -16,6 +16,8 @@
 
 name: google_cloud_language_v2
 description: The Google Cloud client library for the Cloud Natural Language API.
+repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_language_v2
+issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 version: 0.1.0
 
 environment:

--- a/generated/google_cloud_location/.sidekick.toml
+++ b/generated/google_cloud_location/.sidekick.toml
@@ -21,3 +21,4 @@ name-override = 'location'
 
 [codec]
 copyright-year = '2025'
+repository-url = "https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_location"

--- a/generated/google_cloud_location/README.md
+++ b/generated/google_cloud_location/README.md
@@ -16,7 +16,7 @@ The Google Cloud client library for the Cloud Metadata API.
 >
 > Your feedback is valuable and will help us evolve this package. For general
 > feedback, suggestions, and comments, please file an issue in the
-> [bug tracker](/issues).
+> [bug tracker](https://github.com/googleapis/google-cloud-dart/issues).
 
 ## What's this?
 

--- a/generated/google_cloud_location/pubspec.yaml
+++ b/generated/google_cloud_location/pubspec.yaml
@@ -16,6 +16,8 @@
 
 name: google_cloud_location
 description: The Google Cloud client library for the Cloud Metadata API.
+repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_location
+issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 version: 0.1.0
 
 environment:

--- a/generated/google_cloud_longrunning/.sidekick.toml
+++ b/generated/google_cloud_longrunning/.sidekick.toml
@@ -33,3 +33,4 @@ operations.
 copyright-year = '2025'
 dev-dependencies = "test"
 part-file = "src/longrunning.p.dart"
+repository-url = "https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_longrunning"

--- a/generated/google_cloud_longrunning/README.md
+++ b/generated/google_cloud_longrunning/README.md
@@ -16,7 +16,7 @@ The Google Cloud client library for the Long Running Operations API.
 >
 > Your feedback is valuable and will help us evolve this package. For general
 > feedback, suggestions, and comments, please file an issue in the
-> [bug tracker](/issues).
+> [bug tracker](https://github.com/googleapis/google-cloud-dart/issues).
 
 ## What's this?
 

--- a/generated/google_cloud_longrunning/pubspec.yaml
+++ b/generated/google_cloud_longrunning/pubspec.yaml
@@ -16,6 +16,8 @@
 
 name: google_cloud_longrunning
 description: The Google Cloud client library for the Long Running Operations API.
+repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_longrunning
+issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 version: 0.1.0
 
 environment:

--- a/generated/google_cloud_protobuf/.sidekick.toml
+++ b/generated/google_cloud_protobuf/.sidekick.toml
@@ -37,3 +37,4 @@ include-list = """\
 copyright-year   = '2025'
 part-file        = "src/protobuf.p.dart"
 dev-dependencies = "test"
+repository-url = "https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_protobuf"

--- a/generated/google_cloud_protobuf/README.md
+++ b/generated/google_cloud_protobuf/README.md
@@ -16,7 +16,7 @@ The Google Cloud client library for the Core Protobuf Types.
 >
 > Your feedback is valuable and will help us evolve this package. For general
 > feedback, suggestions, and comments, please file an issue in the
-> [bug tracker](/issues).
+> [bug tracker](https://github.com/googleapis/google-cloud-dart/issues).
 
 ## What's this?
 

--- a/generated/google_cloud_protobuf/pubspec.yaml
+++ b/generated/google_cloud_protobuf/pubspec.yaml
@@ -16,6 +16,8 @@
 
 name: google_cloud_protobuf
 description: The Google Cloud client library for the Core Protobuf Types.
+repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_protobuf
+issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 version: 0.1.0
 
 environment:

--- a/generated/google_cloud_rpc/.sidekick.toml
+++ b/generated/google_cloud_rpc/.sidekick.toml
@@ -20,3 +20,4 @@ service-config = 'google/rpc/rpc_publish.yaml'
 copyright-year = '2025'
 part-file = "src/rpc.p.dart"
 dev-dependencies = "test"
+repository-url = "https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_rpc"

--- a/generated/google_cloud_rpc/README.md
+++ b/generated/google_cloud_rpc/README.md
@@ -16,7 +16,7 @@ The Google Cloud client library for the Google RPC Types.
 >
 > Your feedback is valuable and will help us evolve this package. For general
 > feedback, suggestions, and comments, please file an issue in the
-> [bug tracker](/issues).
+> [bug tracker](https://github.com/googleapis/google-cloud-dart/issues).
 
 ## What's this?
 

--- a/generated/google_cloud_rpc/pubspec.yaml
+++ b/generated/google_cloud_rpc/pubspec.yaml
@@ -16,6 +16,8 @@
 
 name: google_cloud_rpc
 description: The Google Cloud client library for the Google RPC Types.
+repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_rpc
+issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 version: 0.1.0
 
 environment:

--- a/generated/google_cloud_secretmanager_v1/.sidekick.toml
+++ b/generated/google_cloud_secretmanager_v1/.sidekick.toml
@@ -18,3 +18,4 @@ service-config = 'google/cloud/secretmanager/v1/secretmanager_v1.yaml'
 
 [codec]
 copyright-year = '2025'
+repository-url = "https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_secretmanager_v1"

--- a/generated/google_cloud_secretmanager_v1/README.md
+++ b/generated/google_cloud_secretmanager_v1/README.md
@@ -16,7 +16,7 @@ The Google Cloud client library for the Secret Manager API.
 >
 > Your feedback is valuable and will help us evolve this package. For general
 > feedback, suggestions, and comments, please file an issue in the
-> [bug tracker](/issues).
+> [bug tracker](https://github.com/googleapis/google-cloud-dart/issues).
 
 ## What's this?
 

--- a/generated/google_cloud_secretmanager_v1/pubspec.yaml
+++ b/generated/google_cloud_secretmanager_v1/pubspec.yaml
@@ -16,6 +16,8 @@
 
 name: google_cloud_secretmanager_v1
 description: The Google Cloud client library for the Secret Manager API.
+repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_secretmanager_v1
+issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 version: 0.1.0
 
 environment:

--- a/generated/google_cloud_type/.sidekick.toml
+++ b/generated/google_cloud_type/.sidekick.toml
@@ -18,3 +18,4 @@ service-config = 'google/type/type.yaml'
 
 [codec]
 copyright-year = '2025'
+repository-url = "https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_type"

--- a/generated/google_cloud_type/README.md
+++ b/generated/google_cloud_type/README.md
@@ -16,7 +16,7 @@ The Google Cloud client library for the Common Types.
 >
 > Your feedback is valuable and will help us evolve this package. For general
 > feedback, suggestions, and comments, please file an issue in the
-> [bug tracker](/issues).
+> [bug tracker](https://github.com/googleapis/google-cloud-dart/issues).
 
 ## What's this?
 

--- a/generated/google_cloud_type/pubspec.yaml
+++ b/generated/google_cloud_type/pubspec.yaml
@@ -16,6 +16,8 @@
 
 name: google_cloud_type
 description: The Google Cloud client library for the Common Types.
+repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_type
+issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 version: 0.1.0
 
 environment:


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloud-dart/issues/8

The only non-generates changes are to:
1. dart_checks.yaml
2. **/.sidekick.toml