### PR TITLE
feat: Remove protobuf dep on _gax

### DIFF
--- a/.github/workflows/dart_checks.yaml
+++ b/.github/workflows/dart_checks.yaml
@@ -90,6 +90,6 @@ jobs:
       - name: Regenerate existing clients
         # The current head version of sidekick can be generated with:
         # GOPROXY=direct go list -m -u -f '{{.Version}}' github.com/googleapis/librarian@main
-        run: go run github.com/googleapis/librarian/cmd/sidekick@v0.4.1-0.20251021180646-b3ac7b4235e8 refreshall -project-root .
+        run: go run github.com/googleapis/librarian/cmd/sidekick@v0.5.1-0.20251023195721-e607ea63417e refreshall -project-root .
       - name: Generated Diff
         run: git diff --exit-code

--- a/generated/google_cloud_ai_generativelanguage_v1beta/lib/generativelanguage.dart
+++ b/generated/google_cloud_ai_generativelanguage_v1beta/lib/generativelanguage.dart
@@ -26,9 +26,9 @@
 library;
 
 import 'package:google_cloud_gax/gax.dart';
-import 'package:google_cloud_gax/src/encoding.dart';
 import 'package:google_cloud_longrunning/longrunning.dart';
 import 'package:google_cloud_protobuf/protobuf.dart';
+import 'package:google_cloud_protobuf/src/encoding.dart';
 import 'package:google_cloud_rpc/rpc.dart';
 import 'package:google_cloud_type/type.dart';
 import 'package:googleapis_auth/auth_io.dart' as auth;

--- a/generated/google_cloud_aiplatform_v1beta1/lib/aiplatform.dart
+++ b/generated/google_cloud_aiplatform_v1beta1/lib/aiplatform.dart
@@ -22,11 +22,11 @@ library;
 
 import 'package:google_cloud_api/api.dart';
 import 'package:google_cloud_gax/gax.dart';
-import 'package:google_cloud_gax/src/encoding.dart';
 import 'package:google_cloud_iam_v1/iam.dart';
 import 'package:google_cloud_location/location.dart';
 import 'package:google_cloud_longrunning/longrunning.dart';
 import 'package:google_cloud_protobuf/protobuf.dart' as protobuf;
+import 'package:google_cloud_protobuf/src/encoding.dart';
 import 'package:google_cloud_rpc/rpc.dart';
 import 'package:google_cloud_type/type.dart';
 import 'package:googleapis_auth/auth_io.dart' as auth;
@@ -633,8 +633,8 @@ final class DatasetService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -970,8 +970,8 @@ final class DeploymentResourcePoolService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -1406,8 +1406,8 @@ final class EndpointService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -1638,8 +1638,8 @@ final class EvaluationService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -1994,8 +1994,8 @@ final class ExampleStoreService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -2209,8 +2209,8 @@ final class ExtensionExecutionService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -2493,8 +2493,8 @@ final class ExtensionRegistryService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -2957,8 +2957,8 @@ final class FeatureOnlineStoreAdminService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -3197,8 +3197,8 @@ final class FeatureOnlineStoreService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -3827,8 +3827,8 @@ final class FeatureRegistryService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -4075,8 +4075,8 @@ final class FeaturestoreOnlineServingService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -4807,8 +4807,8 @@ final class FeaturestoreService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -5065,8 +5065,8 @@ final class GenAiCacheService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -5344,8 +5344,8 @@ final class GenAiTuningService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -5715,8 +5715,8 @@ final class IndexEndpointService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -6055,8 +6055,8 @@ final class IndexService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -6907,8 +6907,8 @@ final class JobService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -7109,8 +7109,8 @@ final class LlmUtilityService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -7332,8 +7332,8 @@ final class MatchService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -7662,8 +7662,8 @@ final class MemoryBankService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -8439,8 +8439,8 @@ final class MetadataService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -8680,8 +8680,8 @@ final class MigrationService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -9035,8 +9035,8 @@ final class ModelGardenService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -9447,8 +9447,8 @@ final class ModelMonitoringService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -10028,8 +10028,8 @@ final class ModelService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -10603,8 +10603,8 @@ final class NotebookService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -10932,8 +10932,8 @@ final class PersistentResourceService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -11383,8 +11383,8 @@ final class PipelineService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -11743,8 +11743,8 @@ final class PredictionService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -11959,8 +11959,8 @@ final class ReasoningEngineExecutionService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -12256,8 +12256,8 @@ final class ReasoningEngineService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -12561,8 +12561,8 @@ final class ScheduleService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -12870,8 +12870,8 @@ final class SessionService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -13172,8 +13172,8 @@ final class SpecialistPoolService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -13918,8 +13918,8 @@ final class TensorboardService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -14335,8 +14335,8 @@ final class VertexRagDataService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -14569,8 +14569,8 @@ final class VertexRagService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -14990,8 +14990,8 @@ final class VizierService {
   /// This method can be used to get the current status of a long-running
   /// operation.
   Future<Operation<T, S>> getOperation<
-    T extends ProtoMessage,
-    S extends ProtoMessage
+    T extends protobuf.ProtoMessage,
+    S extends protobuf.ProtoMessage
   >(Operation<T, S> request) async {
     final url = Uri.https(_host, '/ui/${request.name}');
     final response = await _client.get(url);
@@ -15042,7 +15042,7 @@ final class VizierService {
 
 /// Used to assign specific AnnotationSpec to a particular area of a DataItem or
 /// the whole part of the DataItem.
-final class Annotation extends ProtoMessage {
+final class Annotation extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Annotation';
 
@@ -15153,7 +15153,7 @@ final class Annotation extends ProtoMessage {
 }
 
 /// Identifies a concept with which DataItems may be annotated with.
-final class AnnotationSpec extends ProtoMessage {
+final class AnnotationSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AnnotationSpec';
 
@@ -15216,7 +15216,7 @@ final class AnnotationSpec extends ProtoMessage {
 }
 
 /// The generic reusable api auth config.
-final class ApiAuth extends ProtoMessage {
+final class ApiAuth extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ApiAuth';
 
@@ -15241,7 +15241,7 @@ final class ApiAuth extends ProtoMessage {
 }
 
 /// The API secret.
-final class ApiAuth_ApiKeyConfig extends ProtoMessage {
+final class ApiAuth_ApiKeyConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ApiAuth.ApiKeyConfig';
 
@@ -15276,7 +15276,7 @@ final class ApiAuth_ApiKeyConfig extends ProtoMessage {
 }
 
 /// Instance of a general artifact.
-final class Artifact extends ProtoMessage {
+final class Artifact extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Artifact';
 
@@ -15405,7 +15405,7 @@ final class Artifact extends ProtoMessage {
 }
 
 /// Describes the state of the Artifact.
-final class Artifact_State extends ProtoEnum {
+final class Artifact_State extends protobuf.ProtoEnum {
   /// Unspecified state for the Artifact.
   static const stateUnspecified = Artifact_State('STATE_UNSPECIFIED');
 
@@ -15431,7 +15431,7 @@ final class Artifact_State extends ProtoEnum {
 /// instances][google.cloud.aiplatform.v1beta1.BatchPredictionJob.input_config].
 /// If predictions for significant portion of the instances fail, the job may
 /// finish without attempting predictions for all remaining instances.
-final class BatchPredictionJob extends ProtoMessage {
+final class BatchPredictionJob extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BatchPredictionJob';
 
@@ -15833,7 +15833,7 @@ final class BatchPredictionJob extends ProtoMessage {
 /// `Model.supported_input_storage_formats`
 /// for Model's supported input formats, and how instances should be expressed
 /// via any of them.
-final class BatchPredictionJob_InputConfig extends ProtoMessage {
+final class BatchPredictionJob_InputConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BatchPredictionJob.InputConfig';
 
@@ -15886,7 +15886,7 @@ final class BatchPredictionJob_InputConfig extends ProtoMessage {
 
 /// Configuration defining how to transform batch prediction input instances to
 /// the instances that the Model accepts.
-final class BatchPredictionJob_InstanceConfig extends ProtoMessage {
+final class BatchPredictionJob_InstanceConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BatchPredictionJob.InstanceConfig';
 
@@ -16028,7 +16028,7 @@ final class BatchPredictionJob_InstanceConfig extends ProtoMessage {
 /// `Model.supported_output_storage_formats`
 /// for supported output formats, and how predictions are expressed via any of
 /// them.
-final class BatchPredictionJob_OutputConfig extends ProtoMessage {
+final class BatchPredictionJob_OutputConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BatchPredictionJob.OutputConfig';
 
@@ -16123,7 +16123,7 @@ final class BatchPredictionJob_OutputConfig extends ProtoMessage {
 /// Further describes this job's output.
 /// Supplements
 /// `output_config`.
-final class BatchPredictionJob_OutputInfo extends ProtoMessage {
+final class BatchPredictionJob_OutputInfo extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BatchPredictionJob.OutputInfo';
 
@@ -16182,7 +16182,7 @@ final class BatchPredictionJob_OutputInfo extends ProtoMessage {
 
 /// A resource used in LLM queries for users to explicitly specify what to cache
 /// and how to cache.
-final class CachedContent extends ProtoMessage {
+final class CachedContent extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CachedContent';
 
@@ -16307,7 +16307,7 @@ final class CachedContent extends ProtoMessage {
 }
 
 /// Metadata on the usage of the cached content.
-final class CachedContent_UsageMetadata extends ProtoMessage {
+final class CachedContent_UsageMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CachedContent.UsageMetadata';
 
@@ -16374,7 +16374,7 @@ final class CachedContent_UsageMetadata extends ProtoMessage {
 
 /// Success and error statistics of processing multiple entities
 /// (for example, DataItems or structured data rows) in batch.
-final class CompletionStats extends ProtoMessage {
+final class CompletionStats extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CompletionStats';
 
@@ -16447,7 +16447,7 @@ final class CompletionStats extends ProtoMessage {
 /// A `Content` includes a `role` field designating the producer of the `Content`
 /// and a `parts` field containing multi-part data that contains the content of
 /// the message turn.
-final class Content extends ProtoMessage {
+final class Content extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Content';
 
@@ -16492,7 +16492,7 @@ final class Content extends ProtoMessage {
 ///
 /// A `Part` must have a fixed IANA MIME type identifying the type and subtype
 /// of the media if `inline_data` or `file_data` field is filled with raw bytes.
-final class Part extends ProtoMessage {
+final class Part extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Part';
 
@@ -16601,7 +16601,7 @@ final class Part extends ProtoMessage {
 ///
 /// It's preferred to send as `text`
 /// directly rather than raw bytes.
-final class Blob extends ProtoMessage {
+final class Blob extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Blob';
 
@@ -16636,7 +16636,7 @@ final class Blob extends ProtoMessage {
 }
 
 /// URI based data.
-final class FileData extends ProtoMessage {
+final class FileData extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FileData';
 
@@ -16671,7 +16671,7 @@ final class FileData extends ProtoMessage {
 }
 
 /// Metadata describes the input video content.
-final class VideoMetadata extends ProtoMessage {
+final class VideoMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.VideoMetadata';
 
@@ -16706,7 +16706,7 @@ final class VideoMetadata extends ProtoMessage {
 }
 
 /// The configuration for the prebuilt speaker to use.
-final class PrebuiltVoiceConfig extends ProtoMessage {
+final class PrebuiltVoiceConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PrebuiltVoiceConfig';
 
@@ -16732,7 +16732,7 @@ final class PrebuiltVoiceConfig extends ProtoMessage {
 }
 
 /// The configuration for the voice to use.
-final class VoiceConfig extends ProtoMessage {
+final class VoiceConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.VoiceConfig';
 
@@ -16763,7 +16763,7 @@ final class VoiceConfig extends ProtoMessage {
 }
 
 /// The speech generation config.
-final class SpeechConfig extends ProtoMessage {
+final class SpeechConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SpeechConfig';
 
@@ -16788,7 +16788,7 @@ final class SpeechConfig extends ProtoMessage {
 }
 
 /// Config for image generation features.
-final class ImageConfig extends ProtoMessage {
+final class ImageConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ImageConfig';
 
@@ -16824,7 +16824,7 @@ final class ImageConfig extends ProtoMessage {
 }
 
 /// Generation config.
-final class GenerationConfig extends ProtoMessage {
+final class GenerationConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GenerationConfig';
 
@@ -17068,7 +17068,7 @@ final class GenerationConfig extends ProtoMessage {
 }
 
 /// The configuration for routing the request to a specific model.
-final class GenerationConfig_RoutingConfig extends ProtoMessage {
+final class GenerationConfig_RoutingConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GenerationConfig.RoutingConfig';
 
@@ -17110,7 +17110,7 @@ final class GenerationConfig_RoutingConfig extends ProtoMessage {
 /// the pretrained routing model and customer provided model routing
 /// preference.
 final class GenerationConfig_RoutingConfig_AutoRoutingMode
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GenerationConfig.RoutingConfig.AutoRoutingMode';
 
@@ -17153,7 +17153,7 @@ final class GenerationConfig_RoutingConfig_AutoRoutingMode
 
 /// The model routing preference.
 final class GenerationConfig_RoutingConfig_AutoRoutingMode_ModelRoutingPreference
-    extends ProtoEnum {
+    extends protobuf.ProtoEnum {
   /// Unspecified model routing preference.
   static const unknown =
       GenerationConfig_RoutingConfig_AutoRoutingMode_ModelRoutingPreference(
@@ -17194,7 +17194,7 @@ final class GenerationConfig_RoutingConfig_AutoRoutingMode_ModelRoutingPreferenc
 
 /// When manual routing is set, the specified model will be used directly.
 final class GenerationConfig_RoutingConfig_ManualRoutingMode
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GenerationConfig.RoutingConfig.ManualRoutingMode';
 
@@ -17226,7 +17226,7 @@ final class GenerationConfig_RoutingConfig_ManualRoutingMode
 }
 
 /// Config for thinking features.
-final class GenerationConfig_ThinkingConfig extends ProtoMessage {
+final class GenerationConfig_ThinkingConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GenerationConfig.ThinkingConfig';
 
@@ -17267,7 +17267,7 @@ final class GenerationConfig_ThinkingConfig extends ProtoMessage {
 }
 
 /// Config for model selection.
-final class GenerationConfig_ModelConfig extends ProtoMessage {
+final class GenerationConfig_ModelConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GenerationConfig.ModelConfig';
 
@@ -17307,7 +17307,7 @@ final class GenerationConfig_ModelConfig extends ProtoMessage {
 
 /// Options for feature selection preference.
 final class GenerationConfig_ModelConfig_FeatureSelectionPreference
-    extends ProtoEnum {
+    extends protobuf.ProtoEnum {
   /// Unspecified feature selection preference.
   static const featureSelectionPreferenceUnspecified =
       GenerationConfig_ModelConfig_FeatureSelectionPreference(
@@ -17341,7 +17341,7 @@ final class GenerationConfig_ModelConfig_FeatureSelectionPreference
 }
 
 /// The modalities of the response.
-final class GenerationConfig_Modality extends ProtoEnum {
+final class GenerationConfig_Modality extends protobuf.ProtoEnum {
   /// Unspecified modality. Will be processed as text.
   static const modalityUnspecified = GenerationConfig_Modality(
     'MODALITY_UNSPECIFIED',
@@ -17366,7 +17366,7 @@ final class GenerationConfig_Modality extends ProtoEnum {
 }
 
 /// Media resolution for the input media.
-final class GenerationConfig_MediaResolution extends ProtoEnum {
+final class GenerationConfig_MediaResolution extends protobuf.ProtoEnum {
   /// Media resolution has not been set.
   static const mediaResolutionUnspecified = GenerationConfig_MediaResolution(
     'MEDIA_RESOLUTION_UNSPECIFIED',
@@ -17397,7 +17397,7 @@ final class GenerationConfig_MediaResolution extends ProtoEnum {
 }
 
 /// Safety settings.
-final class SafetySetting extends ProtoMessage {
+final class SafetySetting extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SafetySetting';
 
@@ -17449,7 +17449,7 @@ final class SafetySetting extends ProtoMessage {
 }
 
 /// Probability based thresholds levels for blocking.
-final class SafetySetting_HarmBlockThreshold extends ProtoEnum {
+final class SafetySetting_HarmBlockThreshold extends protobuf.ProtoEnum {
   /// Unspecified harm block threshold.
   static const harmBlockThresholdUnspecified = SafetySetting_HarmBlockThreshold(
     'HARM_BLOCK_THRESHOLD_UNSPECIFIED',
@@ -17486,7 +17486,7 @@ final class SafetySetting_HarmBlockThreshold extends ProtoEnum {
 }
 
 /// Probability vs severity.
-final class SafetySetting_HarmBlockMethod extends ProtoEnum {
+final class SafetySetting_HarmBlockMethod extends protobuf.ProtoEnum {
   /// The harm block method is unspecified.
   static const harmBlockMethodUnspecified = SafetySetting_HarmBlockMethod(
     'HARM_BLOCK_METHOD_UNSPECIFIED',
@@ -17508,7 +17508,7 @@ final class SafetySetting_HarmBlockMethod extends ProtoEnum {
 }
 
 /// Safety rating corresponding to the generated content.
-final class SafetyRating extends ProtoMessage {
+final class SafetyRating extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SafetyRating';
 
@@ -17585,7 +17585,7 @@ final class SafetyRating extends ProtoMessage {
 }
 
 /// Harm probability levels in the content.
-final class SafetyRating_HarmProbability extends ProtoEnum {
+final class SafetyRating_HarmProbability extends protobuf.ProtoEnum {
   /// Harm probability unspecified.
   static const harmProbabilityUnspecified = SafetyRating_HarmProbability(
     'HARM_PROBABILITY_UNSPECIFIED',
@@ -17613,7 +17613,7 @@ final class SafetyRating_HarmProbability extends ProtoEnum {
 }
 
 /// Harm severity levels.
-final class SafetyRating_HarmSeverity extends ProtoEnum {
+final class SafetyRating_HarmSeverity extends protobuf.ProtoEnum {
   /// Harm severity unspecified.
   static const harmSeverityUnspecified = SafetyRating_HarmSeverity(
     'HARM_SEVERITY_UNSPECIFIED',
@@ -17647,7 +17647,7 @@ final class SafetyRating_HarmSeverity extends ProtoEnum {
 }
 
 /// A collection of source attributions for a piece of content.
-final class CitationMetadata extends ProtoMessage {
+final class CitationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CitationMetadata';
 
@@ -17672,7 +17672,7 @@ final class CitationMetadata extends ProtoMessage {
 }
 
 /// Source attributions for content.
-final class Citation extends ProtoMessage {
+final class Citation extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Citation';
 
@@ -17740,7 +17740,7 @@ final class Citation extends ProtoMessage {
 }
 
 /// A response candidate generated from the model.
-final class Candidate extends ProtoMessage {
+final class Candidate extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Candidate';
 
@@ -17854,7 +17854,7 @@ final class Candidate extends ProtoMessage {
 
 /// The reason why the model stopped generating tokens.
 /// If empty, the model has not stopped generating the tokens.
-final class Candidate_FinishReason extends ProtoEnum {
+final class Candidate_FinishReason extends protobuf.ProtoEnum {
   /// The finish reason is unspecified.
   static const finishReasonUnspecified = Candidate_FinishReason(
     'FINISH_REASON_UNSPECIFIED',
@@ -17908,7 +17908,7 @@ final class Candidate_FinishReason extends ProtoEnum {
 }
 
 /// Metadata related to url context retrieval tool.
-final class UrlContextMetadata extends ProtoMessage {
+final class UrlContextMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UrlContextMetadata';
 
@@ -17933,7 +17933,7 @@ final class UrlContextMetadata extends ProtoMessage {
 }
 
 /// Context of the a single url retrieval.
-final class UrlMetadata extends ProtoMessage {
+final class UrlMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UrlMetadata';
 
@@ -17976,7 +17976,7 @@ final class UrlMetadata extends ProtoMessage {
 }
 
 /// Status of the url retrieval.
-final class UrlMetadata_UrlRetrievalStatus extends ProtoEnum {
+final class UrlMetadata_UrlRetrievalStatus extends protobuf.ProtoEnum {
   /// Default value. This value is unused.
   static const urlRetrievalStatusUnspecified = UrlMetadata_UrlRetrievalStatus(
     'URL_RETRIEVAL_STATUS_UNSPECIFIED',
@@ -18002,7 +18002,7 @@ final class UrlMetadata_UrlRetrievalStatus extends ProtoEnum {
 }
 
 /// Logprobs Result
-final class LogprobsResult extends ProtoMessage {
+final class LogprobsResult extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.LogprobsResult';
 
@@ -18043,7 +18043,7 @@ final class LogprobsResult extends ProtoMessage {
 }
 
 /// Candidate for the logprobs token and score.
-final class LogprobsResult_Candidate extends ProtoMessage {
+final class LogprobsResult_Candidate extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.LogprobsResult.Candidate';
 
@@ -18089,7 +18089,7 @@ final class LogprobsResult_Candidate extends ProtoMessage {
 }
 
 /// Candidates with top log probabilities at each decoding step.
-final class LogprobsResult_TopCandidates extends ProtoMessage {
+final class LogprobsResult_TopCandidates extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.LogprobsResult.TopCandidates';
 
@@ -18117,7 +18117,7 @@ final class LogprobsResult_TopCandidates extends ProtoMessage {
 }
 
 /// Segment of the content.
-final class Segment extends ProtoMessage {
+final class Segment extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Segment';
 
@@ -18170,7 +18170,7 @@ final class Segment extends ProtoMessage {
 }
 
 /// Grounding chunk.
-final class GroundingChunk extends ProtoMessage {
+final class GroundingChunk extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GroundingChunk';
 
@@ -18212,7 +18212,7 @@ final class GroundingChunk extends ProtoMessage {
 }
 
 /// Chunk from the web.
-final class GroundingChunk_Web extends ProtoMessage {
+final class GroundingChunk_Web extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GroundingChunk.Web';
 
@@ -18244,7 +18244,7 @@ final class GroundingChunk_Web extends ProtoMessage {
 }
 
 /// Chunk from context retrieved by the retrieval tools.
-final class GroundingChunk_RetrievedContext extends ProtoMessage {
+final class GroundingChunk_RetrievedContext extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GroundingChunk.RetrievedContext';
 
@@ -18307,7 +18307,7 @@ final class GroundingChunk_RetrievedContext extends ProtoMessage {
 }
 
 /// Chunk from Google Maps.
-final class GroundingChunk_Maps extends ProtoMessage {
+final class GroundingChunk_Maps extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GroundingChunk.Maps';
 
@@ -18374,7 +18374,8 @@ final class GroundingChunk_Maps extends ProtoMessage {
   }
 }
 
-final class GroundingChunk_Maps_PlaceAnswerSources extends ProtoMessage {
+final class GroundingChunk_Maps_PlaceAnswerSources
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GroundingChunk.Maps.PlaceAnswerSources';
 
@@ -18409,7 +18410,7 @@ final class GroundingChunk_Maps_PlaceAnswerSources extends ProtoMessage {
 
 /// Encapsulates a review snippet.
 final class GroundingChunk_Maps_PlaceAnswerSources_ReviewSnippet
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GroundingChunk.Maps.PlaceAnswerSources.ReviewSnippet';
 
@@ -18459,7 +18460,7 @@ final class GroundingChunk_Maps_PlaceAnswerSources_ReviewSnippet
 }
 
 /// Grounding support.
-final class GroundingSupport extends ProtoMessage {
+final class GroundingSupport extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GroundingSupport';
 
@@ -18506,7 +18507,7 @@ final class GroundingSupport extends ProtoMessage {
 }
 
 /// Metadata returned to client when grounding is enabled.
-final class GroundingMetadata extends ProtoMessage {
+final class GroundingMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GroundingMetadata';
 
@@ -18608,7 +18609,7 @@ final class GroundingMetadata extends ProtoMessage {
 
 /// Source content flagging uri for a place or review. This is currently
 /// populated only for Google Maps grounding.
-final class GroundingMetadata_SourceFlaggingUri extends ProtoMessage {
+final class GroundingMetadata_SourceFlaggingUri extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GroundingMetadata.SourceFlaggingUri';
 
@@ -18652,7 +18653,7 @@ final class GroundingMetadata_SourceFlaggingUri extends ProtoMessage {
 }
 
 /// Google search entry point.
-final class SearchEntryPoint extends ProtoMessage {
+final class SearchEntryPoint extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SearchEntryPoint';
 
@@ -18693,7 +18694,7 @@ final class SearchEntryPoint extends ProtoMessage {
 }
 
 /// Metadata related to retrieval in the grounding flow.
-final class RetrievalMetadata extends ProtoMessage {
+final class RetrievalMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RetrievalMetadata';
 
@@ -18736,7 +18737,7 @@ final class RetrievalMetadata extends ProtoMessage {
 }
 
 /// Configuration for Model Armor integrations of prompt and responses.
-final class ModelArmorConfig extends ProtoMessage {
+final class ModelArmorConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelArmorConfig';
 
@@ -18779,7 +18780,7 @@ final class ModelArmorConfig extends ProtoMessage {
 }
 
 /// Represents token counting info for a single modality.
-final class ModalityTokenCount extends ProtoMessage {
+final class ModalityTokenCount extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModalityTokenCount';
 
@@ -18818,7 +18819,7 @@ final class ModalityTokenCount extends ProtoMessage {
 }
 
 /// Instance of a general context.
-final class Context extends ProtoMessage {
+final class Context extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Context';
 
@@ -18939,7 +18940,7 @@ final class Context extends ProtoMessage {
 /// Python package. A CustomJob can have multiple worker pools and each worker
 /// pool can have its own machine and input spec. A CustomJob will be cleaned up
 /// once the job enters terminal state (failed or succeeded).
-final class CustomJob extends ProtoMessage {
+final class CustomJob extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CustomJob';
 
@@ -19079,7 +19080,7 @@ final class CustomJob extends ProtoMessage {
 }
 
 /// Represents the spec of a CustomJob.
-final class CustomJobSpec extends ProtoMessage {
+final class CustomJobSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CustomJobSpec';
 
@@ -19315,7 +19316,7 @@ final class CustomJobSpec extends ProtoMessage {
 }
 
 /// Represents the spec of a worker pool in a job.
-final class WorkerPoolSpec extends ProtoMessage {
+final class WorkerPoolSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.WorkerPoolSpec';
 
@@ -19383,7 +19384,7 @@ final class WorkerPoolSpec extends ProtoMessage {
 }
 
 /// The spec of a Container.
-final class ContainerSpec extends ProtoMessage {
+final class ContainerSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ContainerSpec';
 
@@ -19432,7 +19433,7 @@ final class ContainerSpec extends ProtoMessage {
 }
 
 /// The spec of a Python packaged code.
-final class PythonPackageSpec extends ProtoMessage {
+final class PythonPackageSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PythonPackageSpec';
 
@@ -19499,7 +19500,7 @@ final class PythonPackageSpec extends ProtoMessage {
 }
 
 /// All parameters related to queuing and scheduling of custom jobs.
-final class Scheduling extends ProtoMessage {
+final class Scheduling extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Scheduling';
 
@@ -19575,7 +19576,7 @@ final class Scheduling extends ProtoMessage {
 /// demand resources to schedule the job, the other is SPOT which would
 /// leverage spot resources alongwith regular resources to schedule
 /// the job.
-final class Scheduling_Strategy extends ProtoEnum {
+final class Scheduling_Strategy extends protobuf.ProtoEnum {
   /// Strategy will default to STANDARD.
   static const strategyUnspecified = Scheduling_Strategy(
     'STRATEGY_UNSPECIFIED',
@@ -19607,7 +19608,7 @@ final class Scheduling_Strategy extends ProtoEnum {
 
 /// A piece of data in a Dataset. Could be an image, a video, a document or plain
 /// text.
-final class DataItem extends ProtoMessage {
+final class DataItem extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DataItem';
 
@@ -19702,7 +19703,7 @@ final class DataItem extends ProtoMessage {
 
 /// DataLabelingJob is used to trigger a human labeling job on unlabeled data
 /// from the following Dataset:
-final class DataLabelingJob extends ProtoMessage {
+final class DataLabelingJob extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DataLabelingJob';
 
@@ -19889,7 +19890,7 @@ final class DataLabelingJob extends ProtoMessage {
 /// Parameters that configure the active learning pipeline. Active learning will
 ///  label the data incrementally by several iterations. For every iteration, it
 ///  will select a batch of data based on the sampling strategy.
-final class ActiveLearningConfig extends ProtoMessage {
+final class ActiveLearningConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ActiveLearningConfig';
 
@@ -19949,7 +19950,7 @@ final class ActiveLearningConfig extends ProtoMessage {
 
 /// Active learning data sampling config. For every active learning labeling
 /// iteration, it will select a batch of data based on the sampling strategy.
-final class SampleConfig extends ProtoMessage {
+final class SampleConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SampleConfig';
 
@@ -20007,7 +20008,7 @@ final class SampleConfig extends ProtoMessage {
 
 /// Sample strategy decides which subset of DataItems should be selected for
 /// human labeling in every batch.
-final class SampleConfig_SampleStrategy extends ProtoEnum {
+final class SampleConfig_SampleStrategy extends protobuf.ProtoEnum {
   /// Default will be treated as UNCERTAINTY.
   static const sampleStrategyUnspecified = SampleConfig_SampleStrategy(
     'SAMPLE_STRATEGY_UNSPECIFIED',
@@ -20028,7 +20029,7 @@ final class SampleConfig_SampleStrategy extends ProtoEnum {
 /// CMLE training config. For every active learning labeling iteration, system
 /// will train a machine learning model on CMLE. The trained model will be used
 /// by data sampling algorithm to select DataItems.
-final class TrainingConfig extends ProtoMessage {
+final class TrainingConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TrainingConfig';
 
@@ -20063,7 +20064,7 @@ final class TrainingConfig extends ProtoMessage {
 }
 
 /// A collection of DataItems and Annotations on them.
-final class Dataset extends ProtoMessage {
+final class Dataset extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Dataset';
 
@@ -20233,7 +20234,7 @@ final class Dataset extends ProtoMessage {
 
 /// Describes the location from where we import data into a Dataset, together
 /// with the labels that will be applied to the DataItems and the Annotations.
-final class ImportDataConfig extends ProtoMessage {
+final class ImportDataConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ImportDataConfig';
 
@@ -20311,7 +20312,7 @@ final class ImportDataConfig extends ProtoMessage {
 
 /// Describes what part of the Dataset is to be exported, the destination of
 /// the export and how to export.
-final class ExportDataConfig extends ProtoMessage {
+final class ExportDataConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExportDataConfig';
 
@@ -20376,7 +20377,7 @@ final class ExportDataConfig extends ProtoMessage {
 /// provided ones sum to less than 1, the remainder is assigned to sets as
 /// decided by Vertex AI. If none of the fractions are set, by default roughly
 /// 80% of data is used for training, 10% for validation, and 10% for test.
-final class ExportFractionSplit extends ProtoMessage {
+final class ExportFractionSplit extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExportFractionSplit';
 
@@ -20427,7 +20428,7 @@ final class ExportFractionSplit extends ProtoMessage {
 
 /// Request message for
 /// `DatasetService.CreateDataset`.
-final class CreateDatasetRequest extends ProtoMessage {
+final class CreateDatasetRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateDatasetRequest';
 
@@ -20462,7 +20463,7 @@ final class CreateDatasetRequest extends ProtoMessage {
 
 /// Runtime operation information for
 /// `DatasetService.CreateDataset`.
-final class CreateDatasetOperationMetadata extends ProtoMessage {
+final class CreateDatasetOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateDatasetOperationMetadata';
 
@@ -20494,7 +20495,7 @@ final class CreateDatasetOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `DatasetService.GetDataset`.
-final class GetDatasetRequest extends ProtoMessage {
+final class GetDatasetRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetDatasetRequest';
 
@@ -20528,7 +20529,7 @@ final class GetDatasetRequest extends ProtoMessage {
 
 /// Request message for
 /// `DatasetService.UpdateDataset`.
-final class UpdateDatasetRequest extends ProtoMessage {
+final class UpdateDatasetRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateDatasetRequest';
 
@@ -20568,7 +20569,7 @@ final class UpdateDatasetRequest extends ProtoMessage {
 
 /// Request message for
 /// `DatasetService.UpdateDatasetVersion`.
-final class UpdateDatasetVersionRequest extends ProtoMessage {
+final class UpdateDatasetVersionRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateDatasetVersionRequest';
 
@@ -20606,7 +20607,7 @@ final class UpdateDatasetVersionRequest extends ProtoMessage {
 
 /// Request message for
 /// `DatasetService.ListDatasets`.
-final class ListDatasetsRequest extends ProtoMessage {
+final class ListDatasetsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListDatasetsRequest';
 
@@ -20695,7 +20696,7 @@ final class ListDatasetsRequest extends ProtoMessage {
 
 /// Response message for
 /// `DatasetService.ListDatasets`.
-final class ListDatasetsResponse extends ProtoMessage {
+final class ListDatasetsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListDatasetsResponse';
 
@@ -20734,7 +20735,7 @@ final class ListDatasetsResponse extends ProtoMessage {
 
 /// Request message for
 /// `DatasetService.DeleteDataset`.
-final class DeleteDatasetRequest extends ProtoMessage {
+final class DeleteDatasetRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteDatasetRequest';
 
@@ -20763,7 +20764,7 @@ final class DeleteDatasetRequest extends ProtoMessage {
 
 /// Request message for
 /// `DatasetService.ImportData`.
-final class ImportDataRequest extends ProtoMessage {
+final class ImportDataRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ImportDataRequest';
 
@@ -20806,7 +20807,7 @@ final class ImportDataRequest extends ProtoMessage {
 
 /// Response message for
 /// `DatasetService.ImportData`.
-final class ImportDataResponse extends ProtoMessage {
+final class ImportDataResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ImportDataResponse';
 
@@ -20827,7 +20828,7 @@ final class ImportDataResponse extends ProtoMessage {
 
 /// Runtime operation information for
 /// `DatasetService.ImportData`.
-final class ImportDataOperationMetadata extends ProtoMessage {
+final class ImportDataOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ImportDataOperationMetadata';
 
@@ -20859,7 +20860,7 @@ final class ImportDataOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `DatasetService.ExportData`.
-final class ExportDataRequest extends ProtoMessage {
+final class ExportDataRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExportDataRequest';
 
@@ -20898,7 +20899,7 @@ final class ExportDataRequest extends ProtoMessage {
 
 /// Response message for
 /// `DatasetService.ExportData`.
-final class ExportDataResponse extends ProtoMessage {
+final class ExportDataResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExportDataResponse';
 
@@ -20925,7 +20926,7 @@ final class ExportDataResponse extends ProtoMessage {
 
 /// Runtime operation information for
 /// `DatasetService.ExportData`.
-final class ExportDataOperationMetadata extends ProtoMessage {
+final class ExportDataOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExportDataOperationMetadata';
 
@@ -20968,7 +20969,7 @@ final class ExportDataOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `DatasetService.CreateDatasetVersion`.
-final class CreateDatasetVersionRequest extends ProtoMessage {
+final class CreateDatasetVersionRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateDatasetVersionRequest';
 
@@ -21008,7 +21009,8 @@ final class CreateDatasetVersionRequest extends ProtoMessage {
 
 /// Runtime operation information for
 /// `DatasetService.CreateDatasetVersion`.
-final class CreateDatasetVersionOperationMetadata extends ProtoMessage {
+final class CreateDatasetVersionOperationMetadata
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateDatasetVersionOperationMetadata';
 
@@ -21042,7 +21044,7 @@ final class CreateDatasetVersionOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `DatasetService.DeleteDatasetVersion`.
-final class DeleteDatasetVersionRequest extends ProtoMessage {
+final class DeleteDatasetVersionRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteDatasetVersionRequest';
 
@@ -21071,7 +21073,7 @@ final class DeleteDatasetVersionRequest extends ProtoMessage {
 
 /// Request message for
 /// `DatasetService.GetDatasetVersion`.
-final class GetDatasetVersionRequest extends ProtoMessage {
+final class GetDatasetVersionRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetDatasetVersionRequest';
 
@@ -21107,7 +21109,7 @@ final class GetDatasetVersionRequest extends ProtoMessage {
 
 /// Request message for
 /// `DatasetService.ListDatasetVersions`.
-final class ListDatasetVersionsRequest extends ProtoMessage {
+final class ListDatasetVersionsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListDatasetVersionsRequest';
 
@@ -21179,7 +21181,7 @@ final class ListDatasetVersionsRequest extends ProtoMessage {
 
 /// Response message for
 /// `DatasetService.ListDatasetVersions`.
-final class ListDatasetVersionsResponse extends ProtoMessage {
+final class ListDatasetVersionsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListDatasetVersionsResponse';
 
@@ -21222,7 +21224,7 @@ final class ListDatasetVersionsResponse extends ProtoMessage {
 
 /// Request message for
 /// `DatasetService.RestoreDatasetVersion`.
-final class RestoreDatasetVersionRequest extends ProtoMessage {
+final class RestoreDatasetVersionRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RestoreDatasetVersionRequest';
 
@@ -21252,7 +21254,8 @@ final class RestoreDatasetVersionRequest extends ProtoMessage {
 
 /// Runtime operation information for
 /// `DatasetService.RestoreDatasetVersion`.
-final class RestoreDatasetVersionOperationMetadata extends ProtoMessage {
+final class RestoreDatasetVersionOperationMetadata
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RestoreDatasetVersionOperationMetadata';
 
@@ -21286,7 +21289,7 @@ final class RestoreDatasetVersionOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `DatasetService.ListDataItems`.
-final class ListDataItemsRequest extends ProtoMessage {
+final class ListDataItemsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListDataItemsRequest';
 
@@ -21358,7 +21361,7 @@ final class ListDataItemsRequest extends ProtoMessage {
 
 /// Response message for
 /// `DatasetService.ListDataItems`.
-final class ListDataItemsResponse extends ProtoMessage {
+final class ListDataItemsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListDataItemsResponse';
 
@@ -21397,7 +21400,7 @@ final class ListDataItemsResponse extends ProtoMessage {
 
 /// Request message for
 /// `DatasetService.SearchDataItems`.
-final class SearchDataItemsRequest extends ProtoMessage {
+final class SearchDataItemsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SearchDataItemsRequest';
 
@@ -21553,7 +21556,8 @@ final class SearchDataItemsRequest extends ProtoMessage {
 }
 
 /// Expression that allows ranking results based on annotation's property.
-final class SearchDataItemsRequest_OrderByAnnotation extends ProtoMessage {
+final class SearchDataItemsRequest_OrderByAnnotation
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SearchDataItemsRequest.OrderByAnnotation';
 
@@ -21598,7 +21602,7 @@ final class SearchDataItemsRequest_OrderByAnnotation extends ProtoMessage {
 
 /// Response message for
 /// `DatasetService.SearchDataItems`.
-final class SearchDataItemsResponse extends ProtoMessage {
+final class SearchDataItemsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SearchDataItemsResponse';
 
@@ -21642,7 +21646,7 @@ final class SearchDataItemsResponse extends ProtoMessage {
 }
 
 /// A container for a single DataItem and Annotations on it.
-final class DataItemView extends ProtoMessage {
+final class DataItemView extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DataItemView';
 
@@ -21695,7 +21699,7 @@ final class DataItemView extends ProtoMessage {
 
 /// Request message for
 /// `DatasetService.ListSavedQueries`.
-final class ListSavedQueriesRequest extends ProtoMessage {
+final class ListSavedQueriesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListSavedQueriesRequest';
 
@@ -21767,7 +21771,7 @@ final class ListSavedQueriesRequest extends ProtoMessage {
 
 /// Response message for
 /// `DatasetService.ListSavedQueries`.
-final class ListSavedQueriesResponse extends ProtoMessage {
+final class ListSavedQueriesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListSavedQueriesResponse';
 
@@ -21809,7 +21813,7 @@ final class ListSavedQueriesResponse extends ProtoMessage {
 
 /// Request message for
 /// `DatasetService.DeleteSavedQuery`.
-final class DeleteSavedQueryRequest extends ProtoMessage {
+final class DeleteSavedQueryRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteSavedQueryRequest';
 
@@ -21838,7 +21842,7 @@ final class DeleteSavedQueryRequest extends ProtoMessage {
 
 /// Request message for
 /// `DatasetService.GetAnnotationSpec`.
-final class GetAnnotationSpecRequest extends ProtoMessage {
+final class GetAnnotationSpecRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetAnnotationSpecRequest';
 
@@ -21874,7 +21878,7 @@ final class GetAnnotationSpecRequest extends ProtoMessage {
 
 /// Request message for
 /// `DatasetService.ListAnnotations`.
-final class ListAnnotationsRequest extends ProtoMessage {
+final class ListAnnotationsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListAnnotationsRequest';
 
@@ -21946,7 +21950,7 @@ final class ListAnnotationsRequest extends ProtoMessage {
 
 /// Response message for
 /// `DatasetService.ListAnnotations`.
-final class ListAnnotationsResponse extends ProtoMessage {
+final class ListAnnotationsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListAnnotationsResponse';
 
@@ -21986,7 +21990,7 @@ final class ListAnnotationsResponse extends ProtoMessage {
 /// Request message for
 /// `DatasetService.AssessData`.
 /// Used only for MULTIMODAL datasets.
-final class AssessDataRequest extends ProtoMessage {
+final class AssessDataRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AssessDataRequest';
 
@@ -22080,7 +22084,7 @@ final class AssessDataRequest extends ProtoMessage {
 
 /// Configuration for the tuning validation assessment.
 final class AssessDataRequest_TuningValidationAssessmentConfig
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AssessDataRequest.TuningValidationAssessmentConfig';
 
@@ -22129,7 +22133,7 @@ final class AssessDataRequest_TuningValidationAssessmentConfig
 
 /// The dataset usage (e.g. training/validation).
 final class AssessDataRequest_TuningValidationAssessmentConfig_DatasetUsage
-    extends ProtoEnum {
+    extends protobuf.ProtoEnum {
   /// Default value. Should not be used.
   static const datasetUsageUnspecified =
       AssessDataRequest_TuningValidationAssessmentConfig_DatasetUsage(
@@ -22162,7 +22166,7 @@ final class AssessDataRequest_TuningValidationAssessmentConfig_DatasetUsage
 
 /// Configuration for the tuning resource usage assessment.
 final class AssessDataRequest_TuningResourceUsageAssessmentConfig
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AssessDataRequest.TuningResourceUsageAssessmentConfig';
 
@@ -22194,7 +22198,7 @@ final class AssessDataRequest_TuningResourceUsageAssessmentConfig
 
 /// Configuration for the batch prediction validation assessment.
 final class AssessDataRequest_BatchPredictionValidationAssessmentConfig
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AssessDataRequest.BatchPredictionValidationAssessmentConfig';
 
@@ -22226,7 +22230,7 @@ final class AssessDataRequest_BatchPredictionValidationAssessmentConfig
 
 /// Configuration for the batch prediction resource usage assessment.
 final class AssessDataRequest_BatchPredictionResourceUsageAssessmentConfig
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AssessDataRequest.BatchPredictionResourceUsageAssessmentConfig';
 
@@ -22259,7 +22263,7 @@ final class AssessDataRequest_BatchPredictionResourceUsageAssessmentConfig
 
 /// Response message for
 /// `DatasetService.AssessData`.
-final class AssessDataResponse extends ProtoMessage {
+final class AssessDataResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AssessDataResponse';
 
@@ -22332,7 +22336,7 @@ final class AssessDataResponse extends ProtoMessage {
 
 /// The result of the tuning validation assessment.
 final class AssessDataResponse_TuningValidationAssessmentResult
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AssessDataResponse.TuningValidationAssessmentResult';
 
@@ -22361,7 +22365,7 @@ final class AssessDataResponse_TuningValidationAssessmentResult
 
 /// The result of the tuning resource usage assessment.
 final class AssessDataResponse_TuningResourceUsageAssessmentResult
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AssessDataResponse.TuningResourceUsageAssessmentResult';
 
@@ -22407,7 +22411,7 @@ final class AssessDataResponse_TuningResourceUsageAssessmentResult
 
 /// The result of the batch prediction validation assessment.
 final class AssessDataResponse_BatchPredictionValidationAssessmentResult
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AssessDataResponse.BatchPredictionValidationAssessmentResult';
 
@@ -22431,7 +22435,7 @@ final class AssessDataResponse_BatchPredictionValidationAssessmentResult
 
 /// The result of the batch prediction resource usage assessment.
 final class AssessDataResponse_BatchPredictionResourceUsageAssessmentResult
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AssessDataResponse.BatchPredictionResourceUsageAssessmentResult';
 
@@ -22476,7 +22480,7 @@ final class AssessDataResponse_BatchPredictionResourceUsageAssessmentResult
 
 /// Runtime operation information for
 /// `DatasetService.AssessData`.
-final class AssessDataOperationMetadata extends ProtoMessage {
+final class AssessDataOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AssessDataOperationMetadata';
 
@@ -22507,7 +22511,7 @@ final class AssessDataOperationMetadata extends ProtoMessage {
 }
 
 /// Template configuration to create Gemini examples from a multimodal dataset.
-final class GeminiTemplateConfig extends ProtoMessage {
+final class GeminiTemplateConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GeminiTemplateConfig';
 
@@ -22541,7 +22545,7 @@ final class GeminiTemplateConfig extends ProtoMessage {
 }
 
 /// Configuration for how to read Gemini requests from a multimodal dataset.
-final class GeminiRequestReadConfig extends ProtoMessage {
+final class GeminiRequestReadConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GeminiRequestReadConfig';
 
@@ -22587,7 +22591,7 @@ final class GeminiRequestReadConfig extends ProtoMessage {
 }
 
 /// Format for Gemini examples used for Vertex Multimodal datasets.
-final class GeminiExample extends ProtoMessage {
+final class GeminiExample extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GeminiExample';
 
@@ -22710,7 +22714,7 @@ final class GeminiExample extends ProtoMessage {
 /// Request message for
 /// `DatasetService.AssembleData`.
 /// Used only for MULTIMODAL datasets.
-final class AssembleDataRequest extends ProtoMessage {
+final class AssembleDataRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AssembleDataRequest';
 
@@ -22753,7 +22757,7 @@ final class AssembleDataRequest extends ProtoMessage {
 
 /// Response message for
 /// `DatasetService.AssembleData`.
-final class AssembleDataResponse extends ProtoMessage {
+final class AssembleDataResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AssembleDataResponse';
 
@@ -22789,7 +22793,7 @@ final class AssembleDataResponse extends ProtoMessage {
 
 /// Runtime operation information for
 /// `DatasetService.AssembleData`.
-final class AssembleDataOperationMetadata extends ProtoMessage {
+final class AssembleDataOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AssembleDataOperationMetadata';
 
@@ -22820,7 +22824,7 @@ final class AssembleDataOperationMetadata extends ProtoMessage {
 }
 
 /// Describes the dataset version.
-final class DatasetVersion extends ProtoMessage {
+final class DatasetVersion extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DatasetVersion';
 
@@ -22920,7 +22924,7 @@ final class DatasetVersion extends ProtoMessage {
 }
 
 /// Points to a DeployedIndex.
-final class DeployedIndexRef extends ProtoMessage {
+final class DeployedIndexRef extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeployedIndexRef';
 
@@ -22965,7 +22969,7 @@ final class DeployedIndexRef extends ProtoMessage {
 }
 
 /// Points to a DeployedModel.
-final class DeployedModelRef extends ProtoMessage {
+final class DeployedModelRef extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeployedModelRef';
 
@@ -23005,7 +23009,7 @@ final class DeployedModelRef extends ProtoMessage {
 
 /// A description of resources that can be shared by multiple DeployedModels,
 /// whose underlying specification consists of a DedicatedResources.
-final class DeploymentResourcePool extends ProtoMessage {
+final class DeploymentResourcePool extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeploymentResourcePool';
 
@@ -23108,7 +23112,7 @@ final class DeploymentResourcePool extends ProtoMessage {
 }
 
 /// Request message for CreateDeploymentResourcePool method.
-final class CreateDeploymentResourcePoolRequest extends ProtoMessage {
+final class CreateDeploymentResourcePoolRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateDeploymentResourcePoolRequest';
 
@@ -23169,7 +23173,8 @@ final class CreateDeploymentResourcePoolRequest extends ProtoMessage {
 }
 
 /// Runtime operation information for CreateDeploymentResourcePool method.
-final class CreateDeploymentResourcePoolOperationMetadata extends ProtoMessage {
+final class CreateDeploymentResourcePoolOperationMetadata
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateDeploymentResourcePoolOperationMetadata';
 
@@ -23202,7 +23207,7 @@ final class CreateDeploymentResourcePoolOperationMetadata extends ProtoMessage {
 }
 
 /// Request message for GetDeploymentResourcePool method.
-final class GetDeploymentResourcePoolRequest extends ProtoMessage {
+final class GetDeploymentResourcePoolRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetDeploymentResourcePoolRequest';
 
@@ -23231,7 +23236,7 @@ final class GetDeploymentResourcePoolRequest extends ProtoMessage {
 }
 
 /// Request message for ListDeploymentResourcePools method.
-final class ListDeploymentResourcePoolsRequest extends ProtoMessage {
+final class ListDeploymentResourcePoolsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListDeploymentResourcePoolsRequest';
 
@@ -23288,7 +23293,7 @@ final class ListDeploymentResourcePoolsRequest extends ProtoMessage {
 }
 
 /// Response message for ListDeploymentResourcePools method.
-final class ListDeploymentResourcePoolsResponse extends ProtoMessage {
+final class ListDeploymentResourcePoolsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListDeploymentResourcePoolsResponse';
 
@@ -23335,7 +23340,7 @@ final class ListDeploymentResourcePoolsResponse extends ProtoMessage {
 }
 
 /// Request message for UpdateDeploymentResourcePool method.
-final class UpdateDeploymentResourcePoolRequest extends ProtoMessage {
+final class UpdateDeploymentResourcePoolRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateDeploymentResourcePoolRequest';
 
@@ -23380,7 +23385,8 @@ final class UpdateDeploymentResourcePoolRequest extends ProtoMessage {
 }
 
 /// Runtime operation information for UpdateDeploymentResourcePool method.
-final class UpdateDeploymentResourcePoolOperationMetadata extends ProtoMessage {
+final class UpdateDeploymentResourcePoolOperationMetadata
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateDeploymentResourcePoolOperationMetadata';
 
@@ -23413,7 +23419,7 @@ final class UpdateDeploymentResourcePoolOperationMetadata extends ProtoMessage {
 }
 
 /// Request message for DeleteDeploymentResourcePool method.
-final class DeleteDeploymentResourcePoolRequest extends ProtoMessage {
+final class DeleteDeploymentResourcePoolRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteDeploymentResourcePoolRequest';
 
@@ -23444,7 +23450,7 @@ final class DeleteDeploymentResourcePoolRequest extends ProtoMessage {
 }
 
 /// Request message for QueryDeployedModels method.
-final class QueryDeployedModelsRequest extends ProtoMessage {
+final class QueryDeployedModelsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.QueryDeployedModelsRequest';
 
@@ -23500,7 +23506,7 @@ final class QueryDeployedModelsRequest extends ProtoMessage {
 }
 
 /// Response message for QueryDeployedModels method.
-final class QueryDeployedModelsResponse extends ProtoMessage {
+final class QueryDeployedModelsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.QueryDeployedModelsResponse';
 
@@ -23573,7 +23579,7 @@ final class QueryDeployedModelsResponse extends ProtoMessage {
 
 /// Represents a customer-managed encryption key spec that can be applied to
 /// a top-level resource.
-final class EncryptionSpec extends ProtoMessage {
+final class EncryptionSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.EncryptionSpec';
 
@@ -23606,7 +23612,7 @@ final class EncryptionSpec extends ProtoMessage {
 
 /// Models are deployed into it, and afterwards Endpoint is called to obtain
 /// predictions and explanations.
-final class Endpoint extends ProtoMessage {
+final class Endpoint extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Endpoint';
 
@@ -23871,7 +23877,7 @@ final class Endpoint extends ProtoMessage {
 }
 
 /// A deployment of a Model. Endpoints contain one or more DeployedModels.
-final class DeployedModel extends ProtoMessage {
+final class DeployedModel extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeployedModel';
 
@@ -24128,7 +24134,7 @@ final class DeployedModel extends ProtoMessage {
 }
 
 /// Runtime status of the deployed model.
-final class DeployedModel_Status extends ProtoMessage {
+final class DeployedModel_Status extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeployedModel.Status';
 
@@ -24184,7 +24190,7 @@ final class DeployedModel_Status extends ProtoMessage {
 /// To send request via private service access, use predict_http_uri,
 /// explain_http_uri or health_http_uri. To send request via private service
 /// connect, use service_attachment.
-final class PrivateEndpoints extends ProtoMessage {
+final class PrivateEndpoints extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PrivateEndpoints';
 
@@ -24240,7 +24246,7 @@ final class PrivateEndpoints extends ProtoMessage {
 }
 
 /// Configuration for logging request-response to a BigQuery table.
-final class PredictRequestResponseLoggingConfig extends ProtoMessage {
+final class PredictRequestResponseLoggingConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PredictRequestResponseLoggingConfig';
 
@@ -24321,7 +24327,7 @@ final class PredictRequestResponseLoggingConfig extends ProtoMessage {
 }
 
 /// This message contains configs of a publisher model.
-final class PublisherModelConfig extends ProtoMessage {
+final class PublisherModelConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PublisherModelConfig';
 
@@ -24351,7 +24357,7 @@ final class PublisherModelConfig extends ProtoMessage {
 }
 
 /// Configurations (e.g. inference timeout) that are applied on your endpoints.
-final class ClientConnectionConfig extends ProtoMessage {
+final class ClientConnectionConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ClientConnectionConfig';
 
@@ -24382,7 +24388,7 @@ final class ClientConnectionConfig extends ProtoMessage {
 }
 
 /// Configuration for faster model deployment.
-final class FasterDeploymentConfig extends ProtoMessage {
+final class FasterDeploymentConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FasterDeploymentConfig';
 
@@ -24412,7 +24418,7 @@ final class FasterDeploymentConfig extends ProtoMessage {
 }
 
 /// Configuration for rolling deployments.
-final class RolloutOptions extends ProtoMessage {
+final class RolloutOptions extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RolloutOptions';
 
@@ -24491,7 +24497,7 @@ final class RolloutOptions extends ProtoMessage {
 }
 
 /// Configuration for GenAiAdvancedFeatures.
-final class GenAiAdvancedFeaturesConfig extends ProtoMessage {
+final class GenAiAdvancedFeaturesConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GenAiAdvancedFeaturesConfig';
 
@@ -24519,7 +24525,8 @@ final class GenAiAdvancedFeaturesConfig extends ProtoMessage {
 }
 
 /// Configuration for Retrieval Augmented Generation feature.
-final class GenAiAdvancedFeaturesConfig_RagConfig extends ProtoMessage {
+final class GenAiAdvancedFeaturesConfig_RagConfig
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GenAiAdvancedFeaturesConfig.RagConfig';
 
@@ -24550,7 +24557,7 @@ final class GenAiAdvancedFeaturesConfig_RagConfig extends ProtoMessage {
 }
 
 /// Configuration for Speculative Decoding.
-final class SpeculativeDecodingSpec extends ProtoMessage {
+final class SpeculativeDecodingSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SpeculativeDecodingSpec';
 
@@ -24607,7 +24614,8 @@ final class SpeculativeDecodingSpec extends ProtoMessage {
 
 /// Draft model speculation works by using the smaller model to generate
 /// candidate tokens for speculative decoding.
-final class SpeculativeDecodingSpec_DraftModelSpeculation extends ProtoMessage {
+final class SpeculativeDecodingSpec_DraftModelSpeculation
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SpeculativeDecodingSpec.DraftModelSpeculation';
 
@@ -24642,7 +24650,8 @@ final class SpeculativeDecodingSpec_DraftModelSpeculation extends ProtoMessage {
 /// N-Gram speculation works by trying to find matching tokens in the
 /// previous prompt sequence and use those as speculation for generating
 /// new tokens.
-final class SpeculativeDecodingSpec_NgramSpeculation extends ProtoMessage {
+final class SpeculativeDecodingSpec_NgramSpeculation
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SpeculativeDecodingSpec.NgramSpeculation';
 
@@ -24677,7 +24686,7 @@ final class SpeculativeDecodingSpec_NgramSpeculation extends ProtoMessage {
 
 /// Request message for
 /// `EndpointService.CreateEndpoint`.
-final class CreateEndpointRequest extends ProtoMessage {
+final class CreateEndpointRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateEndpointRequest';
 
@@ -24739,7 +24748,7 @@ final class CreateEndpointRequest extends ProtoMessage {
 
 /// Runtime operation information for
 /// `EndpointService.CreateEndpoint`.
-final class CreateEndpointOperationMetadata extends ProtoMessage {
+final class CreateEndpointOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateEndpointOperationMetadata';
 
@@ -24785,7 +24794,7 @@ final class CreateEndpointOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `EndpointService.GetEndpoint`
-final class GetEndpointRequest extends ProtoMessage {
+final class GetEndpointRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetEndpointRequest';
 
@@ -24814,7 +24823,7 @@ final class GetEndpointRequest extends ProtoMessage {
 
 /// Request message for
 /// `EndpointService.ListEndpoints`.
-final class ListEndpointsRequest extends ProtoMessage {
+final class ListEndpointsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListEndpointsRequest';
 
@@ -24900,7 +24909,7 @@ final class ListEndpointsRequest extends ProtoMessage {
 
 /// Response message for
 /// `EndpointService.ListEndpoints`.
-final class ListEndpointsResponse extends ProtoMessage {
+final class ListEndpointsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListEndpointsResponse';
 
@@ -24942,7 +24951,7 @@ final class ListEndpointsResponse extends ProtoMessage {
 
 /// Request message for
 /// `EndpointService.UpdateEndpoint`.
-final class UpdateEndpointRequest extends ProtoMessage {
+final class UpdateEndpointRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateEndpointRequest';
 
@@ -24977,7 +24986,7 @@ final class UpdateEndpointRequest extends ProtoMessage {
 
 /// Request message for
 /// `EndpointService.UpdateEndpointLongRunning`.
-final class UpdateEndpointLongRunningRequest extends ProtoMessage {
+final class UpdateEndpointLongRunningRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateEndpointLongRunningRequest';
 
@@ -25006,7 +25015,7 @@ final class UpdateEndpointLongRunningRequest extends ProtoMessage {
 
 /// Runtime operation information for
 /// `EndpointService.UpdateEndpointLongRunning`.
-final class UpdateEndpointOperationMetadata extends ProtoMessage {
+final class UpdateEndpointOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateEndpointOperationMetadata';
 
@@ -25038,7 +25047,7 @@ final class UpdateEndpointOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `EndpointService.DeleteEndpoint`.
-final class DeleteEndpointRequest extends ProtoMessage {
+final class DeleteEndpointRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteEndpointRequest';
 
@@ -25067,7 +25076,7 @@ final class DeleteEndpointRequest extends ProtoMessage {
 
 /// Request message for
 /// `EndpointService.DeployModel`.
-final class DeployModelRequest extends ProtoMessage {
+final class DeployModelRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeployModelRequest';
 
@@ -25130,7 +25139,7 @@ final class DeployModelRequest extends ProtoMessage {
 
 /// Response message for
 /// `EndpointService.DeployModel`.
-final class DeployModelResponse extends ProtoMessage {
+final class DeployModelResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeployModelResponse';
 
@@ -25158,7 +25167,7 @@ final class DeployModelResponse extends ProtoMessage {
 
 /// Runtime operation information for
 /// `EndpointService.DeployModel`.
-final class DeployModelOperationMetadata extends ProtoMessage {
+final class DeployModelOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeployModelOperationMetadata';
 
@@ -25203,7 +25212,7 @@ final class DeployModelOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `EndpointService.UndeployModel`.
-final class UndeployModelRequest extends ProtoMessage {
+final class UndeployModelRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UndeployModelRequest';
 
@@ -25259,7 +25268,7 @@ final class UndeployModelRequest extends ProtoMessage {
 
 /// Response message for
 /// `EndpointService.UndeployModel`.
-final class UndeployModelResponse extends ProtoMessage {
+final class UndeployModelResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UndeployModelResponse';
 
@@ -25280,7 +25289,7 @@ final class UndeployModelResponse extends ProtoMessage {
 
 /// Request message for
 /// `EndpointService.SetPublisherModelConfig`.
-final class SetPublisherModelConfigRequest extends ProtoMessage {
+final class SetPublisherModelConfigRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SetPublisherModelConfigRequest';
 
@@ -25324,7 +25333,8 @@ final class SetPublisherModelConfigRequest extends ProtoMessage {
 
 /// Runtime operation information for
 /// `EndpointService.SetPublisherModelConfig`.
-final class SetPublisherModelConfigOperationMetadata extends ProtoMessage {
+final class SetPublisherModelConfigOperationMetadata
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SetPublisherModelConfigOperationMetadata';
 
@@ -25358,7 +25368,7 @@ final class SetPublisherModelConfigOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `EndpointService.FetchPublisherModelConfig`.
-final class FetchPublisherModelConfigRequest extends ProtoMessage {
+final class FetchPublisherModelConfigRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FetchPublisherModelConfigRequest';
 
@@ -25387,7 +25397,7 @@ final class FetchPublisherModelConfigRequest extends ProtoMessage {
 
 /// Runtime operation information for
 /// `EndpointService.UndeployModel`.
-final class UndeployModelOperationMetadata extends ProtoMessage {
+final class UndeployModelOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UndeployModelOperationMetadata';
 
@@ -25419,7 +25429,7 @@ final class UndeployModelOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `EndpointService.MutateDeployedModel`.
-final class MutateDeployedModelRequest extends ProtoMessage {
+final class MutateDeployedModelRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.MutateDeployedModelRequest';
 
@@ -25480,7 +25490,7 @@ final class MutateDeployedModelRequest extends ProtoMessage {
 
 /// Response message for
 /// `EndpointService.MutateDeployedModel`.
-final class MutateDeployedModelResponse extends ProtoMessage {
+final class MutateDeployedModelResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.MutateDeployedModelResponse';
 
@@ -25508,7 +25518,7 @@ final class MutateDeployedModelResponse extends ProtoMessage {
 
 /// Runtime operation information for
 /// `EndpointService.MutateDeployedModel`.
-final class MutateDeployedModelOperationMetadata extends ProtoMessage {
+final class MutateDeployedModelOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.MutateDeployedModelOperationMetadata';
 
@@ -25543,7 +25553,7 @@ final class MutateDeployedModelOperationMetadata extends ProtoMessage {
 /// An entity type is a type of object in a system that needs to be modeled and
 /// have stored information about. For example, driver is an entity type, and
 /// driver0 is an instance of an entity type driver.
-final class EntityType extends ProtoMessage {
+final class EntityType extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.EntityType';
 
@@ -25673,7 +25683,7 @@ final class EntityType extends ProtoMessage {
 }
 
 /// Represents an environment variable present in a Container or Python Module.
-final class EnvVar extends ProtoMessage {
+final class EnvVar extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.EnvVar';
 
@@ -25712,7 +25722,7 @@ final class EnvVar extends ProtoMessage {
 
 /// Reference to a secret stored in the Cloud Secret Manager that will
 /// provide the value for this environment variable.
-final class SecretRef extends ProtoMessage {
+final class SecretRef extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SecretRef';
 
@@ -25751,7 +25761,7 @@ final class SecretRef extends ProtoMessage {
 
 /// Represents an environment variable where the value is a secret in Cloud
 /// Secret Manager.
-final class SecretEnvVar extends ProtoMessage {
+final class SecretEnvVar extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SecretEnvVar';
 
@@ -25790,7 +25800,7 @@ final class SecretEnvVar extends ProtoMessage {
 ///
 /// EvaluatedAnnotation is only available under ModelEvaluationSlice with slice
 /// of `annotationSpec` dimension.
-final class EvaluatedAnnotation extends ProtoMessage {
+final class EvaluatedAnnotation extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.EvaluatedAnnotation';
 
@@ -25928,7 +25938,8 @@ final class EvaluatedAnnotation extends ProtoMessage {
 }
 
 /// Describes the type of the EvaluatedAnnotation. The type is determined
-final class EvaluatedAnnotation_EvaluatedAnnotationType extends ProtoEnum {
+final class EvaluatedAnnotation_EvaluatedAnnotationType
+    extends protobuf.ProtoEnum {
   /// Invalid value.
   static const evaluatedAnnotationTypeUnspecified =
       EvaluatedAnnotation_EvaluatedAnnotationType(
@@ -25963,7 +25974,7 @@ final class EvaluatedAnnotation_EvaluatedAnnotationType extends ProtoEnum {
 }
 
 /// Explanation result of the prediction produced by the Model.
-final class EvaluatedAnnotationExplanation extends ProtoMessage {
+final class EvaluatedAnnotationExplanation extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.EvaluatedAnnotationExplanation';
 
@@ -26006,7 +26017,7 @@ final class EvaluatedAnnotationExplanation extends ProtoMessage {
 }
 
 /// Model error analysis for each annotation.
-final class ErrorAnalysisAnnotation extends ProtoMessage {
+final class ErrorAnalysisAnnotation extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ErrorAnalysisAnnotation';
 
@@ -26071,7 +26082,8 @@ final class ErrorAnalysisAnnotation extends ProtoMessage {
 
 /// Attributed items for a given annotation, typically representing neighbors
 /// from the training sets constrained by the query type.
-final class ErrorAnalysisAnnotation_AttributedItem extends ProtoMessage {
+final class ErrorAnalysisAnnotation_AttributedItem
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ErrorAnalysisAnnotation.AttributedItem';
 
@@ -26117,7 +26129,7 @@ final class ErrorAnalysisAnnotation_AttributedItem extends ProtoMessage {
 }
 
 /// The query type used for finding the attributed items.
-final class ErrorAnalysisAnnotation_QueryType extends ProtoEnum {
+final class ErrorAnalysisAnnotation_QueryType extends protobuf.ProtoEnum {
   /// Unspecified query type for model error analysis.
   static const queryTypeUnspecified = ErrorAnalysisAnnotation_QueryType(
     'QUERY_TYPE_UNSPECIFIED',
@@ -26146,7 +26158,7 @@ final class ErrorAnalysisAnnotation_QueryType extends ProtoEnum {
 }
 
 /// Operation metadata for Dataset Evaluation.
-final class EvaluateDatasetOperationMetadata extends ProtoMessage {
+final class EvaluateDatasetOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.EvaluateDatasetOperationMetadata';
 
@@ -26177,7 +26189,7 @@ final class EvaluateDatasetOperationMetadata extends ProtoMessage {
 }
 
 /// Response in LRO for EvaluationService.EvaluateDataset.
-final class EvaluateDatasetResponse extends ProtoMessage {
+final class EvaluateDatasetResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.EvaluateDatasetResponse';
 
@@ -26215,7 +26227,7 @@ final class EvaluateDatasetResponse extends ProtoMessage {
 }
 
 /// Describes the info for output of EvaluationService.EvaluateDataset.
-final class OutputInfo extends ProtoMessage {
+final class OutputInfo extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.OutputInfo';
 
@@ -26246,7 +26258,7 @@ final class OutputInfo extends ProtoMessage {
 }
 
 /// The aggregation result for the entire dataset and all metrics.
-final class AggregationOutput extends ProtoMessage {
+final class AggregationOutput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AggregationOutput';
 
@@ -26283,7 +26295,7 @@ final class AggregationOutput extends ProtoMessage {
 }
 
 /// The aggregation result for a single metric.
-final class AggregationResult extends ProtoMessage {
+final class AggregationResult extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AggregationResult';
 
@@ -26370,7 +26382,7 @@ final class AggregationResult extends ProtoMessage {
 }
 
 /// Request message for EvaluationService.EvaluateDataset.
-final class EvaluateDatasetRequest extends ProtoMessage {
+final class EvaluateDatasetRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.EvaluateDatasetRequest';
 
@@ -26432,7 +26444,7 @@ final class EvaluateDatasetRequest extends ProtoMessage {
 }
 
 /// Config for evaluation output.
-final class OutputConfig extends ProtoMessage {
+final class OutputConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.OutputConfig';
 
@@ -26459,7 +26471,7 @@ final class OutputConfig extends ProtoMessage {
 }
 
 /// The metric used for dataset level evaluation.
-final class Metric extends ProtoMessage {
+final class Metric extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Metric';
 
@@ -26530,7 +26542,7 @@ final class Metric extends ProtoMessage {
 }
 
 /// The aggregation metrics supported by EvaluationService.EvaluateDataset.
-final class Metric_AggregationMetric extends ProtoEnum {
+final class Metric_AggregationMetric extends protobuf.ProtoEnum {
   /// Unspecified aggregation metric.
   static const aggregationMetricUnspecified = Metric_AggregationMetric(
     'AGGREGATION_METRIC_UNSPECIFIED',
@@ -26578,7 +26590,7 @@ final class Metric_AggregationMetric extends ProtoEnum {
 }
 
 /// The dataset used for evaluation.
-final class EvaluationDataset extends ProtoMessage {
+final class EvaluationDataset extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.EvaluationDataset';
 
@@ -26613,7 +26625,7 @@ final class EvaluationDataset extends ProtoMessage {
 
 /// The configs for autorater. This is applicable to both EvaluateInstances and
 /// EvaluateDataset.
-final class AutoraterConfig extends ProtoMessage {
+final class AutoraterConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AutoraterConfig';
 
@@ -26672,7 +26684,7 @@ final class AutoraterConfig extends ProtoMessage {
 }
 
 /// Request message for EvaluationService.EvaluateInstances.
-final class EvaluateInstancesRequest extends ProtoMessage {
+final class EvaluateInstancesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.EvaluateInstancesRequest';
 
@@ -27022,7 +27034,7 @@ final class EvaluateInstancesRequest extends ProtoMessage {
 }
 
 /// Response message for EvaluationService.EvaluateInstances.
-final class EvaluateInstancesResponse extends ProtoMessage {
+final class EvaluateInstancesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.EvaluateInstancesResponse';
 
@@ -27361,7 +27373,7 @@ final class EvaluateInstancesResponse extends ProtoMessage {
 }
 
 /// Input for exact match metric.
-final class ExactMatchInput extends ProtoMessage {
+final class ExactMatchInput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExactMatchInput';
 
@@ -27397,7 +27409,7 @@ final class ExactMatchInput extends ProtoMessage {
 }
 
 /// Spec for exact match instance.
-final class ExactMatchInstance extends ProtoMessage {
+final class ExactMatchInstance extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExactMatchInstance';
 
@@ -27437,7 +27449,7 @@ final class ExactMatchInstance extends ProtoMessage {
 
 /// Spec for exact match metric - returns 1 if prediction and reference exactly
 /// matches, otherwise 0.
-final class ExactMatchSpec extends ProtoMessage {
+final class ExactMatchSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExactMatchSpec';
 
@@ -27457,7 +27469,7 @@ final class ExactMatchSpec extends ProtoMessage {
 }
 
 /// Results for exact match metric.
-final class ExactMatchResults extends ProtoMessage {
+final class ExactMatchResults extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExactMatchResults';
 
@@ -27488,7 +27500,7 @@ final class ExactMatchResults extends ProtoMessage {
 }
 
 /// Exact match metric value for an instance.
-final class ExactMatchMetricValue extends ProtoMessage {
+final class ExactMatchMetricValue extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExactMatchMetricValue';
 
@@ -27514,7 +27526,7 @@ final class ExactMatchMetricValue extends ProtoMessage {
 }
 
 /// Input for bleu metric.
-final class BleuInput extends ProtoMessage {
+final class BleuInput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BleuInput';
 
@@ -27546,7 +27558,7 @@ final class BleuInput extends ProtoMessage {
 }
 
 /// Spec for bleu instance.
-final class BleuInstance extends ProtoMessage {
+final class BleuInstance extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BleuInstance';
 
@@ -27585,7 +27597,7 @@ final class BleuInstance extends ProtoMessage {
 
 /// Spec for bleu score metric - calculates the precision of n-grams in the
 /// prediction as compared to reference - returns a score ranging between 0 to 1.
-final class BleuSpec extends ProtoMessage {
+final class BleuSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BleuSpec';
 
@@ -27615,7 +27627,7 @@ final class BleuSpec extends ProtoMessage {
 }
 
 /// Results for bleu metric.
-final class BleuResults extends ProtoMessage {
+final class BleuResults extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BleuResults';
 
@@ -27646,7 +27658,7 @@ final class BleuResults extends ProtoMessage {
 }
 
 /// Bleu metric value for an instance.
-final class BleuMetricValue extends ProtoMessage {
+final class BleuMetricValue extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BleuMetricValue';
 
@@ -27672,7 +27684,7 @@ final class BleuMetricValue extends ProtoMessage {
 }
 
 /// Input for rouge metric.
-final class RougeInput extends ProtoMessage {
+final class RougeInput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RougeInput';
 
@@ -27704,7 +27716,7 @@ final class RougeInput extends ProtoMessage {
 }
 
 /// Spec for rouge instance.
-final class RougeInstance extends ProtoMessage {
+final class RougeInstance extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RougeInstance';
 
@@ -27743,7 +27755,7 @@ final class RougeInstance extends ProtoMessage {
 
 /// Spec for rouge score metric - calculates the recall of n-grams in prediction
 /// as compared to reference - returns a score ranging between 0 and 1.
-final class RougeSpec extends ProtoMessage {
+final class RougeSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RougeSpec';
 
@@ -27788,7 +27800,7 @@ final class RougeSpec extends ProtoMessage {
 }
 
 /// Results for rouge metric.
-final class RougeResults extends ProtoMessage {
+final class RougeResults extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RougeResults';
 
@@ -27819,7 +27831,7 @@ final class RougeResults extends ProtoMessage {
 }
 
 /// Rouge metric value for an instance.
-final class RougeMetricValue extends ProtoMessage {
+final class RougeMetricValue extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RougeMetricValue';
 
@@ -27845,7 +27857,7 @@ final class RougeMetricValue extends ProtoMessage {
 }
 
 /// Input for coherence metric.
-final class CoherenceInput extends ProtoMessage {
+final class CoherenceInput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CoherenceInput';
 
@@ -27877,7 +27889,7 @@ final class CoherenceInput extends ProtoMessage {
 }
 
 /// Spec for coherence instance.
-final class CoherenceInstance extends ProtoMessage {
+final class CoherenceInstance extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CoherenceInstance';
 
@@ -27905,7 +27917,7 @@ final class CoherenceInstance extends ProtoMessage {
 }
 
 /// Spec for coherence score metric.
-final class CoherenceSpec extends ProtoMessage {
+final class CoherenceSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CoherenceSpec';
 
@@ -27931,7 +27943,7 @@ final class CoherenceSpec extends ProtoMessage {
 }
 
 /// Spec for coherence result.
-final class CoherenceResult extends ProtoMessage {
+final class CoherenceResult extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CoherenceResult';
 
@@ -27976,7 +27988,7 @@ final class CoherenceResult extends ProtoMessage {
 }
 
 /// Input for fluency metric.
-final class FluencyInput extends ProtoMessage {
+final class FluencyInput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FluencyInput';
 
@@ -28008,7 +28020,7 @@ final class FluencyInput extends ProtoMessage {
 }
 
 /// Spec for fluency instance.
-final class FluencyInstance extends ProtoMessage {
+final class FluencyInstance extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FluencyInstance';
 
@@ -28036,7 +28048,7 @@ final class FluencyInstance extends ProtoMessage {
 }
 
 /// Spec for fluency score metric.
-final class FluencySpec extends ProtoMessage {
+final class FluencySpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FluencySpec';
 
@@ -28062,7 +28074,7 @@ final class FluencySpec extends ProtoMessage {
 }
 
 /// Spec for fluency result.
-final class FluencyResult extends ProtoMessage {
+final class FluencyResult extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FluencyResult';
 
@@ -28107,7 +28119,7 @@ final class FluencyResult extends ProtoMessage {
 }
 
 /// Input for safety metric.
-final class SafetyInput extends ProtoMessage {
+final class SafetyInput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SafetyInput';
 
@@ -28139,7 +28151,7 @@ final class SafetyInput extends ProtoMessage {
 }
 
 /// Spec for safety instance.
-final class SafetyInstance extends ProtoMessage {
+final class SafetyInstance extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SafetyInstance';
 
@@ -28167,7 +28179,7 @@ final class SafetyInstance extends ProtoMessage {
 }
 
 /// Spec for safety metric.
-final class SafetySpec extends ProtoMessage {
+final class SafetySpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SafetySpec';
 
@@ -28193,7 +28205,7 @@ final class SafetySpec extends ProtoMessage {
 }
 
 /// Spec for safety result.
-final class SafetyResult extends ProtoMessage {
+final class SafetyResult extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SafetyResult';
 
@@ -28238,7 +28250,7 @@ final class SafetyResult extends ProtoMessage {
 }
 
 /// Input for groundedness metric.
-final class GroundednessInput extends ProtoMessage {
+final class GroundednessInput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GroundednessInput';
 
@@ -28271,7 +28283,7 @@ final class GroundednessInput extends ProtoMessage {
 }
 
 /// Spec for groundedness instance.
-final class GroundednessInstance extends ProtoMessage {
+final class GroundednessInstance extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GroundednessInstance';
 
@@ -28311,7 +28323,7 @@ final class GroundednessInstance extends ProtoMessage {
 }
 
 /// Spec for groundedness metric.
-final class GroundednessSpec extends ProtoMessage {
+final class GroundednessSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GroundednessSpec';
 
@@ -28337,7 +28349,7 @@ final class GroundednessSpec extends ProtoMessage {
 }
 
 /// Spec for groundedness result.
-final class GroundednessResult extends ProtoMessage {
+final class GroundednessResult extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GroundednessResult';
 
@@ -28382,7 +28394,7 @@ final class GroundednessResult extends ProtoMessage {
 }
 
 /// Input for fulfillment metric.
-final class FulfillmentInput extends ProtoMessage {
+final class FulfillmentInput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FulfillmentInput';
 
@@ -28415,7 +28427,7 @@ final class FulfillmentInput extends ProtoMessage {
 }
 
 /// Spec for fulfillment instance.
-final class FulfillmentInstance extends ProtoMessage {
+final class FulfillmentInstance extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FulfillmentInstance';
 
@@ -28454,7 +28466,7 @@ final class FulfillmentInstance extends ProtoMessage {
 }
 
 /// Spec for fulfillment metric.
-final class FulfillmentSpec extends ProtoMessage {
+final class FulfillmentSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FulfillmentSpec';
 
@@ -28480,7 +28492,7 @@ final class FulfillmentSpec extends ProtoMessage {
 }
 
 /// Spec for fulfillment result.
-final class FulfillmentResult extends ProtoMessage {
+final class FulfillmentResult extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FulfillmentResult';
 
@@ -28525,7 +28537,7 @@ final class FulfillmentResult extends ProtoMessage {
 }
 
 /// Input for summarization quality metric.
-final class SummarizationQualityInput extends ProtoMessage {
+final class SummarizationQualityInput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SummarizationQualityInput';
 
@@ -28558,7 +28570,7 @@ final class SummarizationQualityInput extends ProtoMessage {
 }
 
 /// Spec for summarization quality instance.
-final class SummarizationQualityInstance extends ProtoMessage {
+final class SummarizationQualityInstance extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SummarizationQualityInstance';
 
@@ -28613,7 +28625,7 @@ final class SummarizationQualityInstance extends ProtoMessage {
 }
 
 /// Spec for summarization quality score metric.
-final class SummarizationQualitySpec extends ProtoMessage {
+final class SummarizationQualitySpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SummarizationQualitySpec';
 
@@ -28653,7 +28665,7 @@ final class SummarizationQualitySpec extends ProtoMessage {
 }
 
 /// Spec for summarization quality result.
-final class SummarizationQualityResult extends ProtoMessage {
+final class SummarizationQualityResult extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SummarizationQualityResult';
 
@@ -28698,7 +28710,7 @@ final class SummarizationQualityResult extends ProtoMessage {
 }
 
 /// Input for pairwise summarization quality metric.
-final class PairwiseSummarizationQualityInput extends ProtoMessage {
+final class PairwiseSummarizationQualityInput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PairwiseSummarizationQualityInput';
 
@@ -28739,7 +28751,7 @@ final class PairwiseSummarizationQualityInput extends ProtoMessage {
 }
 
 /// Spec for pairwise summarization quality instance.
-final class PairwiseSummarizationQualityInstance extends ProtoMessage {
+final class PairwiseSummarizationQualityInstance extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PairwiseSummarizationQualityInstance';
 
@@ -28803,7 +28815,7 @@ final class PairwiseSummarizationQualityInstance extends ProtoMessage {
 }
 
 /// Spec for pairwise summarization quality score metric.
-final class PairwiseSummarizationQualitySpec extends ProtoMessage {
+final class PairwiseSummarizationQualitySpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PairwiseSummarizationQualitySpec';
 
@@ -28843,7 +28855,7 @@ final class PairwiseSummarizationQualitySpec extends ProtoMessage {
 }
 
 /// Spec for pairwise summarization quality result.
-final class PairwiseSummarizationQualityResult extends ProtoMessage {
+final class PairwiseSummarizationQualityResult extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PairwiseSummarizationQualityResult';
 
@@ -28896,7 +28908,7 @@ final class PairwiseSummarizationQualityResult extends ProtoMessage {
 }
 
 /// Input for summarization helpfulness metric.
-final class SummarizationHelpfulnessInput extends ProtoMessage {
+final class SummarizationHelpfulnessInput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SummarizationHelpfulnessInput';
 
@@ -28935,7 +28947,7 @@ final class SummarizationHelpfulnessInput extends ProtoMessage {
 }
 
 /// Spec for summarization helpfulness instance.
-final class SummarizationHelpfulnessInstance extends ProtoMessage {
+final class SummarizationHelpfulnessInstance extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SummarizationHelpfulnessInstance';
 
@@ -28990,7 +29002,7 @@ final class SummarizationHelpfulnessInstance extends ProtoMessage {
 }
 
 /// Spec for summarization helpfulness score metric.
-final class SummarizationHelpfulnessSpec extends ProtoMessage {
+final class SummarizationHelpfulnessSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SummarizationHelpfulnessSpec';
 
@@ -29030,7 +29042,7 @@ final class SummarizationHelpfulnessSpec extends ProtoMessage {
 }
 
 /// Spec for summarization helpfulness result.
-final class SummarizationHelpfulnessResult extends ProtoMessage {
+final class SummarizationHelpfulnessResult extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SummarizationHelpfulnessResult';
 
@@ -29078,7 +29090,7 @@ final class SummarizationHelpfulnessResult extends ProtoMessage {
 }
 
 /// Input for summarization verbosity metric.
-final class SummarizationVerbosityInput extends ProtoMessage {
+final class SummarizationVerbosityInput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SummarizationVerbosityInput';
 
@@ -29117,7 +29129,7 @@ final class SummarizationVerbosityInput extends ProtoMessage {
 }
 
 /// Spec for summarization verbosity instance.
-final class SummarizationVerbosityInstance extends ProtoMessage {
+final class SummarizationVerbosityInstance extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SummarizationVerbosityInstance';
 
@@ -29172,7 +29184,7 @@ final class SummarizationVerbosityInstance extends ProtoMessage {
 }
 
 /// Spec for summarization verbosity score metric.
-final class SummarizationVerbositySpec extends ProtoMessage {
+final class SummarizationVerbositySpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SummarizationVerbositySpec';
 
@@ -29212,7 +29224,7 @@ final class SummarizationVerbositySpec extends ProtoMessage {
 }
 
 /// Spec for summarization verbosity result.
-final class SummarizationVerbosityResult extends ProtoMessage {
+final class SummarizationVerbosityResult extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SummarizationVerbosityResult';
 
@@ -29257,7 +29269,7 @@ final class SummarizationVerbosityResult extends ProtoMessage {
 }
 
 /// Input for question answering quality metric.
-final class QuestionAnsweringQualityInput extends ProtoMessage {
+final class QuestionAnsweringQualityInput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.QuestionAnsweringQualityInput';
 
@@ -29296,7 +29308,7 @@ final class QuestionAnsweringQualityInput extends ProtoMessage {
 }
 
 /// Spec for question answering quality instance.
-final class QuestionAnsweringQualityInstance extends ProtoMessage {
+final class QuestionAnsweringQualityInstance extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.QuestionAnsweringQualityInstance';
 
@@ -29351,7 +29363,7 @@ final class QuestionAnsweringQualityInstance extends ProtoMessage {
 }
 
 /// Spec for question answering quality score metric.
-final class QuestionAnsweringQualitySpec extends ProtoMessage {
+final class QuestionAnsweringQualitySpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.QuestionAnsweringQualitySpec';
 
@@ -29391,7 +29403,7 @@ final class QuestionAnsweringQualitySpec extends ProtoMessage {
 }
 
 /// Spec for question answering quality result.
-final class QuestionAnsweringQualityResult extends ProtoMessage {
+final class QuestionAnsweringQualityResult extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.QuestionAnsweringQualityResult';
 
@@ -29439,7 +29451,8 @@ final class QuestionAnsweringQualityResult extends ProtoMessage {
 }
 
 /// Input for pairwise question answering quality metric.
-final class PairwiseQuestionAnsweringQualityInput extends ProtoMessage {
+final class PairwiseQuestionAnsweringQualityInput
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PairwiseQuestionAnsweringQualityInput';
 
@@ -29480,7 +29493,8 @@ final class PairwiseQuestionAnsweringQualityInput extends ProtoMessage {
 }
 
 /// Spec for pairwise question answering quality instance.
-final class PairwiseQuestionAnsweringQualityInstance extends ProtoMessage {
+final class PairwiseQuestionAnsweringQualityInstance
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PairwiseQuestionAnsweringQualityInstance';
 
@@ -29544,7 +29558,7 @@ final class PairwiseQuestionAnsweringQualityInstance extends ProtoMessage {
 }
 
 /// Spec for pairwise question answering quality score metric.
-final class PairwiseQuestionAnsweringQualitySpec extends ProtoMessage {
+final class PairwiseQuestionAnsweringQualitySpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PairwiseQuestionAnsweringQualitySpec';
 
@@ -29586,7 +29600,8 @@ final class PairwiseQuestionAnsweringQualitySpec extends ProtoMessage {
 }
 
 /// Spec for pairwise question answering quality result.
-final class PairwiseQuestionAnsweringQualityResult extends ProtoMessage {
+final class PairwiseQuestionAnsweringQualityResult
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PairwiseQuestionAnsweringQualityResult';
 
@@ -29639,7 +29654,7 @@ final class PairwiseQuestionAnsweringQualityResult extends ProtoMessage {
 }
 
 /// Input for question answering relevance metric.
-final class QuestionAnsweringRelevanceInput extends ProtoMessage {
+final class QuestionAnsweringRelevanceInput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.QuestionAnsweringRelevanceInput';
 
@@ -29678,7 +29693,7 @@ final class QuestionAnsweringRelevanceInput extends ProtoMessage {
 }
 
 /// Spec for question answering relevance instance.
-final class QuestionAnsweringRelevanceInstance extends ProtoMessage {
+final class QuestionAnsweringRelevanceInstance extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.QuestionAnsweringRelevanceInstance';
 
@@ -29735,7 +29750,7 @@ final class QuestionAnsweringRelevanceInstance extends ProtoMessage {
 }
 
 /// Spec for question answering relevance metric.
-final class QuestionAnsweringRelevanceSpec extends ProtoMessage {
+final class QuestionAnsweringRelevanceSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.QuestionAnsweringRelevanceSpec';
 
@@ -29775,7 +29790,7 @@ final class QuestionAnsweringRelevanceSpec extends ProtoMessage {
 }
 
 /// Spec for question answering relevance result.
-final class QuestionAnsweringRelevanceResult extends ProtoMessage {
+final class QuestionAnsweringRelevanceResult extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.QuestionAnsweringRelevanceResult';
 
@@ -29823,7 +29838,7 @@ final class QuestionAnsweringRelevanceResult extends ProtoMessage {
 }
 
 /// Input for question answering helpfulness metric.
-final class QuestionAnsweringHelpfulnessInput extends ProtoMessage {
+final class QuestionAnsweringHelpfulnessInput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.QuestionAnsweringHelpfulnessInput';
 
@@ -29864,7 +29879,7 @@ final class QuestionAnsweringHelpfulnessInput extends ProtoMessage {
 }
 
 /// Spec for question answering helpfulness instance.
-final class QuestionAnsweringHelpfulnessInstance extends ProtoMessage {
+final class QuestionAnsweringHelpfulnessInstance extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.QuestionAnsweringHelpfulnessInstance';
 
@@ -29921,7 +29936,7 @@ final class QuestionAnsweringHelpfulnessInstance extends ProtoMessage {
 }
 
 /// Spec for question answering helpfulness metric.
-final class QuestionAnsweringHelpfulnessSpec extends ProtoMessage {
+final class QuestionAnsweringHelpfulnessSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.QuestionAnsweringHelpfulnessSpec';
 
@@ -29961,7 +29976,7 @@ final class QuestionAnsweringHelpfulnessSpec extends ProtoMessage {
 }
 
 /// Spec for question answering helpfulness result.
-final class QuestionAnsweringHelpfulnessResult extends ProtoMessage {
+final class QuestionAnsweringHelpfulnessResult extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.QuestionAnsweringHelpfulnessResult';
 
@@ -30011,7 +30026,7 @@ final class QuestionAnsweringHelpfulnessResult extends ProtoMessage {
 }
 
 /// Input for question answering correctness metric.
-final class QuestionAnsweringCorrectnessInput extends ProtoMessage {
+final class QuestionAnsweringCorrectnessInput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.QuestionAnsweringCorrectnessInput';
 
@@ -30052,7 +30067,7 @@ final class QuestionAnsweringCorrectnessInput extends ProtoMessage {
 }
 
 /// Spec for question answering correctness instance.
-final class QuestionAnsweringCorrectnessInstance extends ProtoMessage {
+final class QuestionAnsweringCorrectnessInstance extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.QuestionAnsweringCorrectnessInstance';
 
@@ -30109,7 +30124,7 @@ final class QuestionAnsweringCorrectnessInstance extends ProtoMessage {
 }
 
 /// Spec for question answering correctness metric.
-final class QuestionAnsweringCorrectnessSpec extends ProtoMessage {
+final class QuestionAnsweringCorrectnessSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.QuestionAnsweringCorrectnessSpec';
 
@@ -30149,7 +30164,7 @@ final class QuestionAnsweringCorrectnessSpec extends ProtoMessage {
 }
 
 /// Spec for question answering correctness result.
-final class QuestionAnsweringCorrectnessResult extends ProtoMessage {
+final class QuestionAnsweringCorrectnessResult extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.QuestionAnsweringCorrectnessResult';
 
@@ -30199,7 +30214,7 @@ final class QuestionAnsweringCorrectnessResult extends ProtoMessage {
 }
 
 /// Input for pointwise metric.
-final class PointwiseMetricInput extends ProtoMessage {
+final class PointwiseMetricInput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PointwiseMetricInput';
 
@@ -30233,7 +30248,7 @@ final class PointwiseMetricInput extends ProtoMessage {
 
 /// Pointwise metric instance. Usually one instance corresponds to one row in an
 /// evaluation dataset.
-final class PointwiseMetricInstance extends ProtoMessage {
+final class PointwiseMetricInstance extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PointwiseMetricInstance';
 
@@ -30279,7 +30294,7 @@ final class PointwiseMetricInstance extends ProtoMessage {
 }
 
 /// Spec for pointwise metric.
-final class PointwiseMetricSpec extends ProtoMessage {
+final class PointwiseMetricSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PointwiseMetricSpec';
 
@@ -30338,7 +30353,7 @@ final class PointwiseMetricSpec extends ProtoMessage {
 }
 
 /// Spec for custom output format configuration.
-final class CustomOutputFormatConfig extends ProtoMessage {
+final class CustomOutputFormatConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CustomOutputFormatConfig';
 
@@ -30366,7 +30381,7 @@ final class CustomOutputFormatConfig extends ProtoMessage {
 }
 
 /// Spec for pointwise metric result.
-final class PointwiseMetricResult extends ProtoMessage {
+final class PointwiseMetricResult extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PointwiseMetricResult';
 
@@ -30410,7 +30425,7 @@ final class PointwiseMetricResult extends ProtoMessage {
 }
 
 /// Spec for custom output.
-final class CustomOutput extends ProtoMessage {
+final class CustomOutput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CustomOutput';
 
@@ -30435,7 +30450,7 @@ final class CustomOutput extends ProtoMessage {
 }
 
 /// Raw output.
-final class RawOutput extends ProtoMessage {
+final class RawOutput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RawOutput';
 
@@ -30458,7 +30473,7 @@ final class RawOutput extends ProtoMessage {
 }
 
 /// Input for pairwise metric.
-final class PairwiseMetricInput extends ProtoMessage {
+final class PairwiseMetricInput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PairwiseMetricInput';
 
@@ -30492,7 +30507,7 @@ final class PairwiseMetricInput extends ProtoMessage {
 
 /// Pairwise metric instance. Usually one instance corresponds to one row in an
 /// evaluation dataset.
-final class PairwiseMetricInstance extends ProtoMessage {
+final class PairwiseMetricInstance extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PairwiseMetricInstance';
 
@@ -30538,7 +30553,7 @@ final class PairwiseMetricInstance extends ProtoMessage {
 }
 
 /// Spec for pairwise metric.
-final class PairwiseMetricSpec extends ProtoMessage {
+final class PairwiseMetricSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PairwiseMetricSpec';
 
@@ -30613,7 +30628,7 @@ final class PairwiseMetricSpec extends ProtoMessage {
 }
 
 /// Spec for pairwise metric result.
-final class PairwiseMetricResult extends ProtoMessage {
+final class PairwiseMetricResult extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PairwiseMetricResult';
 
@@ -30663,7 +30678,7 @@ final class PairwiseMetricResult extends ProtoMessage {
 }
 
 /// Input for tool call valid metric.
-final class ToolCallValidInput extends ProtoMessage {
+final class ToolCallValidInput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ToolCallValidInput';
 
@@ -30699,7 +30714,7 @@ final class ToolCallValidInput extends ProtoMessage {
 }
 
 /// Spec for tool call valid metric.
-final class ToolCallValidSpec extends ProtoMessage {
+final class ToolCallValidSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ToolCallValidSpec';
 
@@ -30719,7 +30734,7 @@ final class ToolCallValidSpec extends ProtoMessage {
 }
 
 /// Spec for tool call valid instance.
-final class ToolCallValidInstance extends ProtoMessage {
+final class ToolCallValidInstance extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ToolCallValidInstance';
 
@@ -30758,7 +30773,7 @@ final class ToolCallValidInstance extends ProtoMessage {
 }
 
 /// Results for tool call valid metric.
-final class ToolCallValidResults extends ProtoMessage {
+final class ToolCallValidResults extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ToolCallValidResults';
 
@@ -30790,7 +30805,7 @@ final class ToolCallValidResults extends ProtoMessage {
 }
 
 /// Tool call valid metric value for an instance.
-final class ToolCallValidMetricValue extends ProtoMessage {
+final class ToolCallValidMetricValue extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ToolCallValidMetricValue';
 
@@ -30816,7 +30831,7 @@ final class ToolCallValidMetricValue extends ProtoMessage {
 }
 
 /// Input for tool name match metric.
-final class ToolNameMatchInput extends ProtoMessage {
+final class ToolNameMatchInput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ToolNameMatchInput';
 
@@ -30852,7 +30867,7 @@ final class ToolNameMatchInput extends ProtoMessage {
 }
 
 /// Spec for tool name match metric.
-final class ToolNameMatchSpec extends ProtoMessage {
+final class ToolNameMatchSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ToolNameMatchSpec';
 
@@ -30872,7 +30887,7 @@ final class ToolNameMatchSpec extends ProtoMessage {
 }
 
 /// Spec for tool name match instance.
-final class ToolNameMatchInstance extends ProtoMessage {
+final class ToolNameMatchInstance extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ToolNameMatchInstance';
 
@@ -30911,7 +30926,7 @@ final class ToolNameMatchInstance extends ProtoMessage {
 }
 
 /// Results for tool name match metric.
-final class ToolNameMatchResults extends ProtoMessage {
+final class ToolNameMatchResults extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ToolNameMatchResults';
 
@@ -30943,7 +30958,7 @@ final class ToolNameMatchResults extends ProtoMessage {
 }
 
 /// Tool name match metric value for an instance.
-final class ToolNameMatchMetricValue extends ProtoMessage {
+final class ToolNameMatchMetricValue extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ToolNameMatchMetricValue';
 
@@ -30969,7 +30984,7 @@ final class ToolNameMatchMetricValue extends ProtoMessage {
 }
 
 /// Input for tool parameter key match metric.
-final class ToolParameterKeyMatchInput extends ProtoMessage {
+final class ToolParameterKeyMatchInput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ToolParameterKeyMatchInput';
 
@@ -31008,7 +31023,7 @@ final class ToolParameterKeyMatchInput extends ProtoMessage {
 }
 
 /// Spec for tool parameter key match metric.
-final class ToolParameterKeyMatchSpec extends ProtoMessage {
+final class ToolParameterKeyMatchSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ToolParameterKeyMatchSpec';
 
@@ -31028,7 +31043,7 @@ final class ToolParameterKeyMatchSpec extends ProtoMessage {
 }
 
 /// Spec for tool parameter key match instance.
-final class ToolParameterKeyMatchInstance extends ProtoMessage {
+final class ToolParameterKeyMatchInstance extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ToolParameterKeyMatchInstance';
 
@@ -31067,7 +31082,7 @@ final class ToolParameterKeyMatchInstance extends ProtoMessage {
 }
 
 /// Results for tool parameter key match metric.
-final class ToolParameterKeyMatchResults extends ProtoMessage {
+final class ToolParameterKeyMatchResults extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ToolParameterKeyMatchResults';
 
@@ -31102,7 +31117,7 @@ final class ToolParameterKeyMatchResults extends ProtoMessage {
 }
 
 /// Tool parameter key match metric value for an instance.
-final class ToolParameterKeyMatchMetricValue extends ProtoMessage {
+final class ToolParameterKeyMatchMetricValue extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ToolParameterKeyMatchMetricValue';
 
@@ -31128,7 +31143,7 @@ final class ToolParameterKeyMatchMetricValue extends ProtoMessage {
 }
 
 /// Input for tool parameter key value match metric.
-final class ToolParameterKvmatchInput extends ProtoMessage {
+final class ToolParameterKvmatchInput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ToolParameterKVMatchInput';
 
@@ -31164,7 +31179,7 @@ final class ToolParameterKvmatchInput extends ProtoMessage {
 }
 
 /// Spec for tool parameter key value match metric.
-final class ToolParameterKvmatchSpec extends ProtoMessage {
+final class ToolParameterKvmatchSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ToolParameterKVMatchSpec';
 
@@ -31199,7 +31214,7 @@ final class ToolParameterKvmatchSpec extends ProtoMessage {
 }
 
 /// Spec for tool parameter key value match instance.
-final class ToolParameterKvmatchInstance extends ProtoMessage {
+final class ToolParameterKvmatchInstance extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ToolParameterKVMatchInstance';
 
@@ -31238,7 +31253,7 @@ final class ToolParameterKvmatchInstance extends ProtoMessage {
 }
 
 /// Results for tool parameter key value match metric.
-final class ToolParameterKvmatchResults extends ProtoMessage {
+final class ToolParameterKvmatchResults extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ToolParameterKVMatchResults';
 
@@ -31272,7 +31287,7 @@ final class ToolParameterKvmatchResults extends ProtoMessage {
 }
 
 /// Tool parameter key value match metric value for an instance.
-final class ToolParameterKvmatchMetricValue extends ProtoMessage {
+final class ToolParameterKvmatchMetricValue extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ToolParameterKVMatchMetricValue';
 
@@ -31298,7 +31313,7 @@ final class ToolParameterKvmatchMetricValue extends ProtoMessage {
 }
 
 /// Input for Comet metric.
-final class CometInput extends ProtoMessage {
+final class CometInput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CometInput';
 
@@ -31330,7 +31345,7 @@ final class CometInput extends ProtoMessage {
 }
 
 /// Spec for Comet metric.
-final class CometSpec extends ProtoMessage {
+final class CometSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CometSpec';
 
@@ -31376,7 +31391,7 @@ final class CometSpec extends ProtoMessage {
 }
 
 /// Comet version options.
-final class CometSpec_CometVersion extends ProtoEnum {
+final class CometSpec_CometVersion extends protobuf.ProtoEnum {
   /// Comet version unspecified.
   static const cometVersionUnspecified = CometSpec_CometVersion(
     'COMET_VERSION_UNSPECIFIED',
@@ -31397,7 +31412,7 @@ final class CometSpec_CometVersion extends ProtoEnum {
 
 /// Spec for Comet instance - The fields used for evaluation are dependent on the
 /// comet version.
-final class CometInstance extends ProtoMessage {
+final class CometInstance extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CometInstance';
 
@@ -31443,7 +31458,7 @@ final class CometInstance extends ProtoMessage {
 
 /// Spec for Comet result - calculates the comet score for the given instance
 /// using the version specified in the spec.
-final class CometResult extends ProtoMessage {
+final class CometResult extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CometResult';
 
@@ -31469,7 +31484,7 @@ final class CometResult extends ProtoMessage {
 }
 
 /// Input for MetricX metric.
-final class MetricxInput extends ProtoMessage {
+final class MetricxInput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.MetricxInput';
 
@@ -31501,7 +31516,7 @@ final class MetricxInput extends ProtoMessage {
 }
 
 /// Spec for MetricX metric.
-final class MetricxSpec extends ProtoMessage {
+final class MetricxSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.MetricxSpec';
 
@@ -31547,7 +31562,7 @@ final class MetricxSpec extends ProtoMessage {
 }
 
 /// MetricX Version options.
-final class MetricxSpec_MetricxVersion extends ProtoEnum {
+final class MetricxSpec_MetricxVersion extends protobuf.ProtoEnum {
   /// MetricX version unspecified.
   static const metricxVersionUnspecified = MetricxSpec_MetricxVersion(
     'METRICX_VERSION_UNSPECIFIED',
@@ -31576,7 +31591,7 @@ final class MetricxSpec_MetricxVersion extends ProtoEnum {
 
 /// Spec for MetricX instance - The fields used for evaluation are dependent on
 /// the MetricX version.
-final class MetricxInstance extends ProtoMessage {
+final class MetricxInstance extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.MetricxInstance';
 
@@ -31622,7 +31637,7 @@ final class MetricxInstance extends ProtoMessage {
 
 /// Spec for MetricX result - calculates the MetricX score for the given instance
 /// using the version specified in the spec.
-final class MetricxResult extends ProtoMessage {
+final class MetricxResult extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.MetricxResult';
 
@@ -31648,7 +31663,7 @@ final class MetricxResult extends ProtoMessage {
 }
 
 /// Instance and metric spec for RubricBasedInstructionFollowing metric.
-final class RubricBasedInstructionFollowingInput extends ProtoMessage {
+final class RubricBasedInstructionFollowingInput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RubricBasedInstructionFollowingInput';
 
@@ -31690,7 +31705,8 @@ final class RubricBasedInstructionFollowingInput extends ProtoMessage {
 
 /// Instance for RubricBasedInstructionFollowing metric - one instance
 /// corresponds to one row in an evaluation dataset.
-final class RubricBasedInstructionFollowingInstance extends ProtoMessage {
+final class RubricBasedInstructionFollowingInstance
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RubricBasedInstructionFollowingInstance';
 
@@ -31726,7 +31742,7 @@ final class RubricBasedInstructionFollowingInstance extends ProtoMessage {
 
 /// Spec for RubricBasedInstructionFollowing metric - returns rubrics
 /// and verdicts corresponding to rubrics along with overall score.
-final class RubricBasedInstructionFollowingSpec extends ProtoMessage {
+final class RubricBasedInstructionFollowingSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RubricBasedInstructionFollowingSpec';
 
@@ -31748,7 +31764,8 @@ final class RubricBasedInstructionFollowingSpec extends ProtoMessage {
 }
 
 /// Result for RubricBasedInstructionFollowing metric.
-final class RubricBasedInstructionFollowingResult extends ProtoMessage {
+final class RubricBasedInstructionFollowingResult
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RubricBasedInstructionFollowingResult';
 
@@ -31792,7 +31809,7 @@ final class RubricBasedInstructionFollowingResult extends ProtoMessage {
 }
 
 /// Rubric critique result.
-final class RubricCritiqueResult extends ProtoMessage {
+final class RubricCritiqueResult extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RubricCritiqueResult';
 
@@ -31831,7 +31848,7 @@ final class RubricCritiqueResult extends ProtoMessage {
 }
 
 /// Instances and metric spec for TrajectoryExactMatch metric.
-final class TrajectoryExactMatchInput extends ProtoMessage {
+final class TrajectoryExactMatchInput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TrajectoryExactMatchInput';
 
@@ -31868,7 +31885,7 @@ final class TrajectoryExactMatchInput extends ProtoMessage {
 
 /// Spec for TrajectoryExactMatch metric - returns 1 if tool calls in the
 /// reference trajectory exactly match the predicted trajectory, else 0.
-final class TrajectoryExactMatchSpec extends ProtoMessage {
+final class TrajectoryExactMatchSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TrajectoryExactMatchSpec';
 
@@ -31888,7 +31905,7 @@ final class TrajectoryExactMatchSpec extends ProtoMessage {
 }
 
 /// Spec for TrajectoryExactMatch instance.
-final class TrajectoryExactMatchInstance extends ProtoMessage {
+final class TrajectoryExactMatchInstance extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TrajectoryExactMatchInstance';
 
@@ -31931,7 +31948,7 @@ final class TrajectoryExactMatchInstance extends ProtoMessage {
 }
 
 /// Results for TrajectoryExactMatch metric.
-final class TrajectoryExactMatchResults extends ProtoMessage {
+final class TrajectoryExactMatchResults extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TrajectoryExactMatchResults';
 
@@ -31965,7 +31982,7 @@ final class TrajectoryExactMatchResults extends ProtoMessage {
 }
 
 /// TrajectoryExactMatch metric value for an instance.
-final class TrajectoryExactMatchMetricValue extends ProtoMessage {
+final class TrajectoryExactMatchMetricValue extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TrajectoryExactMatchMetricValue';
 
@@ -31991,7 +32008,7 @@ final class TrajectoryExactMatchMetricValue extends ProtoMessage {
 }
 
 /// Instances and metric spec for TrajectoryInOrderMatch metric.
-final class TrajectoryInOrderMatchInput extends ProtoMessage {
+final class TrajectoryInOrderMatchInput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TrajectoryInOrderMatchInput';
 
@@ -32032,7 +32049,7 @@ final class TrajectoryInOrderMatchInput extends ProtoMessage {
 /// Spec for TrajectoryInOrderMatch metric - returns 1 if tool calls in the
 /// reference trajectory appear in the predicted trajectory in the same order,
 /// else 0.
-final class TrajectoryInOrderMatchSpec extends ProtoMessage {
+final class TrajectoryInOrderMatchSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TrajectoryInOrderMatchSpec';
 
@@ -32052,7 +32069,7 @@ final class TrajectoryInOrderMatchSpec extends ProtoMessage {
 }
 
 /// Spec for TrajectoryInOrderMatch instance.
-final class TrajectoryInOrderMatchInstance extends ProtoMessage {
+final class TrajectoryInOrderMatchInstance extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TrajectoryInOrderMatchInstance';
 
@@ -32095,7 +32112,7 @@ final class TrajectoryInOrderMatchInstance extends ProtoMessage {
 }
 
 /// Results for TrajectoryInOrderMatch metric.
-final class TrajectoryInOrderMatchResults extends ProtoMessage {
+final class TrajectoryInOrderMatchResults extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TrajectoryInOrderMatchResults';
 
@@ -32130,7 +32147,7 @@ final class TrajectoryInOrderMatchResults extends ProtoMessage {
 }
 
 /// TrajectoryInOrderMatch metric value for an instance.
-final class TrajectoryInOrderMatchMetricValue extends ProtoMessage {
+final class TrajectoryInOrderMatchMetricValue extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TrajectoryInOrderMatchMetricValue';
 
@@ -32160,7 +32177,7 @@ final class TrajectoryInOrderMatchMetricValue extends ProtoMessage {
 }
 
 /// Instances and metric spec for TrajectoryAnyOrderMatch metric.
-final class TrajectoryAnyOrderMatchInput extends ProtoMessage {
+final class TrajectoryAnyOrderMatchInput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TrajectoryAnyOrderMatchInput';
 
@@ -32201,7 +32218,7 @@ final class TrajectoryAnyOrderMatchInput extends ProtoMessage {
 /// Spec for TrajectoryAnyOrderMatch metric - returns 1 if all tool calls in the
 /// reference trajectory appear in the predicted trajectory in any order, else
 /// 0.
-final class TrajectoryAnyOrderMatchSpec extends ProtoMessage {
+final class TrajectoryAnyOrderMatchSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TrajectoryAnyOrderMatchSpec';
 
@@ -32221,7 +32238,7 @@ final class TrajectoryAnyOrderMatchSpec extends ProtoMessage {
 }
 
 /// Spec for TrajectoryAnyOrderMatch instance.
-final class TrajectoryAnyOrderMatchInstance extends ProtoMessage {
+final class TrajectoryAnyOrderMatchInstance extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TrajectoryAnyOrderMatchInstance';
 
@@ -32264,7 +32281,7 @@ final class TrajectoryAnyOrderMatchInstance extends ProtoMessage {
 }
 
 /// Results for TrajectoryAnyOrderMatch metric.
-final class TrajectoryAnyOrderMatchResults extends ProtoMessage {
+final class TrajectoryAnyOrderMatchResults extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TrajectoryAnyOrderMatchResults';
 
@@ -32299,7 +32316,7 @@ final class TrajectoryAnyOrderMatchResults extends ProtoMessage {
 }
 
 /// TrajectoryAnyOrderMatch metric value for an instance.
-final class TrajectoryAnyOrderMatchMetricValue extends ProtoMessage {
+final class TrajectoryAnyOrderMatchMetricValue extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TrajectoryAnyOrderMatchMetricValue';
 
@@ -32329,7 +32346,7 @@ final class TrajectoryAnyOrderMatchMetricValue extends ProtoMessage {
 }
 
 /// Instances and metric spec for TrajectoryPrecision metric.
-final class TrajectoryPrecisionInput extends ProtoMessage {
+final class TrajectoryPrecisionInput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TrajectoryPrecisionInput';
 
@@ -32366,7 +32383,7 @@ final class TrajectoryPrecisionInput extends ProtoMessage {
 
 /// Spec for TrajectoryPrecision metric - returns a float score based on average
 /// precision of individual tool calls.
-final class TrajectoryPrecisionSpec extends ProtoMessage {
+final class TrajectoryPrecisionSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TrajectoryPrecisionSpec';
 
@@ -32386,7 +32403,7 @@ final class TrajectoryPrecisionSpec extends ProtoMessage {
 }
 
 /// Spec for TrajectoryPrecision instance.
-final class TrajectoryPrecisionInstance extends ProtoMessage {
+final class TrajectoryPrecisionInstance extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TrajectoryPrecisionInstance';
 
@@ -32429,7 +32446,7 @@ final class TrajectoryPrecisionInstance extends ProtoMessage {
 }
 
 /// Results for TrajectoryPrecision metric.
-final class TrajectoryPrecisionResults extends ProtoMessage {
+final class TrajectoryPrecisionResults extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TrajectoryPrecisionResults';
 
@@ -32463,7 +32480,7 @@ final class TrajectoryPrecisionResults extends ProtoMessage {
 }
 
 /// TrajectoryPrecision metric value for an instance.
-final class TrajectoryPrecisionMetricValue extends ProtoMessage {
+final class TrajectoryPrecisionMetricValue extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TrajectoryPrecisionMetricValue';
 
@@ -32489,7 +32506,7 @@ final class TrajectoryPrecisionMetricValue extends ProtoMessage {
 }
 
 /// Instances and metric spec for TrajectoryRecall metric.
-final class TrajectoryRecallInput extends ProtoMessage {
+final class TrajectoryRecallInput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TrajectoryRecallInput';
 
@@ -32526,7 +32543,7 @@ final class TrajectoryRecallInput extends ProtoMessage {
 
 /// Spec for TrajectoryRecall metric - returns a float score based on average
 /// recall of individual tool calls.
-final class TrajectoryRecallSpec extends ProtoMessage {
+final class TrajectoryRecallSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TrajectoryRecallSpec';
 
@@ -32546,7 +32563,7 @@ final class TrajectoryRecallSpec extends ProtoMessage {
 }
 
 /// Spec for TrajectoryRecall instance.
-final class TrajectoryRecallInstance extends ProtoMessage {
+final class TrajectoryRecallInstance extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TrajectoryRecallInstance';
 
@@ -32587,7 +32604,7 @@ final class TrajectoryRecallInstance extends ProtoMessage {
 }
 
 /// Results for TrajectoryRecall metric.
-final class TrajectoryRecallResults extends ProtoMessage {
+final class TrajectoryRecallResults extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TrajectoryRecallResults';
 
@@ -32621,7 +32638,7 @@ final class TrajectoryRecallResults extends ProtoMessage {
 }
 
 /// TrajectoryRecall metric value for an instance.
-final class TrajectoryRecallMetricValue extends ProtoMessage {
+final class TrajectoryRecallMetricValue extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TrajectoryRecallMetricValue';
 
@@ -32647,7 +32664,7 @@ final class TrajectoryRecallMetricValue extends ProtoMessage {
 }
 
 /// Instances and metric spec for TrajectorySingleToolUse metric.
-final class TrajectorySingleToolUseInput extends ProtoMessage {
+final class TrajectorySingleToolUseInput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TrajectorySingleToolUseInput';
 
@@ -32687,7 +32704,7 @@ final class TrajectorySingleToolUseInput extends ProtoMessage {
 
 /// Spec for TrajectorySingleToolUse metric - returns 1 if tool is present in the
 /// predicted trajectory, else 0.
-final class TrajectorySingleToolUseSpec extends ProtoMessage {
+final class TrajectorySingleToolUseSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TrajectorySingleToolUseSpec';
 
@@ -32713,7 +32730,7 @@ final class TrajectorySingleToolUseSpec extends ProtoMessage {
 }
 
 /// Spec for TrajectorySingleToolUse instance.
-final class TrajectorySingleToolUseInstance extends ProtoMessage {
+final class TrajectorySingleToolUseInstance extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TrajectorySingleToolUseInstance';
 
@@ -32745,7 +32762,7 @@ final class TrajectorySingleToolUseInstance extends ProtoMessage {
 }
 
 /// Results for TrajectorySingleToolUse metric.
-final class TrajectorySingleToolUseResults extends ProtoMessage {
+final class TrajectorySingleToolUseResults extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TrajectorySingleToolUseResults';
 
@@ -32780,7 +32797,7 @@ final class TrajectorySingleToolUseResults extends ProtoMessage {
 }
 
 /// TrajectorySingleToolUse metric value for an instance.
-final class TrajectorySingleToolUseMetricValue extends ProtoMessage {
+final class TrajectorySingleToolUseMetricValue extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TrajectorySingleToolUseMetricValue';
 
@@ -32810,7 +32827,7 @@ final class TrajectorySingleToolUseMetricValue extends ProtoMessage {
 }
 
 /// Spec for trajectory.
-final class Trajectory extends ProtoMessage {
+final class Trajectory extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Trajectory';
 
@@ -32835,7 +32852,7 @@ final class Trajectory extends ProtoMessage {
 }
 
 /// Spec for tool call.
-final class ToolCall extends ProtoMessage {
+final class ToolCall extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ToolCall';
 
@@ -32870,7 +32887,7 @@ final class ToolCall extends ProtoMessage {
 }
 
 /// Map of placeholder in metric prompt template to contents of model input.
-final class ContentMap extends ProtoMessage {
+final class ContentMap extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ContentMap';
 
@@ -32895,7 +32912,7 @@ final class ContentMap extends ProtoMessage {
 }
 
 /// Repeated Content type.
-final class ContentMap_Contents extends ProtoMessage {
+final class ContentMap_Contents extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ContentMap.Contents';
 
@@ -32921,7 +32938,7 @@ final class ContentMap_Contents extends ProtoMessage {
 
 /// An edge describing the relationship between an Artifact and an Execution in
 /// a lineage graph.
-final class Event extends ProtoMessage {
+final class Event extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Event';
 
@@ -32986,7 +33003,7 @@ final class Event extends ProtoMessage {
 }
 
 /// Describes whether an Event's Artifact is the Execution's input or output.
-final class Event_Type extends ProtoEnum {
+final class Event_Type extends protobuf.ProtoEnum {
   /// Unspecified whether input or output of the Execution.
   static const typeUnspecified = Event_Type('TYPE_UNSPECIFIED');
 
@@ -33005,7 +33022,7 @@ final class Event_Type extends ProtoEnum {
 }
 
 /// A single example of a conversation with the model.
-final class ContentsExample extends ProtoMessage {
+final class ContentsExample extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ContentsExample';
 
@@ -33045,7 +33062,7 @@ final class ContentsExample extends ProtoMessage {
 }
 
 /// A single step of the expected output.
-final class ContentsExample_ExpectedContent extends ProtoMessage {
+final class ContentsExample_ExpectedContent extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ContentsExample.ExpectedContent';
 
@@ -33071,7 +33088,7 @@ final class ContentsExample_ExpectedContent extends ProtoMessage {
 
 /// A ContentsExample to be used with GenerateContent alongside information
 /// required for storage and retrieval with Example Store.
-final class StoredContentsExample extends ProtoMessage {
+final class StoredContentsExample extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StoredContentsExample';
 
@@ -33130,7 +33147,7 @@ final class StoredContentsExample extends ProtoMessage {
 
 /// Options for generating the search key from the conversation history.
 final class StoredContentsExample_SearchKeyGenerationMethod
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StoredContentsExample.SearchKeyGenerationMethod';
 
@@ -33164,7 +33181,7 @@ final class StoredContentsExample_SearchKeyGenerationMethod
 /// Configuration for using only the last entry of the conversation history
 /// as the search key.
 final class StoredContentsExample_SearchKeyGenerationMethod_LastEntry
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StoredContentsExample.SearchKeyGenerationMethod.LastEntry';
 
@@ -33187,7 +33204,7 @@ final class StoredContentsExample_SearchKeyGenerationMethod_LastEntry
 }
 
 /// Represents an executable service to manage and retrieve examples.
-final class ExampleStore extends ProtoMessage {
+final class ExampleStore extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExampleStore';
 
@@ -33259,7 +33276,7 @@ final class ExampleStore extends ProtoMessage {
 }
 
 /// Configuration for the Example Store.
-final class ExampleStoreConfig extends ProtoMessage {
+final class ExampleStoreConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExampleStoreConfig';
 
@@ -33301,7 +33318,7 @@ final class ExampleStoreConfig extends ProtoMessage {
 /// The metadata filters that will be used to remove or fetch
 /// StoredContentsExamples. If a field is unspecified, then no filtering for that
 /// field will be applied.
-final class StoredContentsExampleFilter extends ProtoMessage {
+final class StoredContentsExampleFilter extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StoredContentsExampleFilter';
 
@@ -33341,7 +33358,7 @@ final class StoredContentsExampleFilter extends ProtoMessage {
 
 /// The metadata filters that will be used to search StoredContentsExamples.
 /// If a field is unspecified, then no filtering for that field will be applied
-final class StoredContentsExampleParameters extends ProtoMessage {
+final class StoredContentsExampleParameters extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StoredContentsExampleParameters';
 
@@ -33393,7 +33410,7 @@ final class StoredContentsExampleParameters extends ProtoMessage {
 
 /// The chat history to use to generate the search key for retrieval.
 final class StoredContentsExampleParameters_ContentSearchKey
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StoredContentsExampleParameters.ContentSearchKey';
 
@@ -33436,7 +33453,7 @@ final class StoredContentsExampleParameters_ContentSearchKey
 
 /// Filters for examples' array metadata fields. An array field is example
 /// metadata where multiple values are attributed to a single example.
-final class ExamplesArrayFilter extends ProtoMessage {
+final class ExamplesArrayFilter extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExamplesArrayFilter';
 
@@ -33477,7 +33494,7 @@ final class ExamplesArrayFilter extends ProtoMessage {
 }
 
 /// The logic to use for filtering.
-final class ExamplesArrayFilter_ArrayOperator extends ProtoEnum {
+final class ExamplesArrayFilter_ArrayOperator extends protobuf.ProtoEnum {
   /// Not specified. This value should not be used.
   static const arrayOperatorUnspecified = ExamplesArrayFilter_ArrayOperator(
     'ARRAY_OPERATOR_UNSPECIFIED',
@@ -33501,7 +33518,7 @@ final class ExamplesArrayFilter_ArrayOperator extends ProtoEnum {
 
 /// Request message for
 /// `ExampleStoreService.CreateExampleStore`.
-final class CreateExampleStoreRequest extends ProtoMessage {
+final class CreateExampleStoreRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateExampleStoreRequest';
 
@@ -33538,7 +33555,7 @@ final class CreateExampleStoreRequest extends ProtoMessage {
 /// Details of
 /// `ExampleStoreService.CreateExampleStore`
 /// operation.
-final class CreateExampleStoreOperationMetadata extends ProtoMessage {
+final class CreateExampleStoreOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateExampleStoreOperationMetadata';
 
@@ -33572,7 +33589,7 @@ final class CreateExampleStoreOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `ExampleStoreService.GetExampleStore`.
-final class GetExampleStoreRequest extends ProtoMessage {
+final class GetExampleStoreRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetExampleStoreRequest';
 
@@ -33601,7 +33618,7 @@ final class GetExampleStoreRequest extends ProtoMessage {
 
 /// Request message for
 /// `ExampleStoreService.UpdateExampleStore`.
-final class UpdateExampleStoreRequest extends ProtoMessage {
+final class UpdateExampleStoreRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateExampleStoreRequest';
 
@@ -33640,7 +33657,7 @@ final class UpdateExampleStoreRequest extends ProtoMessage {
 /// Details of
 /// `ExampleStoreService.UpdateExampleStore`
 /// operation.
-final class UpdateExampleStoreOperationMetadata extends ProtoMessage {
+final class UpdateExampleStoreOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateExampleStoreOperationMetadata';
 
@@ -33674,7 +33691,7 @@ final class UpdateExampleStoreOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `ExampleStoreService.DeleteExampleStore`.
-final class DeleteExampleStoreRequest extends ProtoMessage {
+final class DeleteExampleStoreRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteExampleStoreRequest';
 
@@ -33704,7 +33721,7 @@ final class DeleteExampleStoreRequest extends ProtoMessage {
 /// Details of
 /// `ExampleStoreService.DeleteExampleStore`
 /// operation.
-final class DeleteExampleStoreOperationMetadata extends ProtoMessage {
+final class DeleteExampleStoreOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteExampleStoreOperationMetadata';
 
@@ -33738,7 +33755,7 @@ final class DeleteExampleStoreOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `ExampleStoreService.ListExampleStores`.
-final class ListExampleStoresRequest extends ProtoMessage {
+final class ListExampleStoresRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListExampleStoresRequest';
 
@@ -33797,7 +33814,7 @@ final class ListExampleStoresRequest extends ProtoMessage {
 
 /// Response message for
 /// `ExampleStoreService.ListExampleStores`.
-final class ListExampleStoresResponse extends ProtoMessage {
+final class ListExampleStoresResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListExampleStoresResponse';
 
@@ -33841,7 +33858,7 @@ final class ListExampleStoresResponse extends ProtoMessage {
 }
 
 /// A single example to upload or read from the Example Store.
-final class Example extends ProtoMessage {
+final class Example extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Example';
 
@@ -33901,7 +33918,7 @@ final class Example extends ProtoMessage {
 
 /// Request message for
 /// `ExampleStoreService.UpsertExamples`.
-final class UpsertExamplesRequest extends ProtoMessage {
+final class UpsertExamplesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpsertExamplesRequest';
 
@@ -33954,7 +33971,7 @@ final class UpsertExamplesRequest extends ProtoMessage {
 
 /// Response message for
 /// `ExampleStoreService.UpsertExamples`.
-final class UpsertExamplesResponse extends ProtoMessage {
+final class UpsertExamplesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpsertExamplesResponse';
 
@@ -33983,7 +34000,7 @@ final class UpsertExamplesResponse extends ProtoMessage {
 }
 
 /// The result for creating/updating a single example.
-final class UpsertExamplesResponse_UpsertResult extends ProtoMessage {
+final class UpsertExamplesResponse_UpsertResult extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpsertExamplesResponse.UpsertResult';
 
@@ -34020,7 +34037,7 @@ final class UpsertExamplesResponse_UpsertResult extends ProtoMessage {
 
 /// Request message for
 /// `ExampleStoreService.RemoveExamples`.
-final class RemoveExamplesRequest extends ProtoMessage {
+final class RemoveExamplesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RemoveExamplesRequest';
 
@@ -34073,7 +34090,7 @@ final class RemoveExamplesRequest extends ProtoMessage {
 
 /// Response message for
 /// `ExampleStoreService.RemoveExamples`.
-final class RemoveExamplesResponse extends ProtoMessage {
+final class RemoveExamplesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RemoveExamplesResponse';
 
@@ -34097,7 +34114,7 @@ final class RemoveExamplesResponse extends ProtoMessage {
 
 /// Request message for
 /// `ExampleStoreService.SearchExamples`.
-final class SearchExamplesRequest extends ProtoMessage {
+final class SearchExamplesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SearchExamplesRequest';
 
@@ -34152,7 +34169,7 @@ final class SearchExamplesRequest extends ProtoMessage {
 
 /// Response message for
 /// `ExampleStoreService.SearchExamples`.
-final class SearchExamplesResponse extends ProtoMessage {
+final class SearchExamplesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SearchExamplesResponse';
 
@@ -34180,7 +34197,8 @@ final class SearchExamplesResponse extends ProtoMessage {
 }
 
 /// The result of the similar example.
-final class SearchExamplesResponse_SimilarExample extends ProtoMessage {
+final class SearchExamplesResponse_SimilarExample
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SearchExamplesResponse.SimilarExample';
 
@@ -34222,7 +34240,7 @@ final class SearchExamplesResponse_SimilarExample extends ProtoMessage {
 
 /// Request message for
 /// `ExampleStoreService.FetchExamples`.
-final class FetchExamplesRequest extends ProtoMessage {
+final class FetchExamplesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FetchExamplesRequest';
 
@@ -34295,7 +34313,7 @@ final class FetchExamplesRequest extends ProtoMessage {
 
 /// Response message for
 /// `ExampleStoreService.FetchExamples`.
-final class FetchExamplesResponse extends ProtoMessage {
+final class FetchExamplesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FetchExamplesResponse';
 
@@ -34335,7 +34353,7 @@ final class FetchExamplesResponse extends ProtoMessage {
 }
 
 /// Instance of a general execution.
-final class Execution extends ProtoMessage {
+final class Execution extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Execution';
 
@@ -34456,7 +34474,7 @@ final class Execution extends ProtoMessage {
 }
 
 /// Describes the state of the Execution.
-final class Execution_State extends ProtoEnum {
+final class Execution_State extends protobuf.ProtoEnum {
   /// Unspecified Execution state
   static const stateUnspecified = Execution_State('STATE_UNSPECIFIED');
 
@@ -34490,7 +34508,7 @@ final class Execution_State extends ProtoEnum {
 /// `PredictResponse.predictions`)
 /// produced by the Model on a given
 /// `instance`.
-final class Explanation extends ProtoMessage {
+final class Explanation extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Explanation';
 
@@ -34554,7 +34572,7 @@ final class Explanation extends ProtoMessage {
 }
 
 /// Aggregated explanation metrics for a Model over a set of instances.
-final class ModelExplanation extends ProtoMessage {
+final class ModelExplanation extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelExplanation';
 
@@ -34606,7 +34624,7 @@ final class ModelExplanation extends ProtoMessage {
 }
 
 /// Attribution that explains a particular prediction output.
-final class Attribution extends ProtoMessage {
+final class Attribution extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Attribution';
 
@@ -34774,7 +34792,7 @@ final class Attribution extends ProtoMessage {
 }
 
 /// Neighbors for example-based explanations.
-final class Neighbor extends ProtoMessage {
+final class Neighbor extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Neighbor';
 
@@ -34814,7 +34832,7 @@ final class Neighbor extends ProtoMessage {
 }
 
 /// Specification of Model explanation.
-final class ExplanationSpec extends ProtoMessage {
+final class ExplanationSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExplanationSpec';
 
@@ -34846,7 +34864,7 @@ final class ExplanationSpec extends ProtoMessage {
 }
 
 /// Parameters to configure explaining for Model's predictions.
-final class ExplanationParameters extends ProtoMessage {
+final class ExplanationParameters extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExplanationParameters';
 
@@ -34953,7 +34971,7 @@ final class ExplanationParameters extends ProtoMessage {
 /// An attribution method that approximates Shapley values for features that
 /// contribute to the label being predicted. A sampling strategy is used to
 /// approximate the value rather than considering all subsets of features.
-final class SampledShapleyAttribution extends ProtoMessage {
+final class SampledShapleyAttribution extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SampledShapleyAttribution';
 
@@ -34984,7 +35002,7 @@ final class SampledShapleyAttribution extends ProtoMessage {
 /// An attribution method that computes the Aumann-Shapley value taking advantage
 /// of the model's fully differentiable structure. Refer to this paper for
 /// more details: https://arxiv.org/abs/1703.01365
-final class IntegratedGradientsAttribution extends ProtoMessage {
+final class IntegratedGradientsAttribution extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.IntegratedGradientsAttribution';
 
@@ -35055,7 +35073,7 @@ final class IntegratedGradientsAttribution extends ProtoMessage {
 /// https://arxiv.org/abs/1906.02825
 ///
 /// Supported only by image Models.
-final class XraiAttribution extends ProtoMessage {
+final class XraiAttribution extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.XraiAttribution';
 
@@ -35126,7 +35144,7 @@ final class XraiAttribution extends ProtoMessage {
 /// noisy samples in the vicinity of the inputs. Adding noise can help improve
 /// the computed gradients. Refer to this paper for more details:
 /// https://arxiv.org/pdf/1706.03825.pdf
-final class SmoothGradConfig extends ProtoMessage {
+final class SmoothGradConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SmoothGradConfig';
 
@@ -35201,7 +35219,7 @@ final class SmoothGradConfig extends ProtoMessage {
 /// Noise sigma by features. Noise sigma represents the standard deviation of the
 /// gaussian kernel that will be used to add noise to interpolated inputs prior
 /// to computing gradients.
-final class FeatureNoiseSigma extends ProtoMessage {
+final class FeatureNoiseSigma extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureNoiseSigma';
 
@@ -35229,7 +35247,8 @@ final class FeatureNoiseSigma extends ProtoMessage {
 }
 
 /// Noise sigma for a single feature.
-final class FeatureNoiseSigma_NoiseSigmaForFeature extends ProtoMessage {
+final class FeatureNoiseSigma_NoiseSigmaForFeature
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureNoiseSigma.NoiseSigmaForFeature';
 
@@ -35282,7 +35301,7 @@ final class FeatureNoiseSigma_NoiseSigmaForFeature extends ProtoMessage {
 /// image is created. Using a blurred baseline instead of zero (black image) is
 /// motivated by the BlurIG approach explained here:
 /// https://arxiv.org/abs/2004.03383
-final class BlurBaselineConfig extends ProtoMessage {
+final class BlurBaselineConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BlurBaselineConfig';
 
@@ -35316,7 +35335,7 @@ final class BlurBaselineConfig extends ProtoMessage {
 
 /// Example-based explainability that returns the nearest neighbors from the
 /// provided dataset.
-final class Examples extends ProtoMessage {
+final class Examples extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Examples';
 
@@ -35387,7 +35406,7 @@ final class Examples extends ProtoMessage {
 }
 
 /// The Cloud Storage input instances.
-final class Examples_ExampleGcsSource extends ProtoMessage {
+final class Examples_ExampleGcsSource extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Examples.ExampleGcsSource';
 
@@ -35429,7 +35448,7 @@ final class Examples_ExampleGcsSource extends ProtoMessage {
 }
 
 /// The format of the input example instances.
-final class Examples_ExampleGcsSource_DataFormat extends ProtoEnum {
+final class Examples_ExampleGcsSource_DataFormat extends protobuf.ProtoEnum {
   /// Format unspecified, used when unset.
   static const dataFormatUnspecified = Examples_ExampleGcsSource_DataFormat(
     'DATA_FORMAT_UNSPECIFIED',
@@ -35448,7 +35467,7 @@ final class Examples_ExampleGcsSource_DataFormat extends ProtoEnum {
 }
 
 /// Preset configuration for example-based explanations
-final class Presets extends ProtoMessage {
+final class Presets extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Presets';
 
@@ -35490,7 +35509,7 @@ final class Presets extends ProtoMessage {
 }
 
 /// Preset option controlling parameters for query speed-precision trade-off
-final class Presets_Query extends ProtoEnum {
+final class Presets_Query extends protobuf.ProtoEnum {
   /// More precise neighbors as a trade-off against slower response.
   static const precise = Presets_Query('PRECISE');
 
@@ -35506,7 +35525,7 @@ final class Presets_Query extends ProtoEnum {
 }
 
 /// Preset option controlling parameters for different modalities
-final class Presets_Modality extends ProtoEnum {
+final class Presets_Modality extends protobuf.ProtoEnum {
   /// Should not be set. Added as a recommended best practice for enums
   static const modalityUnspecified = Presets_Modality('MODALITY_UNSPECIFIED');
 
@@ -35530,7 +35549,7 @@ final class Presets_Modality extends ProtoEnum {
 /// The `ExplanationSpec`
 /// entries that can be overridden at [online
 /// explanation][google.cloud.aiplatform.v1beta1.PredictionService.Explain] time.
-final class ExplanationSpecOverride extends ProtoMessage {
+final class ExplanationSpecOverride extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExplanationSpecOverride';
 
@@ -35580,7 +35599,7 @@ final class ExplanationSpecOverride extends ProtoMessage {
 /// `ExplanationMetadata`
 /// entries that can be overridden at [online
 /// explanation][google.cloud.aiplatform.v1beta1.PredictionService.Explain] time.
-final class ExplanationMetadataOverride extends ProtoMessage {
+final class ExplanationMetadataOverride extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExplanationMetadataOverride';
 
@@ -35616,7 +35635,7 @@ final class ExplanationMetadataOverride extends ProtoMessage {
 /// metadata][google.cloud.aiplatform.v1beta1.ExplanationMetadata.InputMetadata]
 /// entries to be overridden.
 final class ExplanationMetadataOverride_InputMetadataOverride
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExplanationMetadataOverride.InputMetadataOverride';
 
@@ -35654,7 +35673,7 @@ final class ExplanationMetadataOverride_InputMetadataOverride
 }
 
 /// Overrides for example-based explanations.
-final class ExamplesOverride extends ProtoMessage {
+final class ExamplesOverride extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExamplesOverride';
 
@@ -35721,7 +35740,7 @@ final class ExamplesOverride extends ProtoMessage {
 }
 
 /// Data format enum.
-final class ExamplesOverride_DataFormat extends ProtoEnum {
+final class ExamplesOverride_DataFormat extends protobuf.ProtoEnum {
   /// Unspecified format. Must not be used.
   static const dataFormatUnspecified = ExamplesOverride_DataFormat(
     'DATA_FORMAT_UNSPECIFIED',
@@ -35743,7 +35762,7 @@ final class ExamplesOverride_DataFormat extends ProtoEnum {
 }
 
 /// Restrictions namespace for example-based explanations overrides.
-final class ExamplesRestrictionsNamespace extends ProtoMessage {
+final class ExamplesRestrictionsNamespace extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExamplesRestrictionsNamespace';
 
@@ -35786,7 +35805,7 @@ final class ExamplesRestrictionsNamespace extends ProtoMessage {
 }
 
 /// Metadata describing the Model's input and output for explanation.
-final class ExplanationMetadata extends ProtoMessage {
+final class ExplanationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExplanationMetadata';
 
@@ -35882,7 +35901,7 @@ final class ExplanationMetadata extends ProtoMessage {
 /// `InputMetadata.input_baselines`
 /// are applicable only for Models that are using Vertex AI-provided images for
 /// Tensorflow.
-final class ExplanationMetadata_InputMetadata extends ProtoMessage {
+final class ExplanationMetadata_InputMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExplanationMetadata.InputMetadata';
 
@@ -36067,7 +36086,7 @@ final class ExplanationMetadata_InputMetadata extends ProtoMessage {
 /// mean and stddev of the original feature (e.g. image tensor) from which
 /// input feature (with mean = 0 and stddev = 1) was obtained.
 final class ExplanationMetadata_InputMetadata_FeatureValueDomain
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExplanationMetadata.InputMetadata.FeatureValueDomain';
 
@@ -36130,7 +36149,7 @@ final class ExplanationMetadata_InputMetadata_FeatureValueDomain
 
 /// Visualization configurations for image explanation.
 final class ExplanationMetadata_InputMetadata_Visualization
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExplanationMetadata.InputMetadata.Visualization';
 
@@ -36244,7 +36263,7 @@ final class ExplanationMetadata_InputMetadata_Visualization
 /// [Integrated Gradients
 /// attribution][google.cloud.aiplatform.v1beta1.ExplanationParameters.integrated_gradients_attribution].
 final class ExplanationMetadata_InputMetadata_Visualization_Type
-    extends ProtoEnum {
+    extends protobuf.ProtoEnum {
   /// Should not be used.
   static const typeUnspecified =
       ExplanationMetadata_InputMetadata_Visualization_Type('TYPE_UNSPECIFIED');
@@ -36273,7 +36292,7 @@ final class ExplanationMetadata_InputMetadata_Visualization_Type
 /// Whether to only highlight pixels with positive contributions, negative
 /// or both. Defaults to POSITIVE.
 final class ExplanationMetadata_InputMetadata_Visualization_Polarity
-    extends ProtoEnum {
+    extends protobuf.ProtoEnum {
   /// Default value. This is the same as POSITIVE.
   static const polarityUnspecified =
       ExplanationMetadata_InputMetadata_Visualization_Polarity(
@@ -36307,7 +36326,7 @@ final class ExplanationMetadata_InputMetadata_Visualization_Polarity
 
 /// The color scheme used for highlighting areas.
 final class ExplanationMetadata_InputMetadata_Visualization_ColorMap
-    extends ProtoEnum {
+    extends protobuf.ProtoEnum {
   /// Should not be used.
   static const colorMapUnspecified =
       ExplanationMetadata_InputMetadata_Visualization_ColorMap(
@@ -36356,7 +36375,7 @@ final class ExplanationMetadata_InputMetadata_Visualization_ColorMap
 
 /// How the original image is displayed in the visualization.
 final class ExplanationMetadata_InputMetadata_Visualization_OverlayType
-    extends ProtoEnum {
+    extends protobuf.ProtoEnum {
   /// Default value. This is the same as NONE.
   static const overlayTypeUnspecified =
       ExplanationMetadata_InputMetadata_Visualization_OverlayType(
@@ -36394,7 +36413,8 @@ final class ExplanationMetadata_InputMetadata_Visualization_OverlayType
 }
 
 /// Defines how a feature is encoded. Defaults to IDENTITY.
-final class ExplanationMetadata_InputMetadata_Encoding extends ProtoEnum {
+final class ExplanationMetadata_InputMetadata_Encoding
+    extends protobuf.ProtoEnum {
   /// Default value. This is the same as IDENTITY.
   static const encodingUnspecified = ExplanationMetadata_InputMetadata_Encoding(
     'ENCODING_UNSPECIFIED',
@@ -36481,7 +36501,7 @@ final class ExplanationMetadata_InputMetadata_Encoding extends ProtoEnum {
 }
 
 /// Metadata of the prediction output to be explained.
-final class ExplanationMetadata_OutputMetadata extends ProtoMessage {
+final class ExplanationMetadata_OutputMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExplanationMetadata.OutputMetadata';
 
@@ -36558,7 +36578,7 @@ final class ExplanationMetadata_OutputMetadata extends ProtoMessage {
 
 /// Extensions are tools for large language models to access external data, run
 /// computations, etc.
-final class Extension extends ProtoMessage {
+final class Extension extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Extension';
 
@@ -36679,7 +36699,7 @@ final class Extension extends ProtoMessage {
 }
 
 /// Manifest spec of an Extension needed for runtime execution.
-final class ExtensionManifest extends ProtoMessage {
+final class ExtensionManifest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExtensionManifest';
 
@@ -36736,7 +36756,7 @@ final class ExtensionManifest extends ProtoMessage {
 }
 
 /// The API specification shown to the LLM.
-final class ExtensionManifest_ApiSpec extends ProtoMessage {
+final class ExtensionManifest_ApiSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExtensionManifest.ApiSpec';
 
@@ -36775,7 +36795,7 @@ final class ExtensionManifest_ApiSpec extends ProtoMessage {
 }
 
 /// Operation of an extension.
-final class ExtensionOperation extends ProtoMessage {
+final class ExtensionOperation extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExtensionOperation';
 
@@ -36822,7 +36842,7 @@ final class ExtensionOperation extends ProtoMessage {
 }
 
 /// Auth configuration to run the extension.
-final class AuthConfig extends ProtoMessage {
+final class AuthConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AuthConfig';
 
@@ -36895,7 +36915,7 @@ final class AuthConfig extends ProtoMessage {
 }
 
 /// Config for authentication with API key.
-final class AuthConfig_ApiKeyConfig extends ProtoMessage {
+final class AuthConfig_ApiKeyConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AuthConfig.ApiKeyConfig';
 
@@ -36957,7 +36977,7 @@ final class AuthConfig_ApiKeyConfig extends ProtoMessage {
 }
 
 /// Config for HTTP Basic Authentication.
-final class AuthConfig_HttpBasicAuthConfig extends ProtoMessage {
+final class AuthConfig_HttpBasicAuthConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AuthConfig.HttpBasicAuthConfig';
 
@@ -36995,7 +37015,8 @@ final class AuthConfig_HttpBasicAuthConfig extends ProtoMessage {
 }
 
 /// Config for Google Service Account Authentication.
-final class AuthConfig_GoogleServiceAccountConfig extends ProtoMessage {
+final class AuthConfig_GoogleServiceAccountConfig
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AuthConfig.GoogleServiceAccountConfig';
 
@@ -37038,7 +37059,7 @@ final class AuthConfig_GoogleServiceAccountConfig extends ProtoMessage {
 }
 
 /// Config for user oauth.
-final class AuthConfig_OauthConfig extends ProtoMessage {
+final class AuthConfig_OauthConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AuthConfig.OauthConfig';
 
@@ -37086,7 +37107,7 @@ final class AuthConfig_OauthConfig extends ProtoMessage {
 }
 
 /// Config for user OIDC auth.
-final class AuthConfig_OidcConfig extends ProtoMessage {
+final class AuthConfig_OidcConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AuthConfig.OidcConfig';
 
@@ -37138,7 +37159,7 @@ final class AuthConfig_OidcConfig extends ProtoMessage {
 }
 
 /// Runtime configuration to run the extension.
-final class RuntimeConfig extends ProtoMessage {
+final class RuntimeConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RuntimeConfig';
 
@@ -37197,7 +37218,8 @@ final class RuntimeConfig extends ProtoMessage {
   String toString() => 'RuntimeConfig()';
 }
 
-final class RuntimeConfig_CodeInterpreterRuntimeConfig extends ProtoMessage {
+final class RuntimeConfig_CodeInterpreterRuntimeConfig
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RuntimeConfig.CodeInterpreterRuntimeConfig';
 
@@ -37250,7 +37272,8 @@ final class RuntimeConfig_CodeInterpreterRuntimeConfig extends ProtoMessage {
   }
 }
 
-final class RuntimeConfig_VertexAisearchRuntimeConfig extends ProtoMessage {
+final class RuntimeConfig_VertexAisearchRuntimeConfig
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RuntimeConfig.VertexAISearchRuntimeConfig';
 
@@ -37297,7 +37320,7 @@ final class RuntimeConfig_VertexAisearchRuntimeConfig extends ProtoMessage {
 }
 
 /// PrivateExtensionConfig configuration for the extension.
-final class ExtensionPrivateServiceConnectConfig extends ProtoMessage {
+final class ExtensionPrivateServiceConnectConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExtensionPrivateServiceConnectConfig';
 
@@ -37338,7 +37361,7 @@ final class ExtensionPrivateServiceConnectConfig extends ProtoMessage {
 
 /// Request message for
 /// `ExtensionExecutionService.ExecuteExtension`.
-final class ExecuteExtensionRequest extends ProtoMessage {
+final class ExecuteExtensionRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExecuteExtensionRequest';
 
@@ -37409,7 +37432,7 @@ final class ExecuteExtensionRequest extends ProtoMessage {
 
 /// Response message for
 /// `ExtensionExecutionService.ExecuteExtension`.
-final class ExecuteExtensionResponse extends ProtoMessage {
+final class ExecuteExtensionResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExecuteExtensionResponse';
 
@@ -37437,7 +37460,7 @@ final class ExecuteExtensionResponse extends ProtoMessage {
 
 /// Request message for
 /// `ExtensionExecutionService.QueryExtension`.
-final class QueryExtensionRequest extends ProtoMessage {
+final class QueryExtensionRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.QueryExtensionRequest';
 
@@ -37480,7 +37503,7 @@ final class QueryExtensionRequest extends ProtoMessage {
 
 /// Response message for
 /// `ExtensionExecutionService.QueryExtension`.
-final class QueryExtensionResponse extends ProtoMessage {
+final class QueryExtensionResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.QueryExtensionResponse';
 
@@ -37521,7 +37544,7 @@ final class QueryExtensionResponse extends ProtoMessage {
 
 /// Request message for
 /// `ExtensionRegistryService.ImportExtension`.
-final class ImportExtensionRequest extends ProtoMessage {
+final class ImportExtensionRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ImportExtensionRequest';
 
@@ -37557,7 +37580,7 @@ final class ImportExtensionRequest extends ProtoMessage {
 /// Details of
 /// `ExtensionRegistryService.ImportExtension`
 /// operation.
-final class ImportExtensionOperationMetadata extends ProtoMessage {
+final class ImportExtensionOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ImportExtensionOperationMetadata';
 
@@ -37589,7 +37612,7 @@ final class ImportExtensionOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `ExtensionRegistryService.GetExtension`.
-final class GetExtensionRequest extends ProtoMessage {
+final class GetExtensionRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetExtensionRequest';
 
@@ -37618,7 +37641,7 @@ final class GetExtensionRequest extends ProtoMessage {
 
 /// Request message for
 /// `ExtensionRegistryService.UpdateExtension`.
-final class UpdateExtensionRequest extends ProtoMessage {
+final class UpdateExtensionRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateExtensionRequest';
 
@@ -37659,7 +37682,7 @@ final class UpdateExtensionRequest extends ProtoMessage {
 
 /// Request message for
 /// `ExtensionRegistryService.ListExtensions`.
-final class ListExtensionsRequest extends ProtoMessage {
+final class ListExtensionsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListExtensionsRequest';
 
@@ -37735,7 +37758,7 @@ final class ListExtensionsRequest extends ProtoMessage {
 
 /// Response message for
 /// `ExtensionRegistryService.ListExtensions`
-final class ListExtensionsResponse extends ProtoMessage {
+final class ListExtensionsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListExtensionsResponse';
 
@@ -37777,7 +37800,7 @@ final class ListExtensionsResponse extends ProtoMessage {
 
 /// Request message for
 /// `ExtensionRegistryService.DeleteExtension`.
-final class DeleteExtensionRequest extends ProtoMessage {
+final class DeleteExtensionRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteExtensionRequest';
 
@@ -37806,7 +37829,7 @@ final class DeleteExtensionRequest extends ProtoMessage {
 
 /// Feature Metadata information.
 /// For example, color is a feature that describes an apple.
-final class Feature extends ProtoMessage {
+final class Feature extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Feature';
 
@@ -37999,7 +38022,7 @@ final class Feature extends ProtoMessage {
 /// stats requested by user, sorted by
 /// `FeatureStatsAnomaly.start_time`
 /// descending.
-final class Feature_MonitoringStatsAnomaly extends ProtoMessage {
+final class Feature_MonitoringStatsAnomaly extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Feature.MonitoringStatsAnomaly';
 
@@ -38045,7 +38068,8 @@ final class Feature_MonitoringStatsAnomaly extends ProtoMessage {
 /// Import Feature Analysis and Snapshot Analysis, this objective could be
 /// one of them. Otherwise, this objective should be the same as the
 /// objective in the request.
-final class Feature_MonitoringStatsAnomaly_Objective extends ProtoEnum {
+final class Feature_MonitoringStatsAnomaly_Objective
+    extends protobuf.ProtoEnum {
   /// If it's OBJECTIVE_UNSPECIFIED, monitoring_stats will be empty.
   static const objectiveUnspecified = Feature_MonitoringStatsAnomaly_Objective(
     'OBJECTIVE_UNSPECIFIED',
@@ -38072,7 +38096,7 @@ final class Feature_MonitoringStatsAnomaly_Objective extends ProtoEnum {
 
 /// Only applicable for Vertex AI Legacy Feature Store.
 /// An enum representing the value type of a feature.
-final class Feature_ValueType extends ProtoEnum {
+final class Feature_ValueType extends protobuf.ProtoEnum {
   /// The value type is unspecified.
   static const valueTypeUnspecified = Feature_ValueType(
     'VALUE_TYPE_UNSPECIFIED',
@@ -38117,7 +38141,7 @@ final class Feature_ValueType extends ProtoEnum {
 }
 
 /// Vertex AI Feature Group.
-final class FeatureGroup extends ProtoMessage {
+final class FeatureGroup extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureGroup';
 
@@ -38232,7 +38256,7 @@ final class FeatureGroup extends ProtoMessage {
 }
 
 /// Input source type for BigQuery Tables and Views.
-final class FeatureGroup_BigQuery extends ProtoMessage {
+final class FeatureGroup_BigQuery extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureGroup.BigQuery';
 
@@ -38309,7 +38333,7 @@ final class FeatureGroup_BigQuery extends ProtoMessage {
   }
 }
 
-final class FeatureGroup_BigQuery_TimeSeries extends ProtoMessage {
+final class FeatureGroup_BigQuery_TimeSeries extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureGroup.BigQuery.TimeSeries';
 
@@ -38343,7 +38367,7 @@ final class FeatureGroup_BigQuery_TimeSeries extends ProtoMessage {
 }
 
 /// Service agent type used during jobs under a FeatureGroup.
-final class FeatureGroup_ServiceAgentType extends ProtoEnum {
+final class FeatureGroup_ServiceAgentType extends protobuf.ProtoEnum {
   /// By default, the project-level Vertex AI Service Agent is enabled.
   static const serviceAgentTypeUnspecified = FeatureGroup_ServiceAgentType(
     'SERVICE_AGENT_TYPE_UNSPECIFIED',
@@ -38373,7 +38397,7 @@ final class FeatureGroup_ServiceAgentType extends ProtoEnum {
 }
 
 /// Vertex AI Feature Monitor.
-final class FeatureMonitor extends ProtoMessage {
+final class FeatureMonitor extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureMonitor';
 
@@ -38467,7 +38491,7 @@ final class FeatureMonitor extends ProtoMessage {
 }
 
 /// Schedule configuration for the FeatureMonitor.
-final class ScheduleConfig extends ProtoMessage {
+final class ScheduleConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ScheduleConfig';
 
@@ -38498,7 +38522,7 @@ final class ScheduleConfig extends ProtoMessage {
 }
 
 /// Feature selection configuration for the FeatureMonitor.
-final class FeatureSelectionConfig extends ProtoMessage {
+final class FeatureSelectionConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureSelectionConfig';
 
@@ -38529,7 +38553,7 @@ final class FeatureSelectionConfig extends ProtoMessage {
 }
 
 /// Feature configuration.
-final class FeatureSelectionConfig_FeatureConfig extends ProtoMessage {
+final class FeatureSelectionConfig_FeatureConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureSelectionConfig.FeatureConfig';
 
@@ -38575,7 +38599,7 @@ final class FeatureSelectionConfig_FeatureConfig extends ProtoMessage {
 
 /// Stats and Anomaly generated by FeatureMonitorJobs. Anomaly only includes
 /// Drift.
-final class FeatureStatsAndAnomaly extends ProtoMessage {
+final class FeatureStatsAndAnomaly extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureStatsAndAnomaly';
 
@@ -38672,7 +38696,7 @@ final class FeatureStatsAndAnomaly extends ProtoMessage {
 /// Defines how to select FeatureStatsAndAnomaly to be populated in response.
 /// If set, retrieves FeatureStatsAndAnomaly generated by FeatureMonitors based
 /// on this spec.
-final class FeatureStatsAndAnomalySpec extends ProtoMessage {
+final class FeatureStatsAndAnomalySpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureStatsAndAnomalySpec';
 
@@ -38714,7 +38738,7 @@ final class FeatureStatsAndAnomalySpec extends ProtoMessage {
 }
 
 /// Vertex AI Feature Monitor Job.
-final class FeatureMonitorJob extends ProtoMessage {
+final class FeatureMonitorJob extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureMonitorJob';
 
@@ -38839,7 +38863,7 @@ final class FeatureMonitorJob extends ProtoMessage {
 }
 
 /// Summary from the FeatureMonitorJob.
-final class FeatureMonitorJob_JobSummary extends ProtoMessage {
+final class FeatureMonitorJob_JobSummary extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureMonitorJob.JobSummary';
 
@@ -38883,7 +38907,8 @@ final class FeatureMonitorJob_JobSummary extends ProtoMessage {
 }
 
 /// Choices of the trigger type.
-final class FeatureMonitorJob_FeatureMonitorJobTrigger extends ProtoEnum {
+final class FeatureMonitorJob_FeatureMonitorJobTrigger
+    extends protobuf.ProtoEnum {
   /// Trigger type unspecified.
   static const featureMonitorJobTriggerUnspecified =
       FeatureMonitorJob_FeatureMonitorJobTrigger(
@@ -38920,7 +38945,7 @@ final class FeatureMonitorJob_FeatureMonitorJobTrigger extends ProtoEnum {
 /// anomaly_uri in the tensorflow defined protos. Field data_stats contains
 /// almost identical information with the raw stats in Vertex AI
 /// defined proto, for UI to display.
-final class FeatureStatsAnomaly extends ProtoMessage {
+final class FeatureStatsAnomaly extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureStatsAnomaly';
 
@@ -39030,7 +39055,7 @@ final class FeatureStatsAnomaly extends ProtoMessage {
 /// Vertex AI Feature Online Store provides a centralized repository for serving
 /// ML features and embedding indexes at low latency. The Feature Online Store is
 /// a top-level container.
-final class FeatureOnlineStore extends ProtoMessage {
+final class FeatureOnlineStore extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureOnlineStore';
 
@@ -39171,7 +39196,7 @@ final class FeatureOnlineStore extends ProtoMessage {
   }
 }
 
-final class FeatureOnlineStore_Bigtable extends ProtoMessage {
+final class FeatureOnlineStore_Bigtable extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureOnlineStore.Bigtable';
 
@@ -39225,7 +39250,8 @@ final class FeatureOnlineStore_Bigtable extends ProtoMessage {
   }
 }
 
-final class FeatureOnlineStore_Bigtable_AutoScaling extends ProtoMessage {
+final class FeatureOnlineStore_Bigtable_AutoScaling
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureOnlineStore.Bigtable.AutoScaling';
 
@@ -39285,7 +39311,8 @@ final class FeatureOnlineStore_Bigtable_AutoScaling extends ProtoMessage {
 
 /// Metadata of the Bigtable instance. This is used by direct read access to
 /// the Bigtable in tenant project.
-final class FeatureOnlineStore_Bigtable_BigtableMetadata extends ProtoMessage {
+final class FeatureOnlineStore_Bigtable_BigtableMetadata
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureOnlineStore.Bigtable.BigtableMetadata';
 
@@ -39335,7 +39362,7 @@ final class FeatureOnlineStore_Bigtable_BigtableMetadata extends ProtoMessage {
 }
 
 /// Optimized storage type
-final class FeatureOnlineStore_Optimized extends ProtoMessage {
+final class FeatureOnlineStore_Optimized extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureOnlineStore.Optimized';
 
@@ -39357,7 +39384,8 @@ final class FeatureOnlineStore_Optimized extends ProtoMessage {
 /// The dedicated serving endpoint for this FeatureOnlineStore. Only need to
 /// set when you choose Optimized storage type. Public endpoint is provisioned
 /// by default.
-final class FeatureOnlineStore_DedicatedServingEndpoint extends ProtoMessage {
+final class FeatureOnlineStore_DedicatedServingEndpoint
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureOnlineStore.DedicatedServingEndpoint';
 
@@ -39421,7 +39449,8 @@ final class FeatureOnlineStore_DedicatedServingEndpoint extends ProtoMessage {
 /// Deprecated: This sub message is no longer needed anymore and embedding
 /// management is automatically enabled when specifying Optimized storage type.
 /// Contains settings for embedding management.
-final class FeatureOnlineStore_EmbeddingManagement extends ProtoMessage {
+final class FeatureOnlineStore_EmbeddingManagement
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureOnlineStore.EmbeddingManagement';
 
@@ -39452,7 +39481,7 @@ final class FeatureOnlineStore_EmbeddingManagement extends ProtoMessage {
 }
 
 /// Possible states a featureOnlineStore can have.
-final class FeatureOnlineStore_State extends ProtoEnum {
+final class FeatureOnlineStore_State extends protobuf.ProtoEnum {
   /// Default value. This value is unused.
   static const stateUnspecified = FeatureOnlineStore_State('STATE_UNSPECIFIED');
 
@@ -39478,7 +39507,7 @@ final class FeatureOnlineStore_State extends ProtoEnum {
 
 /// Request message for
 /// `FeatureOnlineStoreAdminService.CreateFeatureOnlineStore`.
-final class CreateFeatureOnlineStoreRequest extends ProtoMessage {
+final class CreateFeatureOnlineStoreRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateFeatureOnlineStoreRequest';
 
@@ -39539,7 +39568,7 @@ final class CreateFeatureOnlineStoreRequest extends ProtoMessage {
 
 /// Request message for
 /// `FeatureOnlineStoreAdminService.GetFeatureOnlineStore`.
-final class GetFeatureOnlineStoreRequest extends ProtoMessage {
+final class GetFeatureOnlineStoreRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetFeatureOnlineStoreRequest';
 
@@ -39567,7 +39596,7 @@ final class GetFeatureOnlineStoreRequest extends ProtoMessage {
 
 /// Request message for
 /// `FeatureOnlineStoreAdminService.ListFeatureOnlineStores`.
-final class ListFeatureOnlineStoresRequest extends ProtoMessage {
+final class ListFeatureOnlineStoresRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListFeatureOnlineStoresRequest';
 
@@ -39662,7 +39691,7 @@ final class ListFeatureOnlineStoresRequest extends ProtoMessage {
 
 /// Response message for
 /// `FeatureOnlineStoreAdminService.ListFeatureOnlineStores`.
-final class ListFeatureOnlineStoresResponse extends ProtoMessage {
+final class ListFeatureOnlineStoresResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListFeatureOnlineStoresResponse';
 
@@ -39710,7 +39739,7 @@ final class ListFeatureOnlineStoresResponse extends ProtoMessage {
 
 /// Request message for
 /// `FeatureOnlineStoreAdminService.UpdateFeatureOnlineStore`.
-final class UpdateFeatureOnlineStoreRequest extends ProtoMessage {
+final class UpdateFeatureOnlineStoreRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateFeatureOnlineStoreRequest';
 
@@ -39765,7 +39794,7 @@ final class UpdateFeatureOnlineStoreRequest extends ProtoMessage {
 
 /// Request message for
 /// `FeatureOnlineStoreAdminService.DeleteFeatureOnlineStore`.
-final class DeleteFeatureOnlineStoreRequest extends ProtoMessage {
+final class DeleteFeatureOnlineStoreRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteFeatureOnlineStoreRequest';
 
@@ -39806,7 +39835,7 @@ final class DeleteFeatureOnlineStoreRequest extends ProtoMessage {
 
 /// Request message for
 /// `FeatureOnlineStoreAdminService.CreateFeatureView`.
-final class CreateFeatureViewRequest extends ProtoMessage {
+final class CreateFeatureViewRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateFeatureViewRequest';
 
@@ -39872,7 +39901,7 @@ final class CreateFeatureViewRequest extends ProtoMessage {
 
 /// Request message for
 /// `FeatureOnlineStoreAdminService.GetFeatureView`.
-final class GetFeatureViewRequest extends ProtoMessage {
+final class GetFeatureViewRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetFeatureViewRequest';
 
@@ -39901,7 +39930,7 @@ final class GetFeatureViewRequest extends ProtoMessage {
 
 /// Request message for
 /// `FeatureOnlineStoreAdminService.ListFeatureViews`.
-final class ListFeatureViewsRequest extends ProtoMessage {
+final class ListFeatureViewsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListFeatureViewsRequest';
 
@@ -39999,7 +40028,7 @@ final class ListFeatureViewsRequest extends ProtoMessage {
 
 /// Response message for
 /// `FeatureOnlineStoreAdminService.ListFeatureViews`.
-final class ListFeatureViewsResponse extends ProtoMessage {
+final class ListFeatureViewsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListFeatureViewsResponse';
 
@@ -40044,7 +40073,7 @@ final class ListFeatureViewsResponse extends ProtoMessage {
 
 /// Request message for
 /// `FeatureOnlineStoreAdminService.UpdateFeatureView`.
-final class UpdateFeatureViewRequest extends ProtoMessage {
+final class UpdateFeatureViewRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateFeatureViewRequest';
 
@@ -40097,7 +40126,7 @@ final class UpdateFeatureViewRequest extends ProtoMessage {
 }
 
 /// Request message for `FeatureOnlineStoreAdminService.DeleteFeatureViews`.
-final class DeleteFeatureViewRequest extends ProtoMessage {
+final class DeleteFeatureViewRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteFeatureViewRequest';
 
@@ -40125,7 +40154,8 @@ final class DeleteFeatureViewRequest extends ProtoMessage {
 }
 
 /// Details of operations that perform create FeatureOnlineStore.
-final class CreateFeatureOnlineStoreOperationMetadata extends ProtoMessage {
+final class CreateFeatureOnlineStoreOperationMetadata
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateFeatureOnlineStoreOperationMetadata';
 
@@ -40158,7 +40188,8 @@ final class CreateFeatureOnlineStoreOperationMetadata extends ProtoMessage {
 }
 
 /// Details of operations that perform update FeatureOnlineStore.
-final class UpdateFeatureOnlineStoreOperationMetadata extends ProtoMessage {
+final class UpdateFeatureOnlineStoreOperationMetadata
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateFeatureOnlineStoreOperationMetadata';
 
@@ -40191,7 +40222,7 @@ final class UpdateFeatureOnlineStoreOperationMetadata extends ProtoMessage {
 }
 
 /// Details of operations that perform create FeatureView.
-final class CreateFeatureViewOperationMetadata extends ProtoMessage {
+final class CreateFeatureViewOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateFeatureViewOperationMetadata';
 
@@ -40224,7 +40255,7 @@ final class CreateFeatureViewOperationMetadata extends ProtoMessage {
 }
 
 /// Details of operations that perform update FeatureView.
-final class UpdateFeatureViewOperationMetadata extends ProtoMessage {
+final class UpdateFeatureViewOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateFeatureViewOperationMetadata';
 
@@ -40258,7 +40289,7 @@ final class UpdateFeatureViewOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `FeatureOnlineStoreAdminService.SyncFeatureView`.
-final class SyncFeatureViewRequest extends ProtoMessage {
+final class SyncFeatureViewRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SyncFeatureViewRequest';
 
@@ -40287,7 +40318,7 @@ final class SyncFeatureViewRequest extends ProtoMessage {
 
 /// Response message for
 /// `FeatureOnlineStoreAdminService.SyncFeatureView`.
-final class SyncFeatureViewResponse extends ProtoMessage {
+final class SyncFeatureViewResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SyncFeatureViewResponse';
 
@@ -40317,7 +40348,7 @@ final class SyncFeatureViewResponse extends ProtoMessage {
 
 /// Request message for
 /// `FeatureOnlineStoreAdminService.GetFeatureViewSync`.
-final class GetFeatureViewSyncRequest extends ProtoMessage {
+final class GetFeatureViewSyncRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetFeatureViewSyncRequest';
 
@@ -40346,7 +40377,7 @@ final class GetFeatureViewSyncRequest extends ProtoMessage {
 
 /// Request message for
 /// `FeatureOnlineStoreAdminService.ListFeatureViewSyncs`.
-final class ListFeatureViewSyncsRequest extends ProtoMessage {
+final class ListFeatureViewSyncsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListFeatureViewSyncsRequest';
 
@@ -40434,7 +40465,7 @@ final class ListFeatureViewSyncsRequest extends ProtoMessage {
 
 /// Response message for
 /// `FeatureOnlineStoreAdminService.ListFeatureViewSyncs`.
-final class ListFeatureViewSyncsResponse extends ProtoMessage {
+final class ListFeatureViewSyncsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListFeatureViewSyncsResponse';
 
@@ -40479,7 +40510,7 @@ final class ListFeatureViewSyncsResponse extends ProtoMessage {
 }
 
 /// Lookup key for a feature view.
-final class FeatureViewDataKey extends ProtoMessage {
+final class FeatureViewDataKey extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureViewDataKey';
 
@@ -40518,7 +40549,7 @@ final class FeatureViewDataKey extends ProtoMessage {
 }
 
 /// ID that is comprised from several parts (columns).
-final class FeatureViewDataKey_CompositeKey extends ProtoMessage {
+final class FeatureViewDataKey_CompositeKey extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureViewDataKey.CompositeKey';
 
@@ -40544,7 +40575,7 @@ final class FeatureViewDataKey_CompositeKey extends ProtoMessage {
 /// Request message for
 /// `FeatureOnlineStoreService.FetchFeatureValues`.
 /// All the features under the requested feature view will be returned.
-final class FetchFeatureValuesRequest extends ProtoMessage {
+final class FetchFeatureValuesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FetchFeatureValuesRequest';
 
@@ -40617,7 +40648,7 @@ final class FetchFeatureValuesRequest extends ProtoMessage {
 }
 
 /// Format of the response data.
-final class FetchFeatureValuesRequest_Format extends ProtoEnum {
+final class FetchFeatureValuesRequest_Format extends protobuf.ProtoEnum {
   /// Not set. Will be treated as the KeyValue format.
   static const formatUnspecified = FetchFeatureValuesRequest_Format(
     'FORMAT_UNSPECIFIED',
@@ -40640,7 +40671,7 @@ final class FetchFeatureValuesRequest_Format extends ProtoEnum {
 
 /// Response message for
 /// `FeatureOnlineStoreService.FetchFeatureValues`
-final class FetchFeatureValuesResponse extends ProtoMessage {
+final class FetchFeatureValuesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FetchFeatureValuesResponse';
 
@@ -40686,7 +40717,7 @@ final class FetchFeatureValuesResponse extends ProtoMessage {
 /// Response structure in the format of key (feature name) and (feature) value
 /// pair.
 final class FetchFeatureValuesResponse_FeatureNameValuePairList
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FetchFeatureValuesResponse.FeatureNameValuePairList';
 
@@ -40722,7 +40753,7 @@ final class FetchFeatureValuesResponse_FeatureNameValuePairList
 
 /// Feature name & value pair.
 final class FetchFeatureValuesResponse_FeatureNameValuePairList_FeatureNameValuePair
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FetchFeatureValuesResponse.FeatureNameValuePairList.FeatureNameValuePair';
 
@@ -40765,7 +40796,7 @@ final class FetchFeatureValuesResponse_FeatureNameValuePairList_FeatureNameValue
 /// `FeatureOnlineStoreService.StreamingFetchFeatureValues`.
 /// For the entities requested, all features under the requested feature view
 /// will be returned.
-final class StreamingFetchFeatureValuesRequest extends ProtoMessage {
+final class StreamingFetchFeatureValuesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StreamingFetchFeatureValuesRequest';
 
@@ -40821,7 +40852,7 @@ final class StreamingFetchFeatureValuesRequest extends ProtoMessage {
 
 /// Response message for
 /// `FeatureOnlineStoreService.StreamingFetchFeatureValues`.
-final class StreamingFetchFeatureValuesResponse extends ProtoMessage {
+final class StreamingFetchFeatureValuesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StreamingFetchFeatureValuesResponse';
 
@@ -40876,7 +40907,7 @@ final class StreamingFetchFeatureValuesResponse extends ProtoMessage {
 }
 
 /// A query to find a number of similar entities.
-final class NearestNeighborQuery extends ProtoMessage {
+final class NearestNeighborQuery extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.NearestNeighborQuery';
 
@@ -40969,7 +41000,7 @@ final class NearestNeighborQuery extends ProtoMessage {
 }
 
 /// The embedding vector.
-final class NearestNeighborQuery_Embedding extends ProtoMessage {
+final class NearestNeighborQuery_Embedding extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.NearestNeighborQuery.Embedding';
 
@@ -40999,7 +41030,7 @@ final class NearestNeighborQuery_Embedding extends ProtoMessage {
 /// points are also purple, then they will be excluded even if they are
 /// red/blue. Only string filter is supported for now, numeric filter will be
 /// supported in the near future.
-final class NearestNeighborQuery_StringFilter extends ProtoMessage {
+final class NearestNeighborQuery_StringFilter extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.NearestNeighborQuery.StringFilter';
 
@@ -41052,7 +41083,7 @@ final class NearestNeighborQuery_StringFilter extends ProtoMessage {
 /// Database Point 2: {name: “a” value_int: -1} {name: “b” value_float: 3.0}
 /// Query: {name: “a” value_int: 12 operator: LESS}    // Matches Point 1, 2
 /// {name: “b” value_float: 2.0 operator: EQUAL} // Matches Point 1
-final class NearestNeighborQuery_NumericFilter extends ProtoMessage {
+final class NearestNeighborQuery_NumericFilter extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.NearestNeighborQuery.NumericFilter';
 
@@ -41121,7 +41152,8 @@ final class NearestNeighborQuery_NumericFilter extends ProtoMessage {
 
 /// Datapoints for which Operator is true relative to the query’s Value
 /// field will be allowlisted.
-final class NearestNeighborQuery_NumericFilter_Operator extends ProtoEnum {
+final class NearestNeighborQuery_NumericFilter_Operator
+    extends protobuf.ProtoEnum {
   /// Unspecified operator.
   static const operatorUnspecified =
       NearestNeighborQuery_NumericFilter_Operator('OPERATOR_UNSPECIFIED');
@@ -41161,7 +41193,7 @@ final class NearestNeighborQuery_NumericFilter_Operator extends ProtoEnum {
 
 /// Parameters that can be overrided in each query to tune query latency and
 /// recall.
-final class NearestNeighborQuery_Parameters extends ProtoMessage {
+final class NearestNeighborQuery_Parameters extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.NearestNeighborQuery.Parameters';
 
@@ -41212,7 +41244,7 @@ final class NearestNeighborQuery_Parameters extends ProtoMessage {
 
 /// The request message for
 /// `FeatureOnlineStoreService.SearchNearestEntities`.
-final class SearchNearestEntitiesRequest extends ProtoMessage {
+final class SearchNearestEntitiesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SearchNearestEntitiesRequest';
 
@@ -41263,7 +41295,7 @@ final class SearchNearestEntitiesRequest extends ProtoMessage {
 }
 
 /// Nearest neighbors for one query.
-final class NearestNeighbors extends ProtoMessage {
+final class NearestNeighbors extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.NearestNeighbors';
 
@@ -41291,7 +41323,7 @@ final class NearestNeighbors extends ProtoMessage {
 }
 
 /// A neighbor of the query vector.
-final class NearestNeighbors_Neighbor extends ProtoMessage {
+final class NearestNeighbors_Neighbor extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.NearestNeighbors.Neighbor';
 
@@ -41345,7 +41377,7 @@ final class NearestNeighbors_Neighbor extends ProtoMessage {
 
 /// Response message for
 /// `FeatureOnlineStoreService.SearchNearestEntities`
-final class SearchNearestEntitiesResponse extends ProtoMessage {
+final class SearchNearestEntitiesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SearchNearestEntitiesResponse';
 
@@ -41378,7 +41410,7 @@ final class SearchNearestEntitiesResponse extends ProtoMessage {
 
 /// Request message for
 /// `FeatureOnlineStoreService.FeatureViewDirectWrite`.
-final class FeatureViewDirectWriteRequest extends ProtoMessage {
+final class FeatureViewDirectWriteRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureViewDirectWriteRequest';
 
@@ -41425,7 +41457,7 @@ final class FeatureViewDirectWriteRequest extends ProtoMessage {
 
 /// A data key and associated feature values to write to the feature view.
 final class FeatureViewDirectWriteRequest_DataKeyAndFeatureValues
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureViewDirectWriteRequest.DataKeyAndFeatureValues';
 
@@ -41467,7 +41499,7 @@ final class FeatureViewDirectWriteRequest_DataKeyAndFeatureValues
 
 /// Feature name & value pair.
 final class FeatureViewDirectWriteRequest_DataKeyAndFeatureValues_Feature
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureViewDirectWriteRequest.DataKeyAndFeatureValues.Feature';
 
@@ -41521,7 +41553,7 @@ final class FeatureViewDirectWriteRequest_DataKeyAndFeatureValues_Feature
 
 /// Feature value and timestamp.
 final class FeatureViewDirectWriteRequest_DataKeyAndFeatureValues_Feature_FeatureValueAndTimestamp
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureViewDirectWriteRequest.DataKeyAndFeatureValues.Feature.FeatureValueAndTimestamp';
 
@@ -41561,7 +41593,7 @@ final class FeatureViewDirectWriteRequest_DataKeyAndFeatureValues_Feature_Featur
 
 /// Response message for
 /// `FeatureOnlineStoreService.FeatureViewDirectWrite`.
-final class FeatureViewDirectWriteResponse extends ProtoMessage {
+final class FeatureViewDirectWriteResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureViewDirectWriteResponse';
 
@@ -41611,7 +41643,8 @@ final class FeatureViewDirectWriteResponse extends ProtoMessage {
 }
 
 /// Details about the write for each key.
-final class FeatureViewDirectWriteResponse_WriteResponse extends ProtoMessage {
+final class FeatureViewDirectWriteResponse_WriteResponse
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureViewDirectWriteResponse.WriteResponse';
 
@@ -41655,7 +41688,7 @@ final class FeatureViewDirectWriteResponse_WriteResponse extends ProtoMessage {
 }
 
 /// Request message for `FeatureOnlineStoreService.GenerateFetchAccessToken`.
-final class GenerateFetchAccessTokenRequest extends ProtoMessage {
+final class GenerateFetchAccessTokenRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GenerateFetchAccessTokenRequest';
 
@@ -41683,7 +41716,7 @@ final class GenerateFetchAccessTokenRequest extends ProtoMessage {
 }
 
 /// Response message for `FeatureOnlineStoreService.GenerateFetchAccessToken`.
-final class GenerateFetchAccessTokenResponse extends ProtoMessage {
+final class GenerateFetchAccessTokenResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GenerateFetchAccessTokenResponse';
 
@@ -41722,7 +41755,7 @@ final class GenerateFetchAccessTokenResponse extends ProtoMessage {
 
 /// Request message for
 /// `FeatureRegistryService.CreateFeatureGroup`.
-final class CreateFeatureGroupRequest extends ProtoMessage {
+final class CreateFeatureGroupRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateFeatureGroupRequest';
 
@@ -41778,7 +41811,7 @@ final class CreateFeatureGroupRequest extends ProtoMessage {
 
 /// Request message for
 /// `FeatureRegistryService.GetFeatureGroup`.
-final class GetFeatureGroupRequest extends ProtoMessage {
+final class GetFeatureGroupRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetFeatureGroupRequest';
 
@@ -41805,7 +41838,7 @@ final class GetFeatureGroupRequest extends ProtoMessage {
 
 /// Request message for
 /// `FeatureRegistryService.ListFeatureGroups`.
-final class ListFeatureGroupsRequest extends ProtoMessage {
+final class ListFeatureGroupsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListFeatureGroupsRequest';
 
@@ -41900,7 +41933,7 @@ final class ListFeatureGroupsRequest extends ProtoMessage {
 
 /// Response message for
 /// `FeatureRegistryService.ListFeatureGroups`.
-final class ListFeatureGroupsResponse extends ProtoMessage {
+final class ListFeatureGroupsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListFeatureGroupsResponse';
 
@@ -41945,7 +41978,7 @@ final class ListFeatureGroupsResponse extends ProtoMessage {
 
 /// Request message for
 /// `FeatureRegistryService.UpdateFeatureGroup`.
-final class UpdateFeatureGroupRequest extends ProtoMessage {
+final class UpdateFeatureGroupRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateFeatureGroupRequest';
 
@@ -41994,7 +42027,7 @@ final class UpdateFeatureGroupRequest extends ProtoMessage {
 
 /// Request message for
 /// `FeatureRegistryService.DeleteFeatureGroup`.
-final class DeleteFeatureGroupRequest extends ProtoMessage {
+final class DeleteFeatureGroupRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteFeatureGroupRequest';
 
@@ -42032,7 +42065,7 @@ final class DeleteFeatureGroupRequest extends ProtoMessage {
 
 /// Request message for
 /// `FeatureRegistryService.CreateFeatureMonitorRequest`.
-final class CreateFeatureMonitorRequest extends ProtoMessage {
+final class CreateFeatureMonitorRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateFeatureMonitorRequest';
 
@@ -42088,7 +42121,7 @@ final class CreateFeatureMonitorRequest extends ProtoMessage {
 
 /// Request message for
 /// `FeatureRegistryService.GetFeatureMonitor`.
-final class GetFeatureMonitorRequest extends ProtoMessage {
+final class GetFeatureMonitorRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetFeatureMonitorRequest';
 
@@ -42115,7 +42148,7 @@ final class GetFeatureMonitorRequest extends ProtoMessage {
 
 /// Request message for
 /// `FeatureRegistryService.ListFeatureMonitors`.
-final class ListFeatureMonitorsRequest extends ProtoMessage {
+final class ListFeatureMonitorsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListFeatureMonitorsRequest';
 
@@ -42209,7 +42242,7 @@ final class ListFeatureMonitorsRequest extends ProtoMessage {
 
 /// Request message for
 /// `FeatureRegistryService.UpdateFeatureMonitor`.
-final class UpdateFeatureMonitorRequest extends ProtoMessage {
+final class UpdateFeatureMonitorRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateFeatureMonitorRequest';
 
@@ -42255,7 +42288,7 @@ final class UpdateFeatureMonitorRequest extends ProtoMessage {
 
 /// Request message for
 /// `FeatureRegistryService.DeleteFeatureMonitor`.
-final class DeleteFeatureMonitorRequest extends ProtoMessage {
+final class DeleteFeatureMonitorRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteFeatureMonitorRequest';
 
@@ -42284,7 +42317,7 @@ final class DeleteFeatureMonitorRequest extends ProtoMessage {
 
 /// Response message for
 /// `FeatureRegistryService.ListFeatureMonitors`.
-final class ListFeatureMonitorsResponse extends ProtoMessage {
+final class ListFeatureMonitorsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListFeatureMonitorsResponse';
 
@@ -42329,7 +42362,7 @@ final class ListFeatureMonitorsResponse extends ProtoMessage {
 }
 
 /// Details of operations that perform create FeatureGroup.
-final class CreateFeatureGroupOperationMetadata extends ProtoMessage {
+final class CreateFeatureGroupOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateFeatureGroupOperationMetadata';
 
@@ -42362,7 +42395,7 @@ final class CreateFeatureGroupOperationMetadata extends ProtoMessage {
 }
 
 /// Details of operations that perform update FeatureGroup.
-final class UpdateFeatureGroupOperationMetadata extends ProtoMessage {
+final class UpdateFeatureGroupOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateFeatureGroupOperationMetadata';
 
@@ -42395,7 +42428,8 @@ final class UpdateFeatureGroupOperationMetadata extends ProtoMessage {
 }
 
 /// Details of operations that perform create FeatureGroup.
-final class CreateRegistryFeatureOperationMetadata extends ProtoMessage {
+final class CreateRegistryFeatureOperationMetadata
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateRegistryFeatureOperationMetadata';
 
@@ -42428,7 +42462,7 @@ final class CreateRegistryFeatureOperationMetadata extends ProtoMessage {
 }
 
 /// Details of operations that perform update Feature.
-final class UpdateFeatureOperationMetadata extends ProtoMessage {
+final class UpdateFeatureOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateFeatureOperationMetadata';
 
@@ -42459,7 +42493,8 @@ final class UpdateFeatureOperationMetadata extends ProtoMessage {
 }
 
 /// Details of operations that perform create FeatureMonitor.
-final class CreateFeatureMonitorOperationMetadata extends ProtoMessage {
+final class CreateFeatureMonitorOperationMetadata
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateFeatureMonitorOperationMetadata';
 
@@ -42492,7 +42527,8 @@ final class CreateFeatureMonitorOperationMetadata extends ProtoMessage {
 }
 
 /// Details of operations that perform update FeatureMonitor.
-final class UpdateFeatureMonitorOperationMetadata extends ProtoMessage {
+final class UpdateFeatureMonitorOperationMetadata
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateFeatureMonitorOperationMetadata';
 
@@ -42526,7 +42562,7 @@ final class UpdateFeatureMonitorOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `FeatureRegistryService.CreateFeatureMonitorJobRequest`.
-final class CreateFeatureMonitorJobRequest extends ProtoMessage {
+final class CreateFeatureMonitorJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateFeatureMonitorJobRequest';
 
@@ -42581,7 +42617,7 @@ final class CreateFeatureMonitorJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `FeatureRegistryService.GetFeatureMonitorJob`.
-final class GetFeatureMonitorJobRequest extends ProtoMessage {
+final class GetFeatureMonitorJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetFeatureMonitorJobRequest';
 
@@ -42610,7 +42646,7 @@ final class GetFeatureMonitorJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `FeatureRegistryService.ListFeatureMonitorJobs`.
-final class ListFeatureMonitorJobsRequest extends ProtoMessage {
+final class ListFeatureMonitorJobsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListFeatureMonitorJobsRequest';
 
@@ -42696,7 +42732,7 @@ final class ListFeatureMonitorJobsRequest extends ProtoMessage {
 
 /// Response message for
 /// `FeatureRegistryService.ListFeatureMonitorJobs`.
-final class ListFeatureMonitorJobsResponse extends ProtoMessage {
+final class ListFeatureMonitorJobsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListFeatureMonitorJobsResponse';
 
@@ -42741,7 +42777,7 @@ final class ListFeatureMonitorJobsResponse extends ProtoMessage {
 }
 
 /// Matcher for Features of an EntityType by Feature ID.
-final class IdMatcher extends ProtoMessage {
+final class IdMatcher extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.IdMatcher';
 
@@ -42769,7 +42805,7 @@ final class IdMatcher extends ProtoMessage {
 }
 
 /// Selector for Features of an EntityType.
-final class FeatureSelector extends ProtoMessage {
+final class FeatureSelector extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureSelector';
 
@@ -42795,7 +42831,7 @@ final class FeatureSelector extends ProtoMessage {
 
 /// FeatureView is representation of values that the FeatureOnlineStore will
 /// serve based on its syncConfig.
-final class FeatureView extends ProtoMessage {
+final class FeatureView extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureView';
 
@@ -42988,7 +43024,7 @@ final class FeatureView extends ProtoMessage {
   }
 }
 
-final class FeatureView_BigQuerySource extends ProtoMessage {
+final class FeatureView_BigQuerySource extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureView.BigQuerySource';
 
@@ -43025,7 +43061,7 @@ final class FeatureView_BigQuerySource extends ProtoMessage {
 }
 
 /// Configuration for Sync. Only one option is set.
-final class FeatureView_SyncConfig extends ProtoMessage {
+final class FeatureView_SyncConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureView.SyncConfig';
 
@@ -43058,7 +43094,7 @@ final class FeatureView_SyncConfig extends ProtoMessage {
 /// Deprecated. Use
 /// `IndexConfig`
 /// instead.
-final class FeatureView_VectorSearchConfig extends ProtoMessage {
+final class FeatureView_VectorSearchConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureView.VectorSearchConfig';
 
@@ -43159,7 +43195,7 @@ final class FeatureView_VectorSearchConfig extends ProtoMessage {
 }
 
 final class FeatureView_VectorSearchConfig_BruteForceConfig
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureView.VectorSearchConfig.BruteForceConfig';
 
@@ -43180,7 +43216,8 @@ final class FeatureView_VectorSearchConfig_BruteForceConfig
   String toString() => 'BruteForceConfig()';
 }
 
-final class FeatureView_VectorSearchConfig_TreeAhconfig extends ProtoMessage {
+final class FeatureView_VectorSearchConfig_TreeAhconfig
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureView.VectorSearchConfig.TreeAHConfig';
 
@@ -43218,7 +43255,7 @@ final class FeatureView_VectorSearchConfig_TreeAhconfig extends ProtoMessage {
 }
 
 final class FeatureView_VectorSearchConfig_DistanceMeasureType
-    extends ProtoEnum {
+    extends protobuf.ProtoEnum {
   /// Should not be set.
   static const distanceMeasureTypeUnspecified =
       FeatureView_VectorSearchConfig_DistanceMeasureType(
@@ -43256,7 +43293,7 @@ final class FeatureView_VectorSearchConfig_DistanceMeasureType
 }
 
 /// Configuration for vector indexing.
-final class FeatureView_IndexConfig extends ProtoMessage {
+final class FeatureView_IndexConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureView.IndexConfig';
 
@@ -43357,7 +43394,8 @@ final class FeatureView_IndexConfig extends ProtoMessage {
 }
 
 /// Configuration options for using brute force search.
-final class FeatureView_IndexConfig_BruteForceConfig extends ProtoMessage {
+final class FeatureView_IndexConfig_BruteForceConfig
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureView.IndexConfig.BruteForceConfig';
 
@@ -43379,7 +43417,7 @@ final class FeatureView_IndexConfig_BruteForceConfig extends ProtoMessage {
 }
 
 /// Configuration options for the tree-AH algorithm.
-final class FeatureView_IndexConfig_TreeAhconfig extends ProtoMessage {
+final class FeatureView_IndexConfig_TreeAhconfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureView.IndexConfig.TreeAHConfig';
 
@@ -43417,7 +43455,8 @@ final class FeatureView_IndexConfig_TreeAhconfig extends ProtoMessage {
 }
 
 /// The distance measure used in nearest neighbor search.
-final class FeatureView_IndexConfig_DistanceMeasureType extends ProtoEnum {
+final class FeatureView_IndexConfig_DistanceMeasureType
+    extends protobuf.ProtoEnum {
   /// Should not be set.
   static const distanceMeasureTypeUnspecified =
       FeatureView_IndexConfig_DistanceMeasureType(
@@ -43456,7 +43495,7 @@ final class FeatureView_IndexConfig_DistanceMeasureType extends ProtoEnum {
 
 /// A Feature Registry source for features that need to be synced to Online
 /// Store.
-final class FeatureView_FeatureRegistrySource extends ProtoMessage {
+final class FeatureView_FeatureRegistrySource extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureView.FeatureRegistrySource';
 
@@ -43501,7 +43540,7 @@ final class FeatureView_FeatureRegistrySource extends ProtoMessage {
 /// Features belonging to a single feature group that will be
 /// synced to Online Store.
 final class FeatureView_FeatureRegistrySource_FeatureGroup
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureView.FeatureRegistrySource.FeatureGroup';
 
@@ -43544,7 +43583,7 @@ final class FeatureView_FeatureRegistrySource_FeatureGroup
 
 /// A Vertex Rag source for features that need to be synced to Online
 /// Store.
-final class FeatureView_VertexRagSource extends ProtoMessage {
+final class FeatureView_VertexRagSource extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureView.VertexRagSource';
 
@@ -43592,7 +43631,7 @@ final class FeatureView_VertexRagSource extends ProtoMessage {
 }
 
 /// Configuration for FeatureViews created in Optimized FeatureOnlineStore.
-final class FeatureView_OptimizedConfig extends ProtoMessage {
+final class FeatureView_OptimizedConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureView.OptimizedConfig';
 
@@ -43629,7 +43668,7 @@ final class FeatureView_OptimizedConfig extends ProtoMessage {
 
 /// Metadata for the Cloud Bigtable that supports directly interacting Bigtable
 /// instances.
-final class FeatureView_BigtableMetadata extends ProtoMessage {
+final class FeatureView_BigtableMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureView.BigtableMetadata';
 
@@ -43658,7 +43697,7 @@ final class FeatureView_BigtableMetadata extends ProtoMessage {
 }
 
 /// Service agent type used during data sync.
-final class FeatureView_ServiceAgentType extends ProtoEnum {
+final class FeatureView_ServiceAgentType extends protobuf.ProtoEnum {
   /// By default, the project-level Vertex AI Service Agent is enabled.
   static const serviceAgentTypeUnspecified = FeatureView_ServiceAgentType(
     'SERVICE_AGENT_TYPE_UNSPECIFIED',
@@ -43689,7 +43728,7 @@ final class FeatureView_ServiceAgentType extends ProtoEnum {
 
 /// FeatureViewSync is a representation of sync operation which copies data from
 /// data source to Feature View in Online Store.
-final class FeatureViewSync extends ProtoMessage {
+final class FeatureViewSync extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureViewSync';
 
@@ -43768,7 +43807,7 @@ final class FeatureViewSync extends ProtoMessage {
 
 /// Summary from the Sync job. For continuous syncs, the summary is updated
 /// periodically. For batch syncs, it gets updated on completion of the sync.
-final class FeatureViewSync_SyncSummary extends ProtoMessage {
+final class FeatureViewSync_SyncSummary extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureViewSync.SyncSummary';
 
@@ -43822,7 +43861,7 @@ final class FeatureViewSync_SyncSummary extends ProtoMessage {
 /// Vertex AI Feature Store provides a centralized repository for organizing,
 /// storing, and serving ML features. The Featurestore is a top-level container
 /// for your features and their values.
-final class Featurestore extends ProtoMessage {
+final class Featurestore extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Featurestore';
 
@@ -43950,7 +43989,7 @@ final class Featurestore extends ProtoMessage {
 
 /// OnlineServingConfig specifies the details for provisioning online serving
 /// resources.
-final class Featurestore_OnlineServingConfig extends ProtoMessage {
+final class Featurestore_OnlineServingConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Featurestore.OnlineServingConfig';
 
@@ -43998,7 +44037,8 @@ final class Featurestore_OnlineServingConfig extends ProtoMessage {
 /// Online serving scaling configuration. If min_node_count and
 /// max_node_count are set to the same value, the cluster will be configured
 /// with the fixed number of node (no auto-scaling).
-final class Featurestore_OnlineServingConfig_Scaling extends ProtoMessage {
+final class Featurestore_OnlineServingConfig_Scaling
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Featurestore.OnlineServingConfig.Scaling';
 
@@ -44058,7 +44098,7 @@ final class Featurestore_OnlineServingConfig_Scaling extends ProtoMessage {
 }
 
 /// Possible states a featurestore can have.
-final class Featurestore_State extends ProtoEnum {
+final class Featurestore_State extends protobuf.ProtoEnum {
   /// Default value. This value is unused.
   static const stateUnspecified = Featurestore_State('STATE_UNSPECIFIED');
 
@@ -44088,7 +44128,7 @@ final class Featurestore_State extends ProtoEnum {
 }
 
 /// Configuration of how features in Featurestore are monitored.
-final class FeaturestoreMonitoringConfig extends ProtoMessage {
+final class FeaturestoreMonitoringConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeaturestoreMonitoringConfig';
 
@@ -44164,7 +44204,8 @@ final class FeaturestoreMonitoringConfig extends ProtoMessage {
 /// This type of analysis generates statistics for each Feature based on a
 /// snapshot of the latest feature value of each entities every
 /// monitoring_interval.
-final class FeaturestoreMonitoringConfig_SnapshotAnalysis extends ProtoMessage {
+final class FeaturestoreMonitoringConfig_SnapshotAnalysis
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeaturestoreMonitoringConfig.SnapshotAnalysis';
 
@@ -44251,7 +44292,7 @@ final class FeaturestoreMonitoringConfig_SnapshotAnalysis extends ProtoMessage {
 /// `ImportFeatureValues`
 /// operation.
 final class FeaturestoreMonitoringConfig_ImportFeaturesAnalysis
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeaturestoreMonitoringConfig.ImportFeaturesAnalysis';
 
@@ -44306,7 +44347,7 @@ final class FeaturestoreMonitoringConfig_ImportFeaturesAnalysis
 
 /// The state defines whether to enable ImportFeature analysis.
 final class FeaturestoreMonitoringConfig_ImportFeaturesAnalysis_State
-    extends ProtoEnum {
+    extends protobuf.ProtoEnum {
   /// Should not be used.
   static const stateUnspecified =
       FeaturestoreMonitoringConfig_ImportFeaturesAnalysis_State(
@@ -44349,7 +44390,7 @@ final class FeaturestoreMonitoringConfig_ImportFeaturesAnalysis_State
 /// `ImportFeatureValues`
 /// operation.
 final class FeaturestoreMonitoringConfig_ImportFeaturesAnalysis_Baseline
-    extends ProtoEnum {
+    extends protobuf.ProtoEnum {
   /// Should not be used.
   static const baselineUnspecified =
       FeaturestoreMonitoringConfig_ImportFeaturesAnalysis_Baseline(
@@ -44391,7 +44432,8 @@ final class FeaturestoreMonitoringConfig_ImportFeaturesAnalysis_Baseline
 }
 
 /// The config for Featurestore Monitoring threshold.
-final class FeaturestoreMonitoringConfig_ThresholdConfig extends ProtoMessage {
+final class FeaturestoreMonitoringConfig_ThresholdConfig
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeaturestoreMonitoringConfig.ThresholdConfig';
 
@@ -44429,7 +44471,7 @@ final class FeaturestoreMonitoringConfig_ThresholdConfig extends ProtoMessage {
 
 /// Request message for
 /// `FeaturestoreOnlineServingService.WriteFeatureValues`.
-final class WriteFeatureValuesRequest extends ProtoMessage {
+final class WriteFeatureValuesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.WriteFeatureValuesRequest';
 
@@ -44474,7 +44516,7 @@ final class WriteFeatureValuesRequest extends ProtoMessage {
 }
 
 /// Contains Feature values to be written for a specific entity.
-final class WriteFeatureValuesPayload extends ProtoMessage {
+final class WriteFeatureValuesPayload extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.WriteFeatureValuesPayload';
 
@@ -44517,7 +44559,7 @@ final class WriteFeatureValuesPayload extends ProtoMessage {
 
 /// Response message for
 /// `FeaturestoreOnlineServingService.WriteFeatureValues`.
-final class WriteFeatureValuesResponse extends ProtoMessage {
+final class WriteFeatureValuesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.WriteFeatureValuesResponse';
 
@@ -44538,7 +44580,7 @@ final class WriteFeatureValuesResponse extends ProtoMessage {
 
 /// Request message for
 /// `FeaturestoreOnlineServingService.ReadFeatureValues`.
-final class ReadFeatureValuesRequest extends ProtoMessage {
+final class ReadFeatureValuesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ReadFeatureValuesRequest';
 
@@ -44595,7 +44637,7 @@ final class ReadFeatureValuesRequest extends ProtoMessage {
 
 /// Response message for
 /// `FeaturestoreOnlineServingService.ReadFeatureValues`.
-final class ReadFeatureValuesResponse extends ProtoMessage {
+final class ReadFeatureValuesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ReadFeatureValuesResponse';
 
@@ -44634,7 +44676,8 @@ final class ReadFeatureValuesResponse extends ProtoMessage {
 }
 
 /// Metadata for requested Features.
-final class ReadFeatureValuesResponse_FeatureDescriptor extends ProtoMessage {
+final class ReadFeatureValuesResponse_FeatureDescriptor
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ReadFeatureValuesResponse.FeatureDescriptor';
 
@@ -44665,7 +44708,7 @@ final class ReadFeatureValuesResponse_FeatureDescriptor extends ProtoMessage {
 /// Response header with metadata for the requested
 /// `ReadFeatureValuesRequest.entity_type`
 /// and Features.
-final class ReadFeatureValuesResponse_Header extends ProtoMessage {
+final class ReadFeatureValuesResponse_Header extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ReadFeatureValuesResponse.Header';
 
@@ -44711,7 +44754,7 @@ final class ReadFeatureValuesResponse_Header extends ProtoMessage {
 }
 
 /// Entity view with Feature values.
-final class ReadFeatureValuesResponse_EntityView extends ProtoMessage {
+final class ReadFeatureValuesResponse_EntityView extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ReadFeatureValuesResponse.EntityView';
 
@@ -44758,7 +44801,8 @@ final class ReadFeatureValuesResponse_EntityView extends ProtoMessage {
 
 /// Container to hold value(s), successive in time, for one Feature from the
 /// request.
-final class ReadFeatureValuesResponse_EntityView_Data extends ProtoMessage {
+final class ReadFeatureValuesResponse_EntityView_Data
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ReadFeatureValuesResponse.EntityView.Data';
 
@@ -44797,7 +44841,7 @@ final class ReadFeatureValuesResponse_EntityView_Data extends ProtoMessage {
 
 /// Request message for
 /// `FeaturestoreOnlineServingService.StreamingReadFeatureValues`.
-final class StreamingReadFeatureValuesRequest extends ProtoMessage {
+final class StreamingReadFeatureValuesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StreamingReadFeatureValuesRequest';
 
@@ -44854,7 +44898,7 @@ final class StreamingReadFeatureValuesRequest extends ProtoMessage {
 }
 
 /// Value for a feature.
-final class FeatureValue extends ProtoMessage {
+final class FeatureValue extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureValue';
 
@@ -44954,7 +44998,7 @@ final class FeatureValue extends ProtoMessage {
 }
 
 /// Metadata of feature value.
-final class FeatureValue_Metadata extends ProtoMessage {
+final class FeatureValue_Metadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureValue.Metadata';
 
@@ -44989,7 +45033,7 @@ final class FeatureValue_Metadata extends ProtoMessage {
 }
 
 /// Struct (or object) type feature value.
-final class StructValue extends ProtoMessage {
+final class StructValue extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StructValue';
 
@@ -45014,7 +45058,7 @@ final class StructValue extends ProtoMessage {
 }
 
 /// One field of a Struct (or object) type feature value.
-final class StructFieldValue extends ProtoMessage {
+final class StructFieldValue extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StructFieldValue';
 
@@ -45049,7 +45093,7 @@ final class StructFieldValue extends ProtoMessage {
 }
 
 /// Container for list of values.
-final class FeatureValueList extends ProtoMessage {
+final class FeatureValueList extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureValueList';
 
@@ -45075,7 +45119,7 @@ final class FeatureValueList extends ProtoMessage {
 
 /// Request message for
 /// `FeaturestoreService.CreateFeaturestore`.
-final class CreateFeaturestoreRequest extends ProtoMessage {
+final class CreateFeaturestoreRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateFeaturestoreRequest';
 
@@ -45131,7 +45175,7 @@ final class CreateFeaturestoreRequest extends ProtoMessage {
 
 /// Request message for
 /// `FeaturestoreService.GetFeaturestore`.
-final class GetFeaturestoreRequest extends ProtoMessage {
+final class GetFeaturestoreRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetFeaturestoreRequest';
 
@@ -45158,7 +45202,7 @@ final class GetFeaturestoreRequest extends ProtoMessage {
 
 /// Request message for
 /// `FeaturestoreService.ListFeaturestores`.
-final class ListFeaturestoresRequest extends ProtoMessage {
+final class ListFeaturestoresRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListFeaturestoresRequest';
 
@@ -45262,7 +45306,7 @@ final class ListFeaturestoresRequest extends ProtoMessage {
 
 /// Response message for
 /// `FeaturestoreService.ListFeaturestores`.
-final class ListFeaturestoresResponse extends ProtoMessage {
+final class ListFeaturestoresResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListFeaturestoresResponse';
 
@@ -45307,7 +45351,7 @@ final class ListFeaturestoresResponse extends ProtoMessage {
 
 /// Request message for
 /// `FeaturestoreService.UpdateFeaturestore`.
-final class UpdateFeaturestoreRequest extends ProtoMessage {
+final class UpdateFeaturestoreRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateFeaturestoreRequest';
 
@@ -45356,7 +45400,7 @@ final class UpdateFeaturestoreRequest extends ProtoMessage {
 
 /// Request message for
 /// `FeaturestoreService.DeleteFeaturestore`.
-final class DeleteFeaturestoreRequest extends ProtoMessage {
+final class DeleteFeaturestoreRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteFeaturestoreRequest';
 
@@ -45394,7 +45438,7 @@ final class DeleteFeaturestoreRequest extends ProtoMessage {
 
 /// Request message for
 /// `FeaturestoreService.ImportFeatureValues`.
-final class ImportFeatureValuesRequest extends ProtoMessage {
+final class ImportFeatureValuesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ImportFeatureValuesRequest';
 
@@ -45514,7 +45558,8 @@ final class ImportFeatureValuesRequest extends ProtoMessage {
 }
 
 /// Defines the Feature value(s) to import.
-final class ImportFeatureValuesRequest_FeatureSpec extends ProtoMessage {
+final class ImportFeatureValuesRequest_FeatureSpec
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ImportFeatureValuesRequest.FeatureSpec';
 
@@ -45558,7 +45603,7 @@ final class ImportFeatureValuesRequest_FeatureSpec extends ProtoMessage {
 
 /// Response message for
 /// `FeaturestoreService.ImportFeatureValues`.
-final class ImportFeatureValuesResponse extends ProtoMessage {
+final class ImportFeatureValuesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ImportFeatureValuesResponse';
 
@@ -45630,7 +45675,7 @@ final class ImportFeatureValuesResponse extends ProtoMessage {
 
 /// Request message for
 /// `FeaturestoreService.BatchReadFeatureValues`.
-final class BatchReadFeatureValuesRequest extends ProtoMessage {
+final class BatchReadFeatureValuesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BatchReadFeatureValuesRequest';
 
@@ -45749,7 +45794,7 @@ final class BatchReadFeatureValuesRequest extends ProtoMessage {
 
 /// Describe pass-through fields in read_instance source.
 final class BatchReadFeatureValuesRequest_PassThroughField
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BatchReadFeatureValuesRequest.PassThroughField';
 
@@ -45783,7 +45828,8 @@ final class BatchReadFeatureValuesRequest_PassThroughField
 
 /// Selects Features of an EntityType to read values of and specifies read
 /// settings.
-final class BatchReadFeatureValuesRequest_EntityTypeSpec extends ProtoMessage {
+final class BatchReadFeatureValuesRequest_EntityTypeSpec
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BatchReadFeatureValuesRequest.EntityTypeSpec';
 
@@ -45842,7 +45888,7 @@ final class BatchReadFeatureValuesRequest_EntityTypeSpec extends ProtoMessage {
 
 /// Request message for
 /// `FeaturestoreService.ExportFeatureValues`.
-final class ExportFeatureValuesRequest extends ProtoMessage {
+final class ExportFeatureValuesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExportFeatureValuesRequest';
 
@@ -45924,7 +45970,8 @@ final class ExportFeatureValuesRequest extends ProtoMessage {
 
 /// Describes exporting the latest Feature values of all entities of the
 /// EntityType between [start_time, snapshot_time].
-final class ExportFeatureValuesRequest_SnapshotExport extends ProtoMessage {
+final class ExportFeatureValuesRequest_SnapshotExport
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExportFeatureValuesRequest.SnapshotExport';
 
@@ -45967,7 +46014,8 @@ final class ExportFeatureValuesRequest_SnapshotExport extends ProtoMessage {
 
 /// Describes exporting all historical Feature values of all entities of the
 /// EntityType between [start_time, end_time].
-final class ExportFeatureValuesRequest_FullExport extends ProtoMessage {
+final class ExportFeatureValuesRequest_FullExport
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExportFeatureValuesRequest.FullExport';
 
@@ -46005,7 +46053,7 @@ final class ExportFeatureValuesRequest_FullExport extends ProtoMessage {
   String toString() => 'FullExport()';
 }
 
-final class DestinationFeatureSetting extends ProtoMessage {
+final class DestinationFeatureSetting extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DestinationFeatureSetting';
 
@@ -46045,7 +46093,7 @@ final class DestinationFeatureSetting extends ProtoMessage {
 }
 
 /// A destination location for Feature values and format.
-final class FeatureValueDestination extends ProtoMessage {
+final class FeatureValueDestination extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FeatureValueDestination';
 
@@ -46110,7 +46158,7 @@ final class FeatureValueDestination extends ProtoMessage {
 
 /// Response message for
 /// `FeaturestoreService.ExportFeatureValues`.
-final class ExportFeatureValuesResponse extends ProtoMessage {
+final class ExportFeatureValuesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExportFeatureValuesResponse';
 
@@ -46131,7 +46179,7 @@ final class ExportFeatureValuesResponse extends ProtoMessage {
 
 /// Response message for
 /// `FeaturestoreService.BatchReadFeatureValues`.
-final class BatchReadFeatureValuesResponse extends ProtoMessage {
+final class BatchReadFeatureValuesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BatchReadFeatureValuesResponse';
 
@@ -46152,7 +46200,7 @@ final class BatchReadFeatureValuesResponse extends ProtoMessage {
 
 /// Request message for
 /// `FeaturestoreService.CreateEntityType`.
-final class CreateEntityTypeRequest extends ProtoMessage {
+final class CreateEntityTypeRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateEntityTypeRequest';
 
@@ -46208,7 +46256,7 @@ final class CreateEntityTypeRequest extends ProtoMessage {
 
 /// Request message for
 /// `FeaturestoreService.GetEntityType`.
-final class GetEntityTypeRequest extends ProtoMessage {
+final class GetEntityTypeRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetEntityTypeRequest';
 
@@ -46237,7 +46285,7 @@ final class GetEntityTypeRequest extends ProtoMessage {
 
 /// Request message for
 /// `FeaturestoreService.ListEntityTypes`.
-final class ListEntityTypesRequest extends ProtoMessage {
+final class ListEntityTypesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListEntityTypesRequest';
 
@@ -46341,7 +46389,7 @@ final class ListEntityTypesRequest extends ProtoMessage {
 
 /// Response message for
 /// `FeaturestoreService.ListEntityTypes`.
-final class ListEntityTypesResponse extends ProtoMessage {
+final class ListEntityTypesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListEntityTypesResponse';
 
@@ -46383,7 +46431,7 @@ final class ListEntityTypesResponse extends ProtoMessage {
 
 /// Request message for
 /// `FeaturestoreService.UpdateEntityType`.
-final class UpdateEntityTypeRequest extends ProtoMessage {
+final class UpdateEntityTypeRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateEntityTypeRequest';
 
@@ -46437,7 +46485,7 @@ final class UpdateEntityTypeRequest extends ProtoMessage {
 }
 
 /// Request message for `FeaturestoreService.DeleteEntityTypes`.
-final class DeleteEntityTypeRequest extends ProtoMessage {
+final class DeleteEntityTypeRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteEntityTypeRequest';
 
@@ -46476,7 +46524,7 @@ final class DeleteEntityTypeRequest extends ProtoMessage {
 /// `FeaturestoreService.CreateFeature`.
 /// Request message for
 /// `FeatureRegistryService.CreateFeature`.
-final class CreateFeatureRequest extends ProtoMessage {
+final class CreateFeatureRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateFeatureRequest';
 
@@ -46536,7 +46584,7 @@ final class CreateFeatureRequest extends ProtoMessage {
 /// `FeaturestoreService.BatchCreateFeatures`.
 /// Request message for
 /// `FeatureRegistryService.BatchCreateFeatures`.
-final class BatchCreateFeaturesRequest extends ProtoMessage {
+final class BatchCreateFeaturesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BatchCreateFeaturesRequest';
 
@@ -46583,7 +46631,7 @@ final class BatchCreateFeaturesRequest extends ProtoMessage {
 
 /// Response message for
 /// `FeaturestoreService.BatchCreateFeatures`.
-final class BatchCreateFeaturesResponse extends ProtoMessage {
+final class BatchCreateFeaturesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BatchCreateFeaturesResponse';
 
@@ -46611,7 +46659,7 @@ final class BatchCreateFeaturesResponse extends ProtoMessage {
 /// `FeaturestoreService.GetFeature`.
 /// Request message for
 /// `FeatureRegistryService.GetFeature`.
-final class GetFeatureRequest extends ProtoMessage {
+final class GetFeatureRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetFeatureRequest';
 
@@ -46660,7 +46708,7 @@ final class GetFeatureRequest extends ProtoMessage {
 /// `FeaturestoreService.ListFeatures`.
 /// Request message for
 /// `FeatureRegistryService.ListFeatures`.
-final class ListFeaturesRequest extends ProtoMessage {
+final class ListFeaturesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListFeaturesRequest';
 
@@ -46787,7 +46835,7 @@ final class ListFeaturesRequest extends ProtoMessage {
 /// `FeaturestoreService.ListFeatures`.
 /// Response message for
 /// `FeatureRegistryService.ListFeatures`.
-final class ListFeaturesResponse extends ProtoMessage {
+final class ListFeaturesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListFeaturesResponse';
 
@@ -46829,7 +46877,7 @@ final class ListFeaturesResponse extends ProtoMessage {
 
 /// Request message for
 /// `FeaturestoreService.SearchFeatures`.
-final class SearchFeaturesRequest extends ProtoMessage {
+final class SearchFeaturesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SearchFeaturesRequest';
 
@@ -46955,7 +47003,7 @@ final class SearchFeaturesRequest extends ProtoMessage {
 
 /// Response message for
 /// `FeaturestoreService.SearchFeatures`.
-final class SearchFeaturesResponse extends ProtoMessage {
+final class SearchFeaturesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SearchFeaturesResponse';
 
@@ -47007,7 +47055,7 @@ final class SearchFeaturesResponse extends ProtoMessage {
 /// `FeaturestoreService.UpdateFeature`.
 /// Request message for
 /// `FeatureRegistryService.UpdateFeature`.
-final class UpdateFeatureRequest extends ProtoMessage {
+final class UpdateFeatureRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateFeatureRequest';
 
@@ -47060,7 +47108,7 @@ final class UpdateFeatureRequest extends ProtoMessage {
 /// `FeaturestoreService.DeleteFeature`.
 /// Request message for
 /// `FeatureRegistryService.DeleteFeature`.
-final class DeleteFeatureRequest extends ProtoMessage {
+final class DeleteFeatureRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteFeatureRequest';
 
@@ -47089,7 +47137,7 @@ final class DeleteFeatureRequest extends ProtoMessage {
 }
 
 /// Details of operations that perform create Featurestore.
-final class CreateFeaturestoreOperationMetadata extends ProtoMessage {
+final class CreateFeaturestoreOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateFeaturestoreOperationMetadata';
 
@@ -47122,7 +47170,7 @@ final class CreateFeaturestoreOperationMetadata extends ProtoMessage {
 }
 
 /// Details of operations that perform update Featurestore.
-final class UpdateFeaturestoreOperationMetadata extends ProtoMessage {
+final class UpdateFeaturestoreOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateFeaturestoreOperationMetadata';
 
@@ -47155,7 +47203,7 @@ final class UpdateFeaturestoreOperationMetadata extends ProtoMessage {
 }
 
 /// Details of operations that perform import Feature values.
-final class ImportFeatureValuesOperationMetadata extends ProtoMessage {
+final class ImportFeatureValuesOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ImportFeatureValuesOperationMetadata';
 
@@ -47251,7 +47299,7 @@ final class ImportFeatureValuesOperationMetadata extends ProtoMessage {
 }
 
 /// Details of operations that exports Features values.
-final class ExportFeatureValuesOperationMetadata extends ProtoMessage {
+final class ExportFeatureValuesOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExportFeatureValuesOperationMetadata';
 
@@ -47284,7 +47332,8 @@ final class ExportFeatureValuesOperationMetadata extends ProtoMessage {
 }
 
 /// Details of operations that batch reads Feature values.
-final class BatchReadFeatureValuesOperationMetadata extends ProtoMessage {
+final class BatchReadFeatureValuesOperationMetadata
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BatchReadFeatureValuesOperationMetadata';
 
@@ -47317,7 +47366,7 @@ final class BatchReadFeatureValuesOperationMetadata extends ProtoMessage {
 }
 
 /// Details of operations that delete Feature values.
-final class DeleteFeatureValuesOperationMetadata extends ProtoMessage {
+final class DeleteFeatureValuesOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteFeatureValuesOperationMetadata';
 
@@ -47350,7 +47399,7 @@ final class DeleteFeatureValuesOperationMetadata extends ProtoMessage {
 }
 
 /// Details of operations that perform create EntityType.
-final class CreateEntityTypeOperationMetadata extends ProtoMessage {
+final class CreateEntityTypeOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateEntityTypeOperationMetadata';
 
@@ -47383,7 +47432,7 @@ final class CreateEntityTypeOperationMetadata extends ProtoMessage {
 }
 
 /// Details of operations that perform create Feature.
-final class CreateFeatureOperationMetadata extends ProtoMessage {
+final class CreateFeatureOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateFeatureOperationMetadata';
 
@@ -47414,7 +47463,7 @@ final class CreateFeatureOperationMetadata extends ProtoMessage {
 }
 
 /// Details of operations that perform batch create Features.
-final class BatchCreateFeaturesOperationMetadata extends ProtoMessage {
+final class BatchCreateFeaturesOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BatchCreateFeaturesOperationMetadata';
 
@@ -47448,7 +47497,7 @@ final class BatchCreateFeaturesOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `FeaturestoreService.DeleteFeatureValues`.
-final class DeleteFeatureValuesRequest extends ProtoMessage {
+final class DeleteFeatureValuesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteFeatureValuesRequest';
 
@@ -47505,7 +47554,8 @@ final class DeleteFeatureValuesRequest extends ProtoMessage {
 /// Message to select entity.
 /// If an entity id is selected, all the feature values corresponding to the
 /// entity id will be deleted, including the entityId.
-final class DeleteFeatureValuesRequest_SelectEntity extends ProtoMessage {
+final class DeleteFeatureValuesRequest_SelectEntity
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteFeatureValuesRequest.SelectEntity';
 
@@ -47546,7 +47596,7 @@ final class DeleteFeatureValuesRequest_SelectEntity extends ProtoMessage {
 /// This might include data from the online storage. If you want to retain
 /// any deleted historical data in the online storage, you must re-ingest it.
 final class DeleteFeatureValuesRequest_SelectTimeRangeAndFeature
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteFeatureValuesRequest.SelectTimeRangeAndFeature';
 
@@ -47604,7 +47654,7 @@ final class DeleteFeatureValuesRequest_SelectTimeRangeAndFeature
 
 /// Response message for
 /// `FeaturestoreService.DeleteFeatureValues`.
-final class DeleteFeatureValuesResponse extends ProtoMessage {
+final class DeleteFeatureValuesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteFeatureValuesResponse';
 
@@ -47647,7 +47697,8 @@ final class DeleteFeatureValuesResponse extends ProtoMessage {
 }
 
 /// Response message if the request uses the SelectEntity option.
-final class DeleteFeatureValuesResponse_SelectEntity extends ProtoMessage {
+final class DeleteFeatureValuesResponse_SelectEntity
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteFeatureValuesResponse.SelectEntity';
 
@@ -47706,7 +47757,7 @@ final class DeleteFeatureValuesResponse_SelectEntity extends ProtoMessage {
 
 /// Response message if the request uses the SelectTimeRangeAndFeature option.
 final class DeleteFeatureValuesResponse_SelectTimeRangeAndFeature
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteFeatureValuesResponse.SelectTimeRangeAndFeature';
 
@@ -47778,7 +47829,7 @@ final class DeleteFeatureValuesResponse_SelectTimeRangeAndFeature
 }
 
 /// Selector for entityId. Getting ids from the given source.
-final class EntityIdSelector extends ProtoMessage {
+final class EntityIdSelector extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.EntityIdSelector';
 
@@ -47818,7 +47869,7 @@ final class EntityIdSelector extends ProtoMessage {
 
 /// Request message for
 /// `GenAiCacheService.CreateCachedContent`.
-final class CreateCachedContentRequest extends ProtoMessage {
+final class CreateCachedContentRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateCachedContentRequest';
 
@@ -47854,7 +47905,7 @@ final class CreateCachedContentRequest extends ProtoMessage {
 
 /// Request message for
 /// `GenAiCacheService.GetCachedContent`.
-final class GetCachedContentRequest extends ProtoMessage {
+final class GetCachedContentRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetCachedContentRequest';
 
@@ -47882,7 +47933,7 @@ final class GetCachedContentRequest extends ProtoMessage {
 /// Request message for
 /// `GenAiCacheService.UpdateCachedContent`.
 /// Only expire_time or ttl can be updated.
-final class UpdateCachedContentRequest extends ProtoMessage {
+final class UpdateCachedContentRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateCachedContentRequest';
 
@@ -47916,7 +47967,7 @@ final class UpdateCachedContentRequest extends ProtoMessage {
 
 /// Request message for
 /// `GenAiCacheService.DeleteCachedContent`.
-final class DeleteCachedContentRequest extends ProtoMessage {
+final class DeleteCachedContentRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteCachedContentRequest';
 
@@ -47942,7 +47993,7 @@ final class DeleteCachedContentRequest extends ProtoMessage {
 }
 
 /// Request to list CachedContents.
-final class ListCachedContentsRequest extends ProtoMessage {
+final class ListCachedContentsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListCachedContentsRequest';
 
@@ -47997,7 +48048,7 @@ final class ListCachedContentsRequest extends ProtoMessage {
 }
 
 /// Response with a list of CachedContents.
-final class ListCachedContentsResponse extends ProtoMessage {
+final class ListCachedContentsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListCachedContentsResponse';
 
@@ -48040,7 +48091,7 @@ final class ListCachedContentsResponse extends ProtoMessage {
 
 /// Request message for
 /// `GenAiTuningService.CreateTuningJob`.
-final class CreateTuningJobRequest extends ProtoMessage {
+final class CreateTuningJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateTuningJobRequest';
 
@@ -48075,7 +48126,7 @@ final class CreateTuningJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `GenAiTuningService.GetTuningJob`.
-final class GetTuningJobRequest extends ProtoMessage {
+final class GetTuningJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetTuningJobRequest';
 
@@ -48103,7 +48154,7 @@ final class GetTuningJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `GenAiTuningService.ListTuningJobs`.
-final class ListTuningJobsRequest extends ProtoMessage {
+final class ListTuningJobsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListTuningJobsRequest';
 
@@ -48162,7 +48213,7 @@ final class ListTuningJobsRequest extends ProtoMessage {
 
 /// Response message for
 /// `GenAiTuningService.ListTuningJobs`
-final class ListTuningJobsResponse extends ProtoMessage {
+final class ListTuningJobsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListTuningJobsResponse';
 
@@ -48204,7 +48255,7 @@ final class ListTuningJobsResponse extends ProtoMessage {
 
 /// Request message for
 /// `GenAiTuningService.CancelTuningJob`.
-final class CancelTuningJobRequest extends ProtoMessage {
+final class CancelTuningJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CancelTuningJobRequest';
 
@@ -48232,7 +48283,7 @@ final class CancelTuningJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `GenAiTuningService.RebaseTunedModel`.
-final class RebaseTunedModelRequest extends ProtoMessage {
+final class RebaseTunedModelRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RebaseTunedModelRequest';
 
@@ -48302,7 +48353,7 @@ final class RebaseTunedModelRequest extends ProtoMessage {
 
 /// Runtime operation information for
 /// `GenAiTuningService.RebaseTunedModel`.
-final class RebaseTunedModelOperationMetadata extends ProtoMessage {
+final class RebaseTunedModelOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RebaseTunedModelOperationMetadata';
 
@@ -48337,7 +48388,7 @@ final class RebaseTunedModelOperationMetadata extends ProtoMessage {
 /// Represents a HyperparameterTuningJob. A HyperparameterTuningJob
 /// has a Study specification and multiple CustomJobs with identical
 /// CustomJob specification.
-final class HyperparameterTuningJob extends ProtoMessage {
+final class HyperparameterTuningJob extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.HyperparameterTuningJob';
 
@@ -48503,7 +48554,7 @@ final class HyperparameterTuningJob extends ProtoMessage {
 
 /// A representation of a collection of database items organized in a way that
 /// allows for approximate nearest neighbor (a.k.a ANN) algorithms search.
-final class Index extends ProtoMessage {
+final class Index extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Index';
 
@@ -48665,7 +48716,7 @@ final class Index extends ProtoMessage {
 }
 
 /// The update method of an Index.
-final class Index_IndexUpdateMethod extends ProtoEnum {
+final class Index_IndexUpdateMethod extends protobuf.ProtoEnum {
   /// Should not be used.
   static const indexUpdateMethodUnspecified = Index_IndexUpdateMethod(
     'INDEX_UPDATE_METHOD_UNSPECIFIED',
@@ -48690,7 +48741,7 @@ final class Index_IndexUpdateMethod extends ProtoEnum {
 }
 
 /// A datapoint of Index.
-final class IndexDatapoint extends ProtoMessage {
+final class IndexDatapoint extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.IndexDatapoint';
 
@@ -48785,7 +48836,7 @@ final class IndexDatapoint extends ProtoMessage {
 
 /// Feature embedding vector for sparse index. An array of numbers whose values
 /// are located in the specified dimensions.
-final class IndexDatapoint_SparseEmbedding extends ProtoMessage {
+final class IndexDatapoint_SparseEmbedding extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.IndexDatapoint.SparseEmbedding';
 
@@ -48820,7 +48871,7 @@ final class IndexDatapoint_SparseEmbedding extends ProtoMessage {
 
 /// Restriction of a datapoint which describe its attributes(tokens) from each
 /// of several attribute categories(namespaces).
-final class IndexDatapoint_Restriction extends ProtoMessage {
+final class IndexDatapoint_Restriction extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.IndexDatapoint.Restriction';
 
@@ -48862,7 +48913,7 @@ final class IndexDatapoint_Restriction extends ProtoMessage {
 
 /// This field allows restricts to be based on numeric comparisons rather
 /// than categorical tokens.
-final class IndexDatapoint_NumericRestriction extends ProtoMessage {
+final class IndexDatapoint_NumericRestriction extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.IndexDatapoint.NumericRestriction';
 
@@ -48934,7 +48985,8 @@ final class IndexDatapoint_NumericRestriction extends ProtoMessage {
 ///
 /// Datapoints for which Operator is true relative to the query's Value
 /// field will be allowlisted.
-final class IndexDatapoint_NumericRestriction_Operator extends ProtoEnum {
+final class IndexDatapoint_NumericRestriction_Operator
+    extends protobuf.ProtoEnum {
   /// Default value of the enum.
   static const operatorUnspecified = IndexDatapoint_NumericRestriction_Operator(
     'OPERATOR_UNSPECIFIED',
@@ -48976,7 +49028,7 @@ final class IndexDatapoint_NumericRestriction_Operator extends ProtoEnum {
 /// Crowding tag is a constraint on a neighbor list produced by nearest
 /// neighbor search requiring that no more than some value k' of the k
 /// neighbors returned have the same value of crowding_attribute.
-final class IndexDatapoint_CrowdingTag extends ProtoMessage {
+final class IndexDatapoint_CrowdingTag extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.IndexDatapoint.CrowdingTag';
 
@@ -49013,7 +49065,7 @@ final class IndexDatapoint_CrowdingTag extends ProtoMessage {
 }
 
 /// Stats of the Index.
-final class IndexStats extends ProtoMessage {
+final class IndexStats extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.IndexStats';
 
@@ -49060,7 +49112,7 @@ final class IndexStats extends ProtoMessage {
 
 /// Indexes are deployed into it. An IndexEndpoint can have multiple
 /// DeployedIndexes.
-final class IndexEndpoint extends ProtoMessage {
+final class IndexEndpoint extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.IndexEndpoint';
 
@@ -49249,7 +49301,7 @@ final class IndexEndpoint extends ProtoMessage {
 }
 
 /// A deployment of an Index. IndexEndpoints contain one or more DeployedIndexes.
-final class DeployedIndex extends ProtoMessage {
+final class DeployedIndex extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeployedIndex';
 
@@ -49480,7 +49532,7 @@ final class DeployedIndex extends ProtoMessage {
 }
 
 /// Used to set up the auth on the DeployedIndex's private endpoint.
-final class DeployedIndexAuthConfig extends ProtoMessage {
+final class DeployedIndexAuthConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeployedIndexAuthConfig';
 
@@ -49510,7 +49562,7 @@ final class DeployedIndexAuthConfig extends ProtoMessage {
 /// Configuration for an authentication provider, including support for
 /// [JSON Web Token
 /// (JWT)](https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-32).
-final class DeployedIndexAuthConfig_AuthProvider extends ProtoMessage {
+final class DeployedIndexAuthConfig_AuthProvider extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeployedIndexAuthConfig.AuthProvider';
 
@@ -49555,7 +49607,7 @@ final class DeployedIndexAuthConfig_AuthProvider extends ProtoMessage {
 /// connect).
 /// To send request via private service access, use match_grpc_address.
 /// To send request via private service connect, use service_attachment.
-final class IndexPrivateEndpoints extends ProtoMessage {
+final class IndexPrivateEndpoints extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.IndexPrivateEndpoints';
 
@@ -49609,7 +49661,7 @@ final class IndexPrivateEndpoints extends ProtoMessage {
 
 /// Request message for
 /// `IndexEndpointService.CreateIndexEndpoint`.
-final class CreateIndexEndpointRequest extends ProtoMessage {
+final class CreateIndexEndpointRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateIndexEndpointRequest';
 
@@ -49646,7 +49698,7 @@ final class CreateIndexEndpointRequest extends ProtoMessage {
 
 /// Runtime operation information for
 /// `IndexEndpointService.CreateIndexEndpoint`.
-final class CreateIndexEndpointOperationMetadata extends ProtoMessage {
+final class CreateIndexEndpointOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateIndexEndpointOperationMetadata';
 
@@ -49680,7 +49732,7 @@ final class CreateIndexEndpointOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `IndexEndpointService.GetIndexEndpoint`
-final class GetIndexEndpointRequest extends ProtoMessage {
+final class GetIndexEndpointRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetIndexEndpointRequest';
 
@@ -49709,7 +49761,7 @@ final class GetIndexEndpointRequest extends ProtoMessage {
 
 /// Request message for
 /// `IndexEndpointService.ListIndexEndpoints`.
-final class ListIndexEndpointsRequest extends ProtoMessage {
+final class ListIndexEndpointsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListIndexEndpointsRequest';
 
@@ -49794,7 +49846,7 @@ final class ListIndexEndpointsRequest extends ProtoMessage {
 
 /// Response message for
 /// `IndexEndpointService.ListIndexEndpoints`.
-final class ListIndexEndpointsResponse extends ProtoMessage {
+final class ListIndexEndpointsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListIndexEndpointsResponse';
 
@@ -49839,7 +49891,7 @@ final class ListIndexEndpointsResponse extends ProtoMessage {
 
 /// Request message for
 /// `IndexEndpointService.UpdateIndexEndpoint`.
-final class UpdateIndexEndpointRequest extends ProtoMessage {
+final class UpdateIndexEndpointRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateIndexEndpointRequest';
 
@@ -49874,7 +49926,7 @@ final class UpdateIndexEndpointRequest extends ProtoMessage {
 
 /// Request message for
 /// `IndexEndpointService.DeleteIndexEndpoint`.
-final class DeleteIndexEndpointRequest extends ProtoMessage {
+final class DeleteIndexEndpointRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteIndexEndpointRequest';
 
@@ -49903,7 +49955,7 @@ final class DeleteIndexEndpointRequest extends ProtoMessage {
 
 /// Request message for
 /// `IndexEndpointService.DeployIndex`.
-final class DeployIndexRequest extends ProtoMessage {
+final class DeployIndexRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeployIndexRequest';
 
@@ -49942,7 +49994,7 @@ final class DeployIndexRequest extends ProtoMessage {
 
 /// Response message for
 /// `IndexEndpointService.DeployIndex`.
-final class DeployIndexResponse extends ProtoMessage {
+final class DeployIndexResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeployIndexResponse';
 
@@ -49970,7 +50022,7 @@ final class DeployIndexResponse extends ProtoMessage {
 
 /// Runtime operation information for
 /// `IndexEndpointService.DeployIndex`.
-final class DeployIndexOperationMetadata extends ProtoMessage {
+final class DeployIndexOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeployIndexOperationMetadata';
 
@@ -50012,7 +50064,7 @@ final class DeployIndexOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `IndexEndpointService.UndeployIndex`.
-final class UndeployIndexRequest extends ProtoMessage {
+final class UndeployIndexRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UndeployIndexRequest';
 
@@ -50055,7 +50107,7 @@ final class UndeployIndexRequest extends ProtoMessage {
 
 /// Response message for
 /// `IndexEndpointService.UndeployIndex`.
-final class UndeployIndexResponse extends ProtoMessage {
+final class UndeployIndexResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UndeployIndexResponse';
 
@@ -50076,7 +50128,7 @@ final class UndeployIndexResponse extends ProtoMessage {
 
 /// Runtime operation information for
 /// `IndexEndpointService.UndeployIndex`.
-final class UndeployIndexOperationMetadata extends ProtoMessage {
+final class UndeployIndexOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UndeployIndexOperationMetadata';
 
@@ -50108,7 +50160,7 @@ final class UndeployIndexOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `IndexEndpointService.MutateDeployedIndex`.
-final class MutateDeployedIndexRequest extends ProtoMessage {
+final class MutateDeployedIndexRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.MutateDeployedIndexRequest';
 
@@ -50151,7 +50203,7 @@ final class MutateDeployedIndexRequest extends ProtoMessage {
 
 /// Response message for
 /// `IndexEndpointService.MutateDeployedIndex`.
-final class MutateDeployedIndexResponse extends ProtoMessage {
+final class MutateDeployedIndexResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.MutateDeployedIndexResponse';
 
@@ -50179,7 +50231,7 @@ final class MutateDeployedIndexResponse extends ProtoMessage {
 
 /// Runtime operation information for
 /// `IndexEndpointService.MutateDeployedIndex`.
-final class MutateDeployedIndexOperationMetadata extends ProtoMessage {
+final class MutateDeployedIndexOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.MutateDeployedIndexOperationMetadata';
 
@@ -50225,7 +50277,7 @@ final class MutateDeployedIndexOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `IndexService.CreateIndex`.
-final class CreateIndexRequest extends ProtoMessage {
+final class CreateIndexRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateIndexRequest';
 
@@ -50260,7 +50312,7 @@ final class CreateIndexRequest extends ProtoMessage {
 
 /// Runtime operation information for
 /// `IndexService.CreateIndex`.
-final class CreateIndexOperationMetadata extends ProtoMessage {
+final class CreateIndexOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateIndexOperationMetadata';
 
@@ -50305,7 +50357,7 @@ final class CreateIndexOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `IndexService.GetIndex`
-final class GetIndexRequest extends ProtoMessage {
+final class GetIndexRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetIndexRequest';
 
@@ -50334,7 +50386,7 @@ final class GetIndexRequest extends ProtoMessage {
 
 /// Request message for
 /// `IndexService.ListIndexes`.
-final class ListIndexesRequest extends ProtoMessage {
+final class ListIndexesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListIndexesRequest';
 
@@ -50402,7 +50454,7 @@ final class ListIndexesRequest extends ProtoMessage {
 
 /// Response message for
 /// `IndexService.ListIndexes`.
-final class ListIndexesResponse extends ProtoMessage {
+final class ListIndexesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListIndexesResponse';
 
@@ -50444,7 +50496,7 @@ final class ListIndexesResponse extends ProtoMessage {
 
 /// Request message for
 /// `IndexService.UpdateIndex`.
-final class UpdateIndexRequest extends ProtoMessage {
+final class UpdateIndexRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateIndexRequest';
 
@@ -50480,7 +50532,7 @@ final class UpdateIndexRequest extends ProtoMessage {
 
 /// Runtime operation information for
 /// `IndexService.UpdateIndex`.
-final class UpdateIndexOperationMetadata extends ProtoMessage {
+final class UpdateIndexOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateIndexOperationMetadata';
 
@@ -50525,7 +50577,7 @@ final class UpdateIndexOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `IndexService.ImportIndex`.
-final class ImportIndexRequest extends ProtoMessage {
+final class ImportIndexRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ImportIndexRequest';
 
@@ -50580,7 +50632,7 @@ final class ImportIndexRequest extends ProtoMessage {
 }
 
 /// Configuration for importing data from an external source.
-final class ImportIndexRequest_ConnectorConfig extends ProtoMessage {
+final class ImportIndexRequest_ConnectorConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ImportIndexRequest.ConnectorConfig';
 
@@ -50616,7 +50668,7 @@ final class ImportIndexRequest_ConnectorConfig extends ProtoMessage {
 
 /// Mapping of datapoint fields to column names for columnar data sources.
 final class ImportIndexRequest_ConnectorConfig_DatapointFieldMapping
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ImportIndexRequest.ConnectorConfig.DatapointFieldMapping';
 
@@ -50692,7 +50744,7 @@ final class ImportIndexRequest_ConnectorConfig_DatapointFieldMapping
 
 /// Restrictions on string values.
 final class ImportIndexRequest_ConnectorConfig_DatapointFieldMapping_Restrict
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ImportIndexRequest.ConnectorConfig.DatapointFieldMapping.Restrict';
 
@@ -50739,7 +50791,7 @@ final class ImportIndexRequest_ConnectorConfig_DatapointFieldMapping_Restrict
 
 /// Restrictions on numeric values.
 final class ImportIndexRequest_ConnectorConfig_DatapointFieldMapping_NumericRestrict
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ImportIndexRequest.ConnectorConfig.DatapointFieldMapping.NumericRestrict';
 
@@ -50796,7 +50848,7 @@ final class ImportIndexRequest_ConnectorConfig_DatapointFieldMapping_NumericRest
 
 /// The type of numeric value for the restrict.
 final class ImportIndexRequest_ConnectorConfig_DatapointFieldMapping_NumericRestrict_ValueType
-    extends ProtoEnum {
+    extends protobuf.ProtoEnum {
   /// Should not be used.
   static const valueTypeUnspecified =
       ImportIndexRequest_ConnectorConfig_DatapointFieldMapping_NumericRestrict_ValueType(
@@ -50838,7 +50890,7 @@ final class ImportIndexRequest_ConnectorConfig_DatapointFieldMapping_NumericRest
 
 /// Configuration for importing data from a BigQuery table.
 final class ImportIndexRequest_ConnectorConfig_BigQuerySourceConfig
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ImportIndexRequest.ConnectorConfig.BigQuerySourceConfig';
 
@@ -50885,7 +50937,7 @@ final class ImportIndexRequest_ConnectorConfig_BigQuerySourceConfig
 
 /// Runtime operation information for
 /// `IndexService.ImportIndex`.
-final class ImportIndexOperationMetadata extends ProtoMessage {
+final class ImportIndexOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ImportIndexOperationMetadata';
 
@@ -50917,7 +50969,7 @@ final class ImportIndexOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `IndexService.DeleteIndex`.
-final class DeleteIndexRequest extends ProtoMessage {
+final class DeleteIndexRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteIndexRequest';
 
@@ -50946,7 +50998,7 @@ final class DeleteIndexRequest extends ProtoMessage {
 
 /// Request message for
 /// `IndexService.UpsertDatapoints`
-final class UpsertDatapointsRequest extends ProtoMessage {
+final class UpsertDatapointsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpsertDatapointsRequest';
 
@@ -51002,7 +51054,7 @@ final class UpsertDatapointsRequest extends ProtoMessage {
 
 /// Response message for
 /// `IndexService.UpsertDatapoints`
-final class UpsertDatapointsResponse extends ProtoMessage {
+final class UpsertDatapointsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpsertDatapointsResponse';
 
@@ -51023,7 +51075,7 @@ final class UpsertDatapointsResponse extends ProtoMessage {
 
 /// Request message for
 /// `IndexService.RemoveDatapoints`
-final class RemoveDatapointsRequest extends ProtoMessage {
+final class RemoveDatapointsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RemoveDatapointsRequest';
 
@@ -51062,7 +51114,7 @@ final class RemoveDatapointsRequest extends ProtoMessage {
 
 /// Response message for
 /// `IndexService.RemoveDatapoints`
-final class RemoveDatapointsResponse extends ProtoMessage {
+final class RemoveDatapointsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RemoveDatapointsResponse';
 
@@ -51082,7 +51134,8 @@ final class RemoveDatapointsResponse extends ProtoMessage {
 }
 
 /// Runtime operation metadata with regard to Matching Engine Index.
-final class NearestNeighborSearchOperationMetadata extends ProtoMessage {
+final class NearestNeighborSearchOperationMetadata
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.NearestNeighborSearchOperationMetadata';
 
@@ -51134,7 +51187,7 @@ final class NearestNeighborSearchOperationMetadata extends ProtoMessage {
 }
 
 final class NearestNeighborSearchOperationMetadata_RecordError
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.NearestNeighborSearchOperationMetadata.RecordError';
 
@@ -51205,7 +51258,7 @@ final class NearestNeighborSearchOperationMetadata_RecordError
 }
 
 final class NearestNeighborSearchOperationMetadata_RecordError_RecordErrorType
-    extends ProtoEnum {
+    extends protobuf.ProtoEnum {
   /// Default, shall not be used.
   static const errorTypeUnspecified =
       NearestNeighborSearchOperationMetadata_RecordError_RecordErrorType(
@@ -51341,7 +51394,7 @@ final class NearestNeighborSearchOperationMetadata_RecordError_RecordErrorType
 }
 
 final class NearestNeighborSearchOperationMetadata_ContentValidationStats
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.NearestNeighborSearchOperationMetadata.ContentValidationStats';
 
@@ -51422,7 +51475,7 @@ final class NearestNeighborSearchOperationMetadata_ContentValidationStats
 }
 
 /// The storage details for Avro input content.
-final class AvroSource extends ProtoMessage {
+final class AvroSource extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AvroSource';
 
@@ -51445,7 +51498,7 @@ final class AvroSource extends ProtoMessage {
 }
 
 /// The storage details for CSV input content.
-final class CsvSource extends ProtoMessage {
+final class CsvSource extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CsvSource';
 
@@ -51468,7 +51521,7 @@ final class CsvSource extends ProtoMessage {
 }
 
 /// The Google Cloud Storage location for the input content.
-final class GcsSource extends ProtoMessage {
+final class GcsSource extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GcsSource';
 
@@ -51493,7 +51546,7 @@ final class GcsSource extends ProtoMessage {
 }
 
 /// The Google Cloud Storage location where the output is to be written to.
-final class GcsDestination extends ProtoMessage {
+final class GcsDestination extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GcsDestination';
 
@@ -51524,7 +51577,7 @@ final class GcsDestination extends ProtoMessage {
 }
 
 /// The BigQuery location for the input content.
-final class BigQuerySource extends ProtoMessage {
+final class BigQuerySource extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BigQuerySource';
 
@@ -51553,7 +51606,7 @@ final class BigQuerySource extends ProtoMessage {
 }
 
 /// The BigQuery location for the output content.
-final class BigQueryDestination extends ProtoMessage {
+final class BigQueryDestination extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BigQueryDestination';
 
@@ -51589,7 +51642,7 @@ final class BigQueryDestination extends ProtoMessage {
 }
 
 /// The storage details for CSV output content.
-final class CsvDestination extends ProtoMessage {
+final class CsvDestination extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CsvDestination';
 
@@ -51616,7 +51669,7 @@ final class CsvDestination extends ProtoMessage {
 }
 
 /// The storage details for TFRecord output content.
-final class TfrecordDestination extends ProtoMessage {
+final class TfrecordDestination extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TFRecordDestination';
 
@@ -51643,7 +51696,7 @@ final class TfrecordDestination extends ProtoMessage {
 }
 
 /// The Container Registry location for the container image.
-final class ContainerRegistryDestination extends ProtoMessage {
+final class ContainerRegistryDestination extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ContainerRegistryDestination';
 
@@ -51679,7 +51732,7 @@ final class ContainerRegistryDestination extends ProtoMessage {
 }
 
 /// The Google Drive location for the input content.
-final class GoogleDriveSource extends ProtoMessage {
+final class GoogleDriveSource extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GoogleDriveSource';
 
@@ -51707,7 +51760,7 @@ final class GoogleDriveSource extends ProtoMessage {
 }
 
 /// The type and ID of the Google Drive resource.
-final class GoogleDriveSource_ResourceId extends ProtoMessage {
+final class GoogleDriveSource_ResourceId extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GoogleDriveSource.ResourceId';
 
@@ -51749,7 +51802,8 @@ final class GoogleDriveSource_ResourceId extends ProtoMessage {
 }
 
 /// The type of the Google Drive resource.
-final class GoogleDriveSource_ResourceId_ResourceType extends ProtoEnum {
+final class GoogleDriveSource_ResourceId_ResourceType
+    extends protobuf.ProtoEnum {
   /// Unspecified resource type.
   static const resourceTypeUnspecified =
       GoogleDriveSource_ResourceId_ResourceType('RESOURCE_TYPE_UNSPECIFIED');
@@ -51774,7 +51828,7 @@ final class GoogleDriveSource_ResourceId_ResourceType extends ProtoEnum {
 }
 
 /// The input content is encapsulated and uploaded in the request.
-final class DirectUploadSource extends ProtoMessage {
+final class DirectUploadSource extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DirectUploadSource';
 
@@ -51794,7 +51848,7 @@ final class DirectUploadSource extends ProtoMessage {
 }
 
 /// The Slack source for the ImportRagFilesRequest.
-final class SlackSource extends ProtoMessage {
+final class SlackSource extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SlackSource';
 
@@ -51822,7 +51876,7 @@ final class SlackSource extends ProtoMessage {
 }
 
 /// SlackChannels contains the Slack channels and corresponding access token.
-final class SlackSource_SlackChannels extends ProtoMessage {
+final class SlackSource_SlackChannels extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SlackSource.SlackChannels';
 
@@ -51861,7 +51915,8 @@ final class SlackSource_SlackChannels extends ProtoMessage {
 }
 
 /// SlackChannel contains the Slack channel ID and the time range to import.
-final class SlackSource_SlackChannels_SlackChannel extends ProtoMessage {
+final class SlackSource_SlackChannels_SlackChannel
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SlackSource.SlackChannels.SlackChannel';
 
@@ -51907,7 +51962,7 @@ final class SlackSource_SlackChannels_SlackChannel extends ProtoMessage {
 }
 
 /// The Jira source for the ImportRagFilesRequest.
-final class JiraSource extends ProtoMessage {
+final class JiraSource extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.JiraSource';
 
@@ -51935,7 +51990,7 @@ final class JiraSource extends ProtoMessage {
 }
 
 /// JiraQueries contains the Jira queries and corresponding authentication.
-final class JiraSource_JiraQueries extends ProtoMessage {
+final class JiraSource_JiraQueries extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.JiraSource.JiraQueries';
 
@@ -51999,7 +52054,7 @@ final class JiraSource_JiraQueries extends ProtoMessage {
 }
 
 /// The SharePointSources to pass to ImportRagFiles.
-final class SharePointSources extends ProtoMessage {
+final class SharePointSources extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SharePointSources';
 
@@ -52030,7 +52085,7 @@ final class SharePointSources extends ProtoMessage {
 }
 
 /// An individual SharePointSource.
-final class SharePointSources_SharePointSource extends ProtoMessage {
+final class SharePointSources_SharePointSource extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SharePointSources.SharePointSource';
 
@@ -52127,7 +52182,7 @@ final class SharePointSources_SharePointSource extends ProtoMessage {
 
 /// Request message for
 /// `JobService.CreateCustomJob`.
-final class CreateCustomJobRequest extends ProtoMessage {
+final class CreateCustomJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateCustomJobRequest';
 
@@ -52162,7 +52217,7 @@ final class CreateCustomJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `JobService.GetCustomJob`.
-final class GetCustomJobRequest extends ProtoMessage {
+final class GetCustomJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetCustomJobRequest';
 
@@ -52191,7 +52246,7 @@ final class GetCustomJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `JobService.ListCustomJobs`.
-final class ListCustomJobsRequest extends ProtoMessage {
+final class ListCustomJobsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListCustomJobsRequest';
 
@@ -52278,7 +52333,7 @@ final class ListCustomJobsRequest extends ProtoMessage {
 
 /// Response message for
 /// `JobService.ListCustomJobs`
-final class ListCustomJobsResponse extends ProtoMessage {
+final class ListCustomJobsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListCustomJobsResponse';
 
@@ -52320,7 +52375,7 @@ final class ListCustomJobsResponse extends ProtoMessage {
 
 /// Request message for
 /// `JobService.DeleteCustomJob`.
-final class DeleteCustomJobRequest extends ProtoMessage {
+final class DeleteCustomJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteCustomJobRequest';
 
@@ -52349,7 +52404,7 @@ final class DeleteCustomJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `JobService.CancelCustomJob`.
-final class CancelCustomJobRequest extends ProtoMessage {
+final class CancelCustomJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CancelCustomJobRequest';
 
@@ -52378,7 +52433,7 @@ final class CancelCustomJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `JobService.CreateDataLabelingJob`.
-final class CreateDataLabelingJobRequest extends ProtoMessage {
+final class CreateDataLabelingJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateDataLabelingJobRequest';
 
@@ -52418,7 +52473,7 @@ final class CreateDataLabelingJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `JobService.GetDataLabelingJob`.
-final class GetDataLabelingJobRequest extends ProtoMessage {
+final class GetDataLabelingJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetDataLabelingJobRequest';
 
@@ -52447,7 +52502,7 @@ final class GetDataLabelingJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `JobService.ListDataLabelingJobs`.
-final class ListDataLabelingJobsRequest extends ProtoMessage {
+final class ListDataLabelingJobsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListDataLabelingJobsRequest';
 
@@ -52541,7 +52596,7 @@ final class ListDataLabelingJobsRequest extends ProtoMessage {
 
 /// Response message for
 /// `JobService.ListDataLabelingJobs`.
-final class ListDataLabelingJobsResponse extends ProtoMessage {
+final class ListDataLabelingJobsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListDataLabelingJobsResponse';
 
@@ -52585,7 +52640,7 @@ final class ListDataLabelingJobsResponse extends ProtoMessage {
 
 /// Request message for
 /// `JobService.DeleteDataLabelingJob`.
-final class DeleteDataLabelingJobRequest extends ProtoMessage {
+final class DeleteDataLabelingJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteDataLabelingJobRequest';
 
@@ -52615,7 +52670,7 @@ final class DeleteDataLabelingJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `JobService.CancelDataLabelingJob`.
-final class CancelDataLabelingJobRequest extends ProtoMessage {
+final class CancelDataLabelingJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CancelDataLabelingJobRequest';
 
@@ -52645,7 +52700,7 @@ final class CancelDataLabelingJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `JobService.CreateHyperparameterTuningJob`.
-final class CreateHyperparameterTuningJobRequest extends ProtoMessage {
+final class CreateHyperparameterTuningJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateHyperparameterTuningJobRequest';
 
@@ -52691,7 +52746,7 @@ final class CreateHyperparameterTuningJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `JobService.GetHyperparameterTuningJob`.
-final class GetHyperparameterTuningJobRequest extends ProtoMessage {
+final class GetHyperparameterTuningJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetHyperparameterTuningJobRequest';
 
@@ -52723,7 +52778,7 @@ final class GetHyperparameterTuningJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `JobService.ListHyperparameterTuningJobs`.
-final class ListHyperparameterTuningJobsRequest extends ProtoMessage {
+final class ListHyperparameterTuningJobsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListHyperparameterTuningJobsRequest';
 
@@ -52813,7 +52868,7 @@ final class ListHyperparameterTuningJobsRequest extends ProtoMessage {
 
 /// Response message for
 /// `JobService.ListHyperparameterTuningJobs`
-final class ListHyperparameterTuningJobsResponse extends ProtoMessage {
+final class ListHyperparameterTuningJobsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListHyperparameterTuningJobsResponse';
 
@@ -52865,7 +52920,7 @@ final class ListHyperparameterTuningJobsResponse extends ProtoMessage {
 
 /// Request message for
 /// `JobService.DeleteHyperparameterTuningJob`.
-final class DeleteHyperparameterTuningJobRequest extends ProtoMessage {
+final class DeleteHyperparameterTuningJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteHyperparameterTuningJobRequest';
 
@@ -52897,7 +52952,7 @@ final class DeleteHyperparameterTuningJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `JobService.CancelHyperparameterTuningJob`.
-final class CancelHyperparameterTuningJobRequest extends ProtoMessage {
+final class CancelHyperparameterTuningJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CancelHyperparameterTuningJobRequest';
 
@@ -52929,7 +52984,7 @@ final class CancelHyperparameterTuningJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `JobService.CreateNasJob`.
-final class CreateNasJobRequest extends ProtoMessage {
+final class CreateNasJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateNasJobRequest';
 
@@ -52964,7 +53019,7 @@ final class CreateNasJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `JobService.GetNasJob`.
-final class GetNasJobRequest extends ProtoMessage {
+final class GetNasJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetNasJobRequest';
 
@@ -52993,7 +53048,7 @@ final class GetNasJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `JobService.ListNasJobs`.
-final class ListNasJobsRequest extends ProtoMessage {
+final class ListNasJobsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListNasJobsRequest';
 
@@ -53080,7 +53135,7 @@ final class ListNasJobsRequest extends ProtoMessage {
 
 /// Response message for
 /// `JobService.ListNasJobs`
-final class ListNasJobsResponse extends ProtoMessage {
+final class ListNasJobsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListNasJobsResponse';
 
@@ -53124,7 +53179,7 @@ final class ListNasJobsResponse extends ProtoMessage {
 
 /// Request message for
 /// `JobService.DeleteNasJob`.
-final class DeleteNasJobRequest extends ProtoMessage {
+final class DeleteNasJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteNasJobRequest';
 
@@ -53153,7 +53208,7 @@ final class DeleteNasJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `JobService.CancelNasJob`.
-final class CancelNasJobRequest extends ProtoMessage {
+final class CancelNasJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CancelNasJobRequest';
 
@@ -53182,7 +53237,7 @@ final class CancelNasJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `JobService.GetNasTrialDetail`.
-final class GetNasTrialDetailRequest extends ProtoMessage {
+final class GetNasTrialDetailRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetNasTrialDetailRequest';
 
@@ -53211,7 +53266,7 @@ final class GetNasTrialDetailRequest extends ProtoMessage {
 
 /// Request message for
 /// `JobService.ListNasTrialDetails`.
-final class ListNasTrialDetailsRequest extends ProtoMessage {
+final class ListNasTrialDetailsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListNasTrialDetailsRequest';
 
@@ -53267,7 +53322,7 @@ final class ListNasTrialDetailsRequest extends ProtoMessage {
 
 /// Response message for
 /// `JobService.ListNasTrialDetails`
-final class ListNasTrialDetailsResponse extends ProtoMessage {
+final class ListNasTrialDetailsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListNasTrialDetailsResponse';
 
@@ -53313,7 +53368,7 @@ final class ListNasTrialDetailsResponse extends ProtoMessage {
 
 /// Request message for
 /// `JobService.CreateBatchPredictionJob`.
-final class CreateBatchPredictionJobRequest extends ProtoMessage {
+final class CreateBatchPredictionJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateBatchPredictionJobRequest';
 
@@ -53356,7 +53411,7 @@ final class CreateBatchPredictionJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `JobService.GetBatchPredictionJob`.
-final class GetBatchPredictionJobRequest extends ProtoMessage {
+final class GetBatchPredictionJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetBatchPredictionJobRequest';
 
@@ -53386,7 +53441,7 @@ final class GetBatchPredictionJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `JobService.ListBatchPredictionJobs`.
-final class ListBatchPredictionJobsRequest extends ProtoMessage {
+final class ListBatchPredictionJobsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListBatchPredictionJobsRequest';
 
@@ -53474,7 +53529,7 @@ final class ListBatchPredictionJobsRequest extends ProtoMessage {
 
 /// Response message for
 /// `JobService.ListBatchPredictionJobs`
-final class ListBatchPredictionJobsResponse extends ProtoMessage {
+final class ListBatchPredictionJobsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListBatchPredictionJobsResponse';
 
@@ -53522,7 +53577,7 @@ final class ListBatchPredictionJobsResponse extends ProtoMessage {
 
 /// Request message for
 /// `JobService.DeleteBatchPredictionJob`.
-final class DeleteBatchPredictionJobRequest extends ProtoMessage {
+final class DeleteBatchPredictionJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteBatchPredictionJobRequest';
 
@@ -53552,7 +53607,7 @@ final class DeleteBatchPredictionJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `JobService.CancelBatchPredictionJob`.
-final class CancelBatchPredictionJobRequest extends ProtoMessage {
+final class CancelBatchPredictionJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CancelBatchPredictionJobRequest';
 
@@ -53582,7 +53637,8 @@ final class CancelBatchPredictionJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `JobService.CreateModelDeploymentMonitoringJob`.
-final class CreateModelDeploymentMonitoringJobRequest extends ProtoMessage {
+final class CreateModelDeploymentMonitoringJobRequest
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateModelDeploymentMonitoringJobRequest';
 
@@ -53628,7 +53684,7 @@ final class CreateModelDeploymentMonitoringJobRequest extends ProtoMessage {
 /// Request message for
 /// `JobService.SearchModelDeploymentMonitoringStatsAnomalies`.
 final class SearchModelDeploymentMonitoringStatsAnomaliesRequest
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SearchModelDeploymentMonitoringStatsAnomaliesRequest';
 
@@ -53728,7 +53784,7 @@ final class SearchModelDeploymentMonitoringStatsAnomaliesRequest
 
 /// Stats requested for specific objective.
 final class SearchModelDeploymentMonitoringStatsAnomaliesRequest_StatsAnomaliesObjective
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SearchModelDeploymentMonitoringStatsAnomaliesRequest.StatsAnomaliesObjective';
 
@@ -53781,7 +53837,7 @@ final class SearchModelDeploymentMonitoringStatsAnomaliesRequest_StatsAnomaliesO
 /// Response message for
 /// `JobService.SearchModelDeploymentMonitoringStatsAnomalies`.
 final class SearchModelDeploymentMonitoringStatsAnomaliesResponse
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SearchModelDeploymentMonitoringStatsAnomaliesResponse';
 
@@ -53833,7 +53889,8 @@ final class SearchModelDeploymentMonitoringStatsAnomaliesResponse
 
 /// Request message for
 /// `JobService.GetModelDeploymentMonitoringJob`.
-final class GetModelDeploymentMonitoringJobRequest extends ProtoMessage {
+final class GetModelDeploymentMonitoringJobRequest
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetModelDeploymentMonitoringJobRequest';
 
@@ -53865,7 +53922,8 @@ final class GetModelDeploymentMonitoringJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `JobService.ListModelDeploymentMonitoringJobs`.
-final class ListModelDeploymentMonitoringJobsRequest extends ProtoMessage {
+final class ListModelDeploymentMonitoringJobsRequest
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListModelDeploymentMonitoringJobsRequest';
 
@@ -53949,7 +54007,8 @@ final class ListModelDeploymentMonitoringJobsRequest extends ProtoMessage {
 
 /// Response message for
 /// `JobService.ListModelDeploymentMonitoringJobs`.
-final class ListModelDeploymentMonitoringJobsResponse extends ProtoMessage {
+final class ListModelDeploymentMonitoringJobsResponse
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListModelDeploymentMonitoringJobsResponse';
 
@@ -53999,7 +54058,8 @@ final class ListModelDeploymentMonitoringJobsResponse extends ProtoMessage {
 
 /// Request message for
 /// `JobService.UpdateModelDeploymentMonitoringJob`.
-final class UpdateModelDeploymentMonitoringJobRequest extends ProtoMessage {
+final class UpdateModelDeploymentMonitoringJobRequest
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateModelDeploymentMonitoringJobRequest';
 
@@ -54066,7 +54126,8 @@ final class UpdateModelDeploymentMonitoringJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `JobService.DeleteModelDeploymentMonitoringJob`.
-final class DeleteModelDeploymentMonitoringJobRequest extends ProtoMessage {
+final class DeleteModelDeploymentMonitoringJobRequest
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteModelDeploymentMonitoringJobRequest';
 
@@ -54098,7 +54159,8 @@ final class DeleteModelDeploymentMonitoringJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `JobService.PauseModelDeploymentMonitoringJob`.
-final class PauseModelDeploymentMonitoringJobRequest extends ProtoMessage {
+final class PauseModelDeploymentMonitoringJobRequest
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PauseModelDeploymentMonitoringJobRequest';
 
@@ -54130,7 +54192,8 @@ final class PauseModelDeploymentMonitoringJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `JobService.ResumeModelDeploymentMonitoringJob`.
-final class ResumeModelDeploymentMonitoringJobRequest extends ProtoMessage {
+final class ResumeModelDeploymentMonitoringJobRequest
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ResumeModelDeploymentMonitoringJobRequest';
 
@@ -54163,7 +54226,7 @@ final class ResumeModelDeploymentMonitoringJobRequest extends ProtoMessage {
 /// Runtime operation information for
 /// `JobService.UpdateModelDeploymentMonitoringJob`.
 final class UpdateModelDeploymentMonitoringJobOperationMetadata
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateModelDeploymentMonitoringJobOperationMetadata';
 
@@ -54197,7 +54260,7 @@ final class UpdateModelDeploymentMonitoringJobOperationMetadata
 
 /// A subgraph of the overall lineage graph. Event edges connect Artifact and
 /// Execution nodes.
-final class LineageSubgraph extends ProtoMessage {
+final class LineageSubgraph extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.LineageSubgraph';
 
@@ -54235,7 +54298,7 @@ final class LineageSubgraph extends ProtoMessage {
 }
 
 /// Request message for ComputeTokens RPC call.
-final class ComputeTokensRequest extends ProtoMessage {
+final class ComputeTokensRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ComputeTokensRequest';
 
@@ -54296,7 +54359,7 @@ final class ComputeTokensRequest extends ProtoMessage {
 }
 
 /// Tokens info with a list of tokens and the corresponding list of token ids.
-final class TokensInfo extends ProtoMessage {
+final class TokensInfo extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TokensInfo';
 
@@ -54337,7 +54400,7 @@ final class TokensInfo extends ProtoMessage {
 }
 
 /// Response message for ComputeTokens RPC call.
-final class ComputeTokensResponse extends ProtoMessage {
+final class ComputeTokensResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ComputeTokensResponse';
 
@@ -54364,7 +54427,7 @@ final class ComputeTokensResponse extends ProtoMessage {
 }
 
 /// Specification of a single machine.
-final class MachineSpec extends ProtoMessage {
+final class MachineSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.MachineSpec';
 
@@ -54479,7 +54542,7 @@ final class MachineSpec extends ProtoMessage {
 
 /// A description of resources that are dedicated to a DeployedModel or
 /// DeployedIndex, and that need a higher degree of manual configuration.
-final class DedicatedResources extends ProtoMessage {
+final class DedicatedResources extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DedicatedResources';
 
@@ -54634,7 +54697,7 @@ final class DedicatedResources extends ProtoMessage {
 }
 
 /// Specification for scale-to-zero feature.
-final class DedicatedResources_ScaleToZeroSpec extends ProtoMessage {
+final class DedicatedResources_ScaleToZeroSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DedicatedResources.ScaleToZeroSpec';
 
@@ -54685,7 +54748,7 @@ final class DedicatedResources_ScaleToZeroSpec extends ProtoMessage {
 /// A description of resources that to large degree are decided by Vertex AI,
 /// and require only a modest additional configuration.
 /// Each Model supporting these resources documents its specific guidelines.
-final class AutomaticResources extends ProtoMessage {
+final class AutomaticResources extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AutomaticResources';
 
@@ -54737,7 +54800,7 @@ final class AutomaticResources extends ProtoMessage {
 
 /// A description of resources that are used for performing batch operations, are
 /// dedicated to a Model, and need manual configuration.
-final class BatchDedicatedResources extends ProtoMessage {
+final class BatchDedicatedResources extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BatchDedicatedResources';
 
@@ -54805,7 +54868,7 @@ final class BatchDedicatedResources extends ProtoMessage {
 }
 
 /// Statistics information about resource consumption.
-final class ResourcesConsumed extends ProtoMessage {
+final class ResourcesConsumed extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ResourcesConsumed';
 
@@ -54837,7 +54900,7 @@ final class ResourcesConsumed extends ProtoMessage {
 }
 
 /// Represents the spec of disk options.
-final class DiskSpec extends ProtoMessage {
+final class DiskSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DiskSpec';
 
@@ -54880,7 +54943,7 @@ final class DiskSpec extends ProtoMessage {
 
 /// Represents the spec of [persistent
 /// disk][https://cloud.google.com/compute/docs/disks/persistent-disks] options.
-final class PersistentDiskSpec extends ProtoMessage {
+final class PersistentDiskSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PersistentDiskSpec';
 
@@ -54923,7 +54986,7 @@ final class PersistentDiskSpec extends ProtoMessage {
 }
 
 /// Represents a mount configuration for Network File System (NFS) to mount.
-final class NfsMount extends ProtoMessage {
+final class NfsMount extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.NfsMount';
 
@@ -54973,7 +55036,7 @@ final class NfsMount extends ProtoMessage {
 /// The metric specification that defines the target resource utilization
 /// (CPU utilization, accelerator's duty cycle, and so on) for calculating the
 /// desired replica count.
-final class AutoscalingMetricSpec extends ProtoMessage {
+final class AutoscalingMetricSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AutoscalingMetricSpec';
 
@@ -55034,7 +55097,7 @@ final class AutoscalingMetricSpec extends ProtoMessage {
 /// A set of Shielded Instance options.
 /// See [Images using supported Shielded VM
 /// features](https://cloud.google.com/compute/docs/instances/modifying-shielded-vm).
-final class ShieldedVmConfig extends ProtoMessage {
+final class ShieldedVmConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ShieldedVmConfig';
 
@@ -55069,7 +55132,7 @@ final class ShieldedVmConfig extends ProtoMessage {
 
 /// FlexStart is used to schedule the deployment workload on DWS resource. It
 /// contains the max duration of the deployment.
-final class FlexStart extends ProtoMessage {
+final class FlexStart extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FlexStart';
 
@@ -55102,7 +55165,7 @@ final class FlexStart extends ProtoMessage {
 }
 
 /// Manual batch tuning parameters.
-final class ManualBatchTuningParameters extends ProtoMessage {
+final class ManualBatchTuningParameters extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ManualBatchTuningParameters';
 
@@ -55135,7 +55198,7 @@ final class ManualBatchTuningParameters extends ProtoMessage {
 
 /// The request message for
 /// `MatchService.FindNeighbors`.
-final class FindNeighborsRequest extends ProtoMessage {
+final class FindNeighborsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FindNeighborsRequest';
 
@@ -55205,7 +55268,7 @@ final class FindNeighborsRequest extends ProtoMessage {
 
 /// A query to find a number of the nearest neighbors (most similar vectors)
 /// of a vector.
-final class FindNeighborsRequest_Query extends ProtoMessage {
+final class FindNeighborsRequest_Query extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FindNeighborsRequest.Query';
 
@@ -55297,7 +55360,7 @@ final class FindNeighborsRequest_Query extends ProtoMessage {
 }
 
 /// Parameters for RRF algorithm that combines search results.
-final class FindNeighborsRequest_Query_Rrf extends ProtoMessage {
+final class FindNeighborsRequest_Query_Rrf extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FindNeighborsRequest.Query.RRF';
 
@@ -55326,7 +55389,7 @@ final class FindNeighborsRequest_Query_Rrf extends ProtoMessage {
 
 /// The response message for
 /// `MatchService.FindNeighbors`.
-final class FindNeighborsResponse extends ProtoMessage {
+final class FindNeighborsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FindNeighborsResponse';
 
@@ -55357,7 +55420,7 @@ final class FindNeighborsResponse extends ProtoMessage {
 }
 
 /// A neighbor of the query vector.
-final class FindNeighborsResponse_Neighbor extends ProtoMessage {
+final class FindNeighborsResponse_Neighbor extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FindNeighborsResponse.Neighbor';
 
@@ -55408,7 +55471,8 @@ final class FindNeighborsResponse_Neighbor extends ProtoMessage {
 }
 
 /// Nearest neighbors for one query.
-final class FindNeighborsResponse_NearestNeighbors extends ProtoMessage {
+final class FindNeighborsResponse_NearestNeighbors
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FindNeighborsResponse.NearestNeighbors';
 
@@ -55450,7 +55514,7 @@ final class FindNeighborsResponse_NearestNeighbors extends ProtoMessage {
 
 /// The request message for
 /// `MatchService.ReadIndexDatapoints`.
-final class ReadIndexDatapointsRequest extends ProtoMessage {
+final class ReadIndexDatapointsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ReadIndexDatapointsRequest';
 
@@ -55500,7 +55564,7 @@ final class ReadIndexDatapointsRequest extends ProtoMessage {
 
 /// The response message for
 /// `MatchService.ReadIndexDatapoints`.
-final class ReadIndexDatapointsResponse extends ProtoMessage {
+final class ReadIndexDatapointsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ReadIndexDatapointsResponse';
 
@@ -55528,7 +55592,7 @@ final class ReadIndexDatapointsResponse extends ProtoMessage {
 }
 
 /// A memory.
-final class Memory extends ProtoMessage {
+final class Memory extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Memory';
 
@@ -55621,7 +55685,7 @@ final class Memory extends ProtoMessage {
 
 /// Request message for
 /// `MemoryBankService.CreateMemory`.
-final class CreateMemoryRequest extends ProtoMessage {
+final class CreateMemoryRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateMemoryRequest';
 
@@ -55658,7 +55722,7 @@ final class CreateMemoryRequest extends ProtoMessage {
 /// Details of
 /// `MemoryBankService.CreateMemory`
 /// operation.
-final class CreateMemoryOperationMetadata extends ProtoMessage {
+final class CreateMemoryOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateMemoryOperationMetadata';
 
@@ -55690,7 +55754,7 @@ final class CreateMemoryOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `MemoryBankService.GetMemory`.
-final class GetMemoryRequest extends ProtoMessage {
+final class GetMemoryRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetMemoryRequest';
 
@@ -55719,7 +55783,7 @@ final class GetMemoryRequest extends ProtoMessage {
 
 /// Request message for
 /// `MemoryBankService.UpdateMemory`.
-final class UpdateMemoryRequest extends ProtoMessage {
+final class UpdateMemoryRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateMemoryRequest';
 
@@ -55759,7 +55823,7 @@ final class UpdateMemoryRequest extends ProtoMessage {
 /// Details of
 /// `MemoryBankService.UpdateMemory`
 /// operation.
-final class UpdateMemoryOperationMetadata extends ProtoMessage {
+final class UpdateMemoryOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateMemoryOperationMetadata';
 
@@ -55791,7 +55855,7 @@ final class UpdateMemoryOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `MemoryBankService.ListMemories`.
-final class ListMemoriesRequest extends ProtoMessage {
+final class ListMemoriesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListMemoriesRequest';
 
@@ -55853,7 +55917,7 @@ final class ListMemoriesRequest extends ProtoMessage {
 
 /// Response message for
 /// `MemoryBankService.ListMemories`.
-final class ListMemoriesResponse extends ProtoMessage {
+final class ListMemoriesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListMemoriesResponse';
 
@@ -55895,7 +55959,7 @@ final class ListMemoriesResponse extends ProtoMessage {
 
 /// Request message for
 /// `MemoryBankService.DeleteMemory`.
-final class DeleteMemoryRequest extends ProtoMessage {
+final class DeleteMemoryRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteMemoryRequest';
 
@@ -55925,7 +55989,7 @@ final class DeleteMemoryRequest extends ProtoMessage {
 /// Details of
 /// `MemoryBankService.DeleteMemory`
 /// operation.
-final class DeleteMemoryOperationMetadata extends ProtoMessage {
+final class DeleteMemoryOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteMemoryOperationMetadata';
 
@@ -55957,7 +56021,7 @@ final class DeleteMemoryOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `MemoryBankService.GenerateMemories`.
-final class GenerateMemoriesRequest extends ProtoMessage {
+final class GenerateMemoriesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GenerateMemoriesRequest';
 
@@ -56051,7 +56115,8 @@ final class GenerateMemoriesRequest extends ProtoMessage {
 /// Defines an Agent Engine Session from which to generate the memories. If
 /// `scope` is not provided, the scope will be extracted from the Session
 /// (i.e. {"user_id": sesison.user_id}).
-final class GenerateMemoriesRequest_VertexSessionSource extends ProtoMessage {
+final class GenerateMemoriesRequest_VertexSessionSource
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GenerateMemoriesRequest.VertexSessionSource';
 
@@ -56102,7 +56167,8 @@ final class GenerateMemoriesRequest_VertexSessionSource extends ProtoMessage {
 }
 
 /// Defines a direct source of content from which to generate the memories.
-final class GenerateMemoriesRequest_DirectContentsSource extends ProtoMessage {
+final class GenerateMemoriesRequest_DirectContentsSource
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GenerateMemoriesRequest.DirectContentsSource';
 
@@ -56135,7 +56201,7 @@ final class GenerateMemoriesRequest_DirectContentsSource extends ProtoMessage {
 
 /// A single piece of conversation from which to generate memories.
 final class GenerateMemoriesRequest_DirectContentsSource_Event
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GenerateMemoriesRequest.DirectContentsSource.Event';
 
@@ -56164,7 +56230,8 @@ final class GenerateMemoriesRequest_DirectContentsSource_Event
 
 /// Defines a direct source of memories that should be uploaded to Memory Bank
 /// with consolidation.
-final class GenerateMemoriesRequest_DirectMemoriesSource extends ProtoMessage {
+final class GenerateMemoriesRequest_DirectMemoriesSource
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GenerateMemoriesRequest.DirectMemoriesSource';
 
@@ -56200,7 +56267,7 @@ final class GenerateMemoriesRequest_DirectMemoriesSource extends ProtoMessage {
 
 /// A direct memory to upload to Memory Bank.
 final class GenerateMemoriesRequest_DirectMemoriesSource_DirectMemory
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GenerateMemoriesRequest.DirectMemoriesSource.DirectMemory';
 
@@ -56232,7 +56299,7 @@ final class GenerateMemoriesRequest_DirectMemoriesSource_DirectMemory
 
 /// Response message for
 /// `MemoryBankService.GenerateMemories`.
-final class GenerateMemoriesResponse extends ProtoMessage {
+final class GenerateMemoriesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GenerateMemoriesResponse';
 
@@ -56264,7 +56331,8 @@ final class GenerateMemoriesResponse extends ProtoMessage {
 }
 
 /// A memory generated by the operation.
-final class GenerateMemoriesResponse_GeneratedMemory extends ProtoMessage {
+final class GenerateMemoriesResponse_GeneratedMemory
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GenerateMemoriesResponse.GeneratedMemory';
 
@@ -56305,7 +56373,8 @@ final class GenerateMemoriesResponse_GeneratedMemory extends ProtoMessage {
 }
 
 /// Actions that can be performed on a Memory.
-final class GenerateMemoriesResponse_GeneratedMemory_Action extends ProtoEnum {
+final class GenerateMemoriesResponse_GeneratedMemory_Action
+    extends protobuf.ProtoEnum {
   /// Action is unspecified.
   static const actionUnspecified =
       GenerateMemoriesResponse_GeneratedMemory_Action('ACTION_UNSPECIFIED');
@@ -56339,7 +56408,7 @@ final class GenerateMemoriesResponse_GeneratedMemory_Action extends ProtoEnum {
 /// Details of
 /// `MemoryBankService.GenerateMemories`
 /// operation.
-final class GenerateMemoriesOperationMetadata extends ProtoMessage {
+final class GenerateMemoriesOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GenerateMemoriesOperationMetadata';
 
@@ -56373,7 +56442,7 @@ final class GenerateMemoriesOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `MemoryBankService.RetrieveMemories`.
-final class RetrieveMemoriesRequest extends ProtoMessage {
+final class RetrieveMemoriesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RetrieveMemoriesRequest';
 
@@ -56437,7 +56506,7 @@ final class RetrieveMemoriesRequest extends ProtoMessage {
 
 /// Parameters for semantic similarity search based retrieval.
 final class RetrieveMemoriesRequest_SimilaritySearchParams
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RetrieveMemoriesRequest.SimilaritySearchParams';
 
@@ -56484,7 +56553,8 @@ final class RetrieveMemoriesRequest_SimilaritySearchParams
 }
 
 /// Parameters for simple (non-similarity search) retrieval.
-final class RetrieveMemoriesRequest_SimpleRetrievalParams extends ProtoMessage {
+final class RetrieveMemoriesRequest_SimpleRetrievalParams
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RetrieveMemoriesRequest.SimpleRetrievalParams';
 
@@ -56530,7 +56600,7 @@ final class RetrieveMemoriesRequest_SimpleRetrievalParams extends ProtoMessage {
 
 /// Response message for
 /// `MemoryBankService.RetrieveMemories`.
-final class RetrieveMemoriesResponse extends ProtoMessage {
+final class RetrieveMemoriesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RetrieveMemoriesResponse';
 
@@ -56574,7 +56644,8 @@ final class RetrieveMemoriesResponse extends ProtoMessage {
 }
 
 /// A retrieved memory.
-final class RetrieveMemoriesResponse_RetrievedMemory extends ProtoMessage {
+final class RetrieveMemoriesResponse_RetrievedMemory
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RetrieveMemoriesResponse.RetrievedMemory';
 
@@ -56614,7 +56685,7 @@ final class RetrieveMemoriesResponse_RetrievedMemory extends ProtoMessage {
 }
 
 /// Instance of a general MetadataSchema.
-final class MetadataSchema extends ProtoMessage {
+final class MetadataSchema extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.MetadataSchema';
 
@@ -56694,7 +56765,7 @@ final class MetadataSchema extends ProtoMessage {
 }
 
 /// Describes the type of the MetadataSchema.
-final class MetadataSchema_MetadataSchemaType extends ProtoEnum {
+final class MetadataSchema_MetadataSchemaType extends protobuf.ProtoEnum {
   /// Unspecified type for the MetadataSchema.
   static const metadataSchemaTypeUnspecified =
       MetadataSchema_MetadataSchemaType('METADATA_SCHEMA_TYPE_UNSPECIFIED');
@@ -56723,7 +56794,7 @@ final class MetadataSchema_MetadataSchemaType extends ProtoEnum {
 
 /// Request message for
 /// `MetadataService.CreateMetadataStore`.
-final class CreateMetadataStoreRequest extends ProtoMessage {
+final class CreateMetadataStoreRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateMetadataStoreRequest';
 
@@ -56780,7 +56851,7 @@ final class CreateMetadataStoreRequest extends ProtoMessage {
 
 /// Details of operations that perform
 /// `MetadataService.CreateMetadataStore`.
-final class CreateMetadataStoreOperationMetadata extends ProtoMessage {
+final class CreateMetadataStoreOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateMetadataStoreOperationMetadata';
 
@@ -56814,7 +56885,7 @@ final class CreateMetadataStoreOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `MetadataService.GetMetadataStore`.
-final class GetMetadataStoreRequest extends ProtoMessage {
+final class GetMetadataStoreRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetMetadataStoreRequest';
 
@@ -56843,7 +56914,7 @@ final class GetMetadataStoreRequest extends ProtoMessage {
 
 /// Request message for
 /// `MetadataService.ListMetadataStores`.
-final class ListMetadataStoresRequest extends ProtoMessage {
+final class ListMetadataStoresRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListMetadataStoresRequest';
 
@@ -56902,7 +56973,7 @@ final class ListMetadataStoresRequest extends ProtoMessage {
 
 /// Response message for
 /// `MetadataService.ListMetadataStores`.
-final class ListMetadataStoresResponse extends ProtoMessage {
+final class ListMetadataStoresResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListMetadataStoresResponse';
 
@@ -56947,7 +57018,7 @@ final class ListMetadataStoresResponse extends ProtoMessage {
 
 /// Request message for
 /// `MetadataService.DeleteMetadataStore`.
-final class DeleteMetadataStoreRequest extends ProtoMessage {
+final class DeleteMetadataStoreRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteMetadataStoreRequest';
 
@@ -56983,7 +57054,7 @@ final class DeleteMetadataStoreRequest extends ProtoMessage {
 
 /// Details of operations that perform
 /// `MetadataService.DeleteMetadataStore`.
-final class DeleteMetadataStoreOperationMetadata extends ProtoMessage {
+final class DeleteMetadataStoreOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteMetadataStoreOperationMetadata';
 
@@ -57017,7 +57088,7 @@ final class DeleteMetadataStoreOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `MetadataService.CreateArtifact`.
-final class CreateArtifactRequest extends ProtoMessage {
+final class CreateArtifactRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateArtifactRequest';
 
@@ -57074,7 +57145,7 @@ final class CreateArtifactRequest extends ProtoMessage {
 
 /// Request message for
 /// `MetadataService.GetArtifact`.
-final class GetArtifactRequest extends ProtoMessage {
+final class GetArtifactRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetArtifactRequest';
 
@@ -57103,7 +57174,7 @@ final class GetArtifactRequest extends ProtoMessage {
 
 /// Request message for
 /// `MetadataService.ListArtifacts`.
-final class ListArtifactsRequest extends ProtoMessage {
+final class ListArtifactsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListArtifactsRequest';
 
@@ -57210,7 +57281,7 @@ final class ListArtifactsRequest extends ProtoMessage {
 
 /// Response message for
 /// `MetadataService.ListArtifacts`.
-final class ListArtifactsResponse extends ProtoMessage {
+final class ListArtifactsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListArtifactsResponse';
 
@@ -57252,7 +57323,7 @@ final class ListArtifactsResponse extends ProtoMessage {
 
 /// Request message for
 /// `MetadataService.UpdateArtifact`.
-final class UpdateArtifactRequest extends ProtoMessage {
+final class UpdateArtifactRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateArtifactRequest';
 
@@ -57305,7 +57376,7 @@ final class UpdateArtifactRequest extends ProtoMessage {
 
 /// Request message for
 /// `MetadataService.DeleteArtifact`.
-final class DeleteArtifactRequest extends ProtoMessage {
+final class DeleteArtifactRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteArtifactRequest';
 
@@ -57340,7 +57411,7 @@ final class DeleteArtifactRequest extends ProtoMessage {
 
 /// Request message for
 /// `MetadataService.PurgeArtifacts`.
-final class PurgeArtifactsRequest extends ProtoMessage {
+final class PurgeArtifactsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PurgeArtifactsRequest';
 
@@ -57391,7 +57462,7 @@ final class PurgeArtifactsRequest extends ProtoMessage {
 
 /// Response message for
 /// `MetadataService.PurgeArtifacts`.
-final class PurgeArtifactsResponse extends ProtoMessage {
+final class PurgeArtifactsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PurgeArtifactsResponse';
 
@@ -57433,7 +57504,7 @@ final class PurgeArtifactsResponse extends ProtoMessage {
 
 /// Details of operations that perform
 /// `MetadataService.PurgeArtifacts`.
-final class PurgeArtifactsMetadata extends ProtoMessage {
+final class PurgeArtifactsMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PurgeArtifactsMetadata';
 
@@ -57464,7 +57535,7 @@ final class PurgeArtifactsMetadata extends ProtoMessage {
 
 /// Request message for
 /// `MetadataService.CreateContext`.
-final class CreateContextRequest extends ProtoMessage {
+final class CreateContextRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateContextRequest';
 
@@ -57520,7 +57591,7 @@ final class CreateContextRequest extends ProtoMessage {
 
 /// Request message for
 /// `MetadataService.GetContext`.
-final class GetContextRequest extends ProtoMessage {
+final class GetContextRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetContextRequest';
 
@@ -57549,7 +57620,7 @@ final class GetContextRequest extends ProtoMessage {
 
 /// Request message for
 /// `MetadataService.ListContexts`
-final class ListContextsRequest extends ProtoMessage {
+final class ListContextsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListContextsRequest';
 
@@ -57660,7 +57731,7 @@ final class ListContextsRequest extends ProtoMessage {
 
 /// Response message for
 /// `MetadataService.ListContexts`.
-final class ListContextsResponse extends ProtoMessage {
+final class ListContextsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListContextsResponse';
 
@@ -57702,7 +57773,7 @@ final class ListContextsResponse extends ProtoMessage {
 
 /// Request message for
 /// `MetadataService.UpdateContext`.
-final class UpdateContextRequest extends ProtoMessage {
+final class UpdateContextRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateContextRequest';
 
@@ -57754,7 +57825,7 @@ final class UpdateContextRequest extends ProtoMessage {
 
 /// Request message for
 /// `MetadataService.DeleteContext`.
-final class DeleteContextRequest extends ProtoMessage {
+final class DeleteContextRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteContextRequest';
 
@@ -57805,7 +57876,7 @@ final class DeleteContextRequest extends ProtoMessage {
 
 /// Request message for
 /// `MetadataService.PurgeContexts`.
-final class PurgeContextsRequest extends ProtoMessage {
+final class PurgeContextsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PurgeContextsRequest';
 
@@ -57856,7 +57927,7 @@ final class PurgeContextsRequest extends ProtoMessage {
 
 /// Response message for
 /// `MetadataService.PurgeContexts`.
-final class PurgeContextsResponse extends ProtoMessage {
+final class PurgeContextsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PurgeContextsResponse';
 
@@ -57898,7 +57969,7 @@ final class PurgeContextsResponse extends ProtoMessage {
 
 /// Details of operations that perform
 /// `MetadataService.PurgeContexts`.
-final class PurgeContextsMetadata extends ProtoMessage {
+final class PurgeContextsMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PurgeContextsMetadata';
 
@@ -57929,7 +58000,8 @@ final class PurgeContextsMetadata extends ProtoMessage {
 
 /// Request message for
 /// `MetadataService.AddContextArtifactsAndExecutions`.
-final class AddContextArtifactsAndExecutionsRequest extends ProtoMessage {
+final class AddContextArtifactsAndExecutionsRequest
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AddContextArtifactsAndExecutionsRequest';
 
@@ -57985,7 +58057,8 @@ final class AddContextArtifactsAndExecutionsRequest extends ProtoMessage {
 
 /// Response message for
 /// `MetadataService.AddContextArtifactsAndExecutions`.
-final class AddContextArtifactsAndExecutionsResponse extends ProtoMessage {
+final class AddContextArtifactsAndExecutionsResponse
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AddContextArtifactsAndExecutionsResponse';
 
@@ -58008,7 +58081,7 @@ final class AddContextArtifactsAndExecutionsResponse extends ProtoMessage {
 
 /// Request message for
 /// `MetadataService.AddContextChildren`.
-final class AddContextChildrenRequest extends ProtoMessage {
+final class AddContextChildrenRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AddContextChildrenRequest';
 
@@ -58048,7 +58121,7 @@ final class AddContextChildrenRequest extends ProtoMessage {
 
 /// Response message for
 /// `MetadataService.AddContextChildren`.
-final class AddContextChildrenResponse extends ProtoMessage {
+final class AddContextChildrenResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AddContextChildrenResponse';
 
@@ -58069,7 +58142,7 @@ final class AddContextChildrenResponse extends ProtoMessage {
 
 /// Request message for
 /// `MetadataService.DeleteContextChildrenRequest`.
-final class RemoveContextChildrenRequest extends ProtoMessage {
+final class RemoveContextChildrenRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RemoveContextChildrenRequest';
 
@@ -58109,7 +58182,7 @@ final class RemoveContextChildrenRequest extends ProtoMessage {
 
 /// Response message for
 /// `MetadataService.RemoveContextChildren`.
-final class RemoveContextChildrenResponse extends ProtoMessage {
+final class RemoveContextChildrenResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RemoveContextChildrenResponse';
 
@@ -58130,7 +58203,7 @@ final class RemoveContextChildrenResponse extends ProtoMessage {
 
 /// Request message for
 /// `MetadataService.QueryContextLineageSubgraph`.
-final class QueryContextLineageSubgraphRequest extends ProtoMessage {
+final class QueryContextLineageSubgraphRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.QueryContextLineageSubgraphRequest';
 
@@ -58167,7 +58240,7 @@ final class QueryContextLineageSubgraphRequest extends ProtoMessage {
 
 /// Request message for
 /// `MetadataService.CreateExecution`.
-final class CreateExecutionRequest extends ProtoMessage {
+final class CreateExecutionRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateExecutionRequest';
 
@@ -58225,7 +58298,7 @@ final class CreateExecutionRequest extends ProtoMessage {
 
 /// Request message for
 /// `MetadataService.GetExecution`.
-final class GetExecutionRequest extends ProtoMessage {
+final class GetExecutionRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetExecutionRequest';
 
@@ -58254,7 +58327,7 @@ final class GetExecutionRequest extends ProtoMessage {
 
 /// Request message for
 /// `MetadataService.ListExecutions`.
-final class ListExecutionsRequest extends ProtoMessage {
+final class ListExecutionsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListExecutionsRequest';
 
@@ -58361,7 +58434,7 @@ final class ListExecutionsRequest extends ProtoMessage {
 
 /// Response message for
 /// `MetadataService.ListExecutions`.
-final class ListExecutionsResponse extends ProtoMessage {
+final class ListExecutionsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListExecutionsResponse';
 
@@ -58403,7 +58476,7 @@ final class ListExecutionsResponse extends ProtoMessage {
 
 /// Request message for
 /// `MetadataService.UpdateExecution`.
-final class UpdateExecutionRequest extends ProtoMessage {
+final class UpdateExecutionRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateExecutionRequest';
 
@@ -58456,7 +58529,7 @@ final class UpdateExecutionRequest extends ProtoMessage {
 
 /// Request message for
 /// `MetadataService.DeleteExecution`.
-final class DeleteExecutionRequest extends ProtoMessage {
+final class DeleteExecutionRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteExecutionRequest';
 
@@ -58491,7 +58564,7 @@ final class DeleteExecutionRequest extends ProtoMessage {
 
 /// Request message for
 /// `MetadataService.PurgeExecutions`.
-final class PurgeExecutionsRequest extends ProtoMessage {
+final class PurgeExecutionsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PurgeExecutionsRequest';
 
@@ -58542,7 +58615,7 @@ final class PurgeExecutionsRequest extends ProtoMessage {
 
 /// Response message for
 /// `MetadataService.PurgeExecutions`.
-final class PurgeExecutionsResponse extends ProtoMessage {
+final class PurgeExecutionsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PurgeExecutionsResponse';
 
@@ -58585,7 +58658,7 @@ final class PurgeExecutionsResponse extends ProtoMessage {
 
 /// Details of operations that perform
 /// `MetadataService.PurgeExecutions`.
-final class PurgeExecutionsMetadata extends ProtoMessage {
+final class PurgeExecutionsMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PurgeExecutionsMetadata';
 
@@ -58616,7 +58689,7 @@ final class PurgeExecutionsMetadata extends ProtoMessage {
 
 /// Request message for
 /// `MetadataService.AddExecutionEvents`.
-final class AddExecutionEventsRequest extends ProtoMessage {
+final class AddExecutionEventsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AddExecutionEventsRequest';
 
@@ -58656,7 +58729,7 @@ final class AddExecutionEventsRequest extends ProtoMessage {
 
 /// Response message for
 /// `MetadataService.AddExecutionEvents`.
-final class AddExecutionEventsResponse extends ProtoMessage {
+final class AddExecutionEventsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AddExecutionEventsResponse';
 
@@ -58677,7 +58750,8 @@ final class AddExecutionEventsResponse extends ProtoMessage {
 
 /// Request message for
 /// `MetadataService.QueryExecutionInputsAndOutputs`.
-final class QueryExecutionInputsAndOutputsRequest extends ProtoMessage {
+final class QueryExecutionInputsAndOutputsRequest
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.QueryExecutionInputsAndOutputsRequest';
 
@@ -58709,7 +58783,7 @@ final class QueryExecutionInputsAndOutputsRequest extends ProtoMessage {
 
 /// Request message for
 /// `MetadataService.CreateMetadataSchema`.
-final class CreateMetadataSchemaRequest extends ProtoMessage {
+final class CreateMetadataSchemaRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateMetadataSchemaRequest';
 
@@ -58766,7 +58840,7 @@ final class CreateMetadataSchemaRequest extends ProtoMessage {
 
 /// Request message for
 /// `MetadataService.GetMetadataSchema`.
-final class GetMetadataSchemaRequest extends ProtoMessage {
+final class GetMetadataSchemaRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetMetadataSchemaRequest';
 
@@ -58795,7 +58869,7 @@ final class GetMetadataSchemaRequest extends ProtoMessage {
 
 /// Request message for
 /// `MetadataService.ListMetadataSchemas`.
-final class ListMetadataSchemasRequest extends ProtoMessage {
+final class ListMetadataSchemasRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListMetadataSchemasRequest';
 
@@ -58861,7 +58935,7 @@ final class ListMetadataSchemasRequest extends ProtoMessage {
 
 /// Response message for
 /// `MetadataService.ListMetadataSchemas`.
-final class ListMetadataSchemasResponse extends ProtoMessage {
+final class ListMetadataSchemasResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListMetadataSchemasResponse';
 
@@ -58907,7 +58981,7 @@ final class ListMetadataSchemasResponse extends ProtoMessage {
 
 /// Request message for
 /// `MetadataService.QueryArtifactLineageSubgraph`.
-final class QueryArtifactLineageSubgraphRequest extends ProtoMessage {
+final class QueryArtifactLineageSubgraphRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.QueryArtifactLineageSubgraphRequest';
 
@@ -58992,7 +59066,7 @@ final class QueryArtifactLineageSubgraphRequest extends ProtoMessage {
 
 /// Instance of a metadata store. Contains a set of metadata that can be
 /// queried.
-final class MetadataStore extends ProtoMessage {
+final class MetadataStore extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.MetadataStore';
 
@@ -59068,7 +59142,7 @@ final class MetadataStore extends ProtoMessage {
 }
 
 /// Represents state information for a MetadataStore.
-final class MetadataStore_MetadataStoreState extends ProtoMessage {
+final class MetadataStore_MetadataStoreState extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.MetadataStore.MetadataStoreState';
 
@@ -59103,7 +59177,7 @@ final class MetadataStore_MetadataStoreState extends ProtoMessage {
 }
 
 /// Represents Dataplex integration settings.
-final class MetadataStore_DataplexConfig extends ProtoMessage {
+final class MetadataStore_DataplexConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.MetadataStore.DataplexConfig';
 
@@ -59140,7 +59214,7 @@ final class MetadataStore_DataplexConfig extends ProtoMessage {
 
 /// Represents one resource that exists in automl.googleapis.com,
 /// datalabeling.googleapis.com or ml.googleapis.com.
-final class MigratableResource extends ProtoMessage {
+final class MigratableResource extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.MigratableResource';
 
@@ -59221,7 +59295,8 @@ final class MigratableResource extends ProtoMessage {
 }
 
 /// Represents one model Version in ml.googleapis.com.
-final class MigratableResource_MlEngineModelVersion extends ProtoMessage {
+final class MigratableResource_MlEngineModelVersion
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.MigratableResource.MlEngineModelVersion';
 
@@ -59270,7 +59345,7 @@ final class MigratableResource_MlEngineModelVersion extends ProtoMessage {
 }
 
 /// Represents one Model in automl.googleapis.com.
-final class MigratableResource_AutomlModel extends ProtoMessage {
+final class MigratableResource_AutomlModel extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.MigratableResource.AutomlModel';
 
@@ -59311,7 +59386,7 @@ final class MigratableResource_AutomlModel extends ProtoMessage {
 }
 
 /// Represents one Dataset in automl.googleapis.com.
-final class MigratableResource_AutomlDataset extends ProtoMessage {
+final class MigratableResource_AutomlDataset extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.MigratableResource.AutomlDataset';
 
@@ -59352,7 +59427,8 @@ final class MigratableResource_AutomlDataset extends ProtoMessage {
 }
 
 /// Represents one Dataset in datalabeling.googleapis.com.
-final class MigratableResource_DataLabelingDataset extends ProtoMessage {
+final class MigratableResource_DataLabelingDataset
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.MigratableResource.DataLabelingDataset';
 
@@ -59415,7 +59491,7 @@ final class MigratableResource_DataLabelingDataset extends ProtoMessage {
 
 /// Represents one AnnotatedDataset in datalabeling.googleapis.com.
 final class MigratableResource_DataLabelingDataset_DataLabelingAnnotatedDataset
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.MigratableResource.DataLabelingDataset.DataLabelingAnnotatedDataset';
 
@@ -59463,7 +59539,7 @@ final class MigratableResource_DataLabelingDataset_DataLabelingAnnotatedDataset
 
 /// Request message for
 /// `MigrationService.SearchMigratableResources`.
-final class SearchMigratableResourcesRequest extends ProtoMessage {
+final class SearchMigratableResourcesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SearchMigratableResourcesRequest';
 
@@ -59535,7 +59611,7 @@ final class SearchMigratableResourcesRequest extends ProtoMessage {
 
 /// Response message for
 /// `MigrationService.SearchMigratableResources`.
-final class SearchMigratableResourcesResponse extends ProtoMessage {
+final class SearchMigratableResourcesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SearchMigratableResourcesResponse';
 
@@ -59585,7 +59661,7 @@ final class SearchMigratableResourcesResponse extends ProtoMessage {
 
 /// Request message for
 /// `MigrationService.BatchMigrateResources`.
-final class BatchMigrateResourcesRequest extends ProtoMessage {
+final class BatchMigrateResourcesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BatchMigrateResourcesRequest';
 
@@ -59631,7 +59707,7 @@ final class BatchMigrateResourcesRequest extends ProtoMessage {
 
 /// Config of migrating one resource from automl.googleapis.com,
 /// datalabeling.googleapis.com and ml.googleapis.com to Vertex AI.
-final class MigrateResourceRequest extends ProtoMessage {
+final class MigrateResourceRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.MigrateResourceRequest';
 
@@ -59704,7 +59780,7 @@ final class MigrateResourceRequest extends ProtoMessage {
 
 /// Config for migrating version in ml.googleapis.com to Vertex AI's Model.
 final class MigrateResourceRequest_MigrateMlEngineModelVersionConfig
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.MigrateResourceRequest.MigrateMlEngineModelVersionConfig';
 
@@ -59766,7 +59842,7 @@ final class MigrateResourceRequest_MigrateMlEngineModelVersionConfig
 
 /// Config for migrating Model in automl.googleapis.com to Vertex AI's Model.
 final class MigrateResourceRequest_MigrateAutomlModelConfig
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.MigrateResourceRequest.MigrateAutomlModelConfig';
 
@@ -59814,7 +59890,7 @@ final class MigrateResourceRequest_MigrateAutomlModelConfig
 /// Config for migrating Dataset in automl.googleapis.com to Vertex AI's
 /// Dataset.
 final class MigrateResourceRequest_MigrateAutomlDatasetConfig
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.MigrateResourceRequest.MigrateAutomlDatasetConfig';
 
@@ -59862,7 +59938,7 @@ final class MigrateResourceRequest_MigrateAutomlDatasetConfig
 /// Config for migrating Dataset in datalabeling.googleapis.com to Vertex
 /// AI's Dataset.
 final class MigrateResourceRequest_MigrateDataLabelingDatasetConfig
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.MigrateResourceRequest.MigrateDataLabelingDatasetConfig';
 
@@ -59928,7 +60004,7 @@ final class MigrateResourceRequest_MigrateDataLabelingDatasetConfig
 /// Config for migrating AnnotatedDataset in datalabeling.googleapis.com to
 /// Vertex AI's SavedQuery.
 final class MigrateResourceRequest_MigrateDataLabelingDatasetConfig_MigrateDataLabelingAnnotatedDatasetConfig
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.MigrateResourceRequest.MigrateDataLabelingDatasetConfig.MigrateDataLabelingAnnotatedDatasetConfig';
 
@@ -59965,7 +60041,7 @@ final class MigrateResourceRequest_MigrateDataLabelingDatasetConfig_MigrateDataL
 
 /// Response message for
 /// `MigrationService.BatchMigrateResources`.
-final class BatchMigrateResourcesResponse extends ProtoMessage {
+final class BatchMigrateResourcesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BatchMigrateResourcesResponse';
 
@@ -59997,7 +60073,7 @@ final class BatchMigrateResourcesResponse extends ProtoMessage {
 }
 
 /// Describes a successfully migrated resource.
-final class MigrateResourceResponse extends ProtoMessage {
+final class MigrateResourceResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.MigrateResourceResponse';
 
@@ -60047,7 +60123,8 @@ final class MigrateResourceResponse extends ProtoMessage {
 
 /// Runtime operation information for
 /// `MigrationService.BatchMigrateResources`.
-final class BatchMigrateResourcesOperationMetadata extends ProtoMessage {
+final class BatchMigrateResourcesOperationMetadata
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BatchMigrateResourcesOperationMetadata';
 
@@ -60093,7 +60170,7 @@ final class BatchMigrateResourcesOperationMetadata extends ProtoMessage {
 /// Represents a partial result in batch migration operation for one
 /// `MigrateResourceRequest`.
 final class BatchMigrateResourcesOperationMetadata_PartialResult
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BatchMigrateResourcesOperationMetadata.PartialResult';
 
@@ -60149,7 +60226,7 @@ final class BatchMigrateResourcesOperationMetadata_PartialResult
 }
 
 /// A trained machine learning Model.
-final class Model extends ProtoMessage {
+final class Model extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Model';
 
@@ -60616,7 +60693,7 @@ final class Model extends ProtoMessage {
 
 /// Represents export format supported by the Model.
 /// All formats export to Google Cloud Storage.
-final class Model_ExportFormat extends ProtoMessage {
+final class Model_ExportFormat extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Model.ExportFormat';
 
@@ -60676,7 +60753,7 @@ final class Model_ExportFormat extends ProtoMessage {
 }
 
 /// The Model content that can be exported.
-final class Model_ExportFormat_ExportableContent extends ProtoEnum {
+final class Model_ExportFormat_ExportableContent extends protobuf.ProtoEnum {
   /// Should not be used.
   static const exportableContentUnspecified =
       Model_ExportFormat_ExportableContent('EXPORTABLE_CONTENT_UNSPECIFIED');
@@ -60704,7 +60781,7 @@ final class Model_ExportFormat_ExportableContent extends ProtoEnum {
 }
 
 /// Contains information about the original Model if this Model is a copy.
-final class Model_OriginalModelInfo extends ProtoMessage {
+final class Model_OriginalModelInfo extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Model.OriginalModelInfo';
 
@@ -60733,7 +60810,7 @@ final class Model_OriginalModelInfo extends ProtoMessage {
 
 /// User input field to specify the base model source. Currently it only
 /// supports specifing the Model Garden models and Genie models.
-final class Model_BaseModelSource extends ProtoMessage {
+final class Model_BaseModelSource extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Model.BaseModelSource';
 
@@ -60770,7 +60847,7 @@ final class Model_BaseModelSource extends ProtoMessage {
 }
 
 /// Identifies a type of Model's prediction resources.
-final class Model_DeploymentResourcesType extends ProtoEnum {
+final class Model_DeploymentResourcesType extends protobuf.ProtoEnum {
   /// Should not be used.
   static const deploymentResourcesTypeUnspecified =
       Model_DeploymentResourcesType('DEPLOYMENT_RESOURCES_TYPE_UNSPECIFIED');
@@ -60807,7 +60884,7 @@ final class Model_DeploymentResourcesType extends ProtoEnum {
 }
 
 /// Contains information about the Large Model.
-final class LargeModelReference extends ProtoMessage {
+final class LargeModelReference extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.LargeModelReference';
 
@@ -60836,7 +60913,7 @@ final class LargeModelReference extends ProtoMessage {
 
 /// Contains information about the source of the models generated from Model
 /// Garden.
-final class ModelGardenSource extends ProtoMessage {
+final class ModelGardenSource extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelGardenSource';
 
@@ -60885,7 +60962,7 @@ final class ModelGardenSource extends ProtoMessage {
 
 /// Contains information about the source of the models generated from Generative
 /// AI Studio.
-final class GenieSource extends ProtoMessage {
+final class GenieSource extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GenieSource';
 
@@ -60916,7 +60993,7 @@ final class GenieSource extends ProtoMessage {
 /// `PredictionService.Predict`,
 /// `PredictionService.Explain`
 /// and `BatchPredictionJob`.
-final class PredictSchemata extends ProtoMessage {
+final class PredictSchemata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PredictSchemata';
 
@@ -61005,7 +61082,7 @@ final class PredictSchemata extends ProtoMessage {
 /// Specification of a container for serving predictions. Some fields in this
 /// message correspond to fields in the [Kubernetes Container v1 core
 /// specification](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#container-v1-core).
-final class ModelContainerSpec extends ProtoMessage {
+final class ModelContainerSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelContainerSpec';
 
@@ -61340,7 +61417,7 @@ final class ModelContainerSpec extends ProtoMessage {
 }
 
 /// Represents a network port in a container.
-final class Port extends ProtoMessage {
+final class Port extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Port';
 
@@ -61369,7 +61446,7 @@ final class Port extends ProtoMessage {
 }
 
 /// Detail description of the source information of the model.
-final class ModelSourceInfo extends ProtoMessage {
+final class ModelSourceInfo extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelSourceInfo';
 
@@ -61416,7 +61493,7 @@ final class ModelSourceInfo extends ProtoMessage {
 /// indicates the source from which the model was accessed or obtained,
 /// whereas the `objective` indicates the overall aim or function of this
 /// model.
-final class ModelSourceInfo_ModelSourceType extends ProtoEnum {
+final class ModelSourceInfo_ModelSourceType extends protobuf.ProtoEnum {
   /// Should not be used.
   static const modelSourceTypeUnspecified = ModelSourceInfo_ModelSourceType(
     'MODEL_SOURCE_TYPE_UNSPECIFIED',
@@ -61456,7 +61533,7 @@ final class ModelSourceInfo_ModelSourceType extends ProtoEnum {
 
 /// Probe describes a health check to be performed against a container to
 /// determine whether it is alive or ready to receive traffic.
-final class Probe extends ProtoMessage {
+final class Probe extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Probe';
 
@@ -61561,7 +61638,7 @@ final class Probe extends ProtoMessage {
 }
 
 /// ExecAction specifies a command to execute.
-final class Probe_ExecAction extends ProtoMessage {
+final class Probe_ExecAction extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Probe.ExecAction';
 
@@ -61589,7 +61666,7 @@ final class Probe_ExecAction extends ProtoMessage {
 }
 
 /// HttpGetAction describes an action based on HTTP Get requests.
-final class Probe_HttpGetAction extends ProtoMessage {
+final class Probe_HttpGetAction extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Probe.HttpGetAction';
 
@@ -61656,7 +61733,7 @@ final class Probe_HttpGetAction extends ProtoMessage {
 }
 
 /// GrpcAction checks the health of a container using a gRPC service.
-final class Probe_GrpcAction extends ProtoMessage {
+final class Probe_GrpcAction extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Probe.GrpcAction';
 
@@ -61696,7 +61773,7 @@ final class Probe_GrpcAction extends ProtoMessage {
 
 /// TcpSocketAction probes the health of a container by opening a TCP socket
 /// connection.
-final class Probe_TcpSocketAction extends ProtoMessage {
+final class Probe_TcpSocketAction extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Probe.TcpSocketAction';
 
@@ -61730,7 +61807,7 @@ final class Probe_TcpSocketAction extends ProtoMessage {
 }
 
 /// HttpHeader describes a custom header to be used in HTTP probes
-final class Probe_HttpHeader extends ProtoMessage {
+final class Probe_HttpHeader extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Probe.HttpHeader';
 
@@ -61764,7 +61841,7 @@ final class Probe_HttpHeader extends ProtoMessage {
 }
 
 /// Describes the machine learning model version checkpoint.
-final class Checkpoint extends ProtoMessage {
+final class Checkpoint extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Checkpoint';
 
@@ -61811,7 +61888,7 @@ final class Checkpoint extends ProtoMessage {
 /// Represents a job that runs periodically to monitor the deployed models in an
 /// endpoint. It will analyze the logged training & prediction data to detect any
 /// abnormal behaviors.
-final class ModelDeploymentMonitoringJob extends ProtoMessage {
+final class ModelDeploymentMonitoringJob extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelDeploymentMonitoringJob';
 
@@ -62098,7 +62175,7 @@ final class ModelDeploymentMonitoringJob extends ProtoMessage {
 
 /// All metadata of most recent monitoring pipelines.
 final class ModelDeploymentMonitoringJob_LatestMonitoringPipelineMetadata
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelDeploymentMonitoringJob.LatestMonitoringPipelineMetadata';
 
@@ -62137,7 +62214,7 @@ final class ModelDeploymentMonitoringJob_LatestMonitoringPipelineMetadata
 
 /// The state to Specify the monitoring pipeline.
 final class ModelDeploymentMonitoringJob_MonitoringScheduleState
-    extends ProtoEnum {
+    extends protobuf.ProtoEnum {
   /// Unspecified state.
   static const monitoringScheduleStateUnspecified =
       ModelDeploymentMonitoringJob_MonitoringScheduleState(
@@ -62171,7 +62248,8 @@ final class ModelDeploymentMonitoringJob_MonitoringScheduleState
 
 /// ModelDeploymentMonitoringBigQueryTable specifies the BigQuery table name
 /// as well as some information of the logs stored in this table.
-final class ModelDeploymentMonitoringBigQueryTable extends ProtoMessage {
+final class ModelDeploymentMonitoringBigQueryTable
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelDeploymentMonitoringBigQueryTable';
 
@@ -62241,7 +62319,8 @@ final class ModelDeploymentMonitoringBigQueryTable extends ProtoMessage {
 }
 
 /// Indicates where does the log come from.
-final class ModelDeploymentMonitoringBigQueryTable_LogSource extends ProtoEnum {
+final class ModelDeploymentMonitoringBigQueryTable_LogSource
+    extends protobuf.ProtoEnum {
   /// Unspecified source.
   static const logSourceUnspecified =
       ModelDeploymentMonitoringBigQueryTable_LogSource(
@@ -62269,7 +62348,8 @@ final class ModelDeploymentMonitoringBigQueryTable_LogSource extends ProtoEnum {
 }
 
 /// Indicates what type of traffic does the log belong to.
-final class ModelDeploymentMonitoringBigQueryTable_LogType extends ProtoEnum {
+final class ModelDeploymentMonitoringBigQueryTable_LogType
+    extends protobuf.ProtoEnum {
   /// Unspecified type.
   static const logTypeUnspecified =
       ModelDeploymentMonitoringBigQueryTable_LogType('LOG_TYPE_UNSPECIFIED');
@@ -62296,7 +62376,8 @@ final class ModelDeploymentMonitoringBigQueryTable_LogType extends ProtoEnum {
 
 /// ModelDeploymentMonitoringObjectiveConfig contains the pair of
 /// deployed_model_id to ModelMonitoringObjectiveConfig.
-final class ModelDeploymentMonitoringObjectiveConfig extends ProtoMessage {
+final class ModelDeploymentMonitoringObjectiveConfig
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelDeploymentMonitoringObjectiveConfig';
 
@@ -62341,7 +62422,8 @@ final class ModelDeploymentMonitoringObjectiveConfig extends ProtoMessage {
 }
 
 /// The config for scheduling monitoring job.
-final class ModelDeploymentMonitoringScheduleConfig extends ProtoMessage {
+final class ModelDeploymentMonitoringScheduleConfig
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelDeploymentMonitoringScheduleConfig';
 
@@ -62393,7 +62475,7 @@ final class ModelDeploymentMonitoringScheduleConfig extends ProtoMessage {
 }
 
 /// Statistics and anomalies generated by Model Monitoring.
-final class ModelMonitoringStatsAnomalies extends ProtoMessage {
+final class ModelMonitoringStatsAnomalies extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringStatsAnomalies';
 
@@ -62455,7 +62537,7 @@ final class ModelMonitoringStatsAnomalies extends ProtoMessage {
 
 /// Historical Stats (and Anomalies) for a specific Feature.
 final class ModelMonitoringStatsAnomalies_FeatureHistoricStatsAnomalies
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringStatsAnomalies.FeatureHistoricStatsAnomalies';
 
@@ -62518,7 +62600,7 @@ final class ModelMonitoringStatsAnomalies_FeatureHistoricStatsAnomalies
 
 /// A collection of metrics calculated by comparing Model's predictions on all of
 /// the test data against annotations from the test data.
-final class ModelEvaluation extends ProtoMessage {
+final class ModelEvaluation extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelEvaluation';
 
@@ -62634,7 +62716,7 @@ final class ModelEvaluation extends ProtoMessage {
 }
 
 final class ModelEvaluation_ModelEvaluationExplanationSpec
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelEvaluation.ModelEvaluationExplanationSpec';
 
@@ -62684,7 +62766,7 @@ final class ModelEvaluation_ModelEvaluationExplanationSpec
 }
 
 /// Configuration for bias detection.
-final class ModelEvaluation_BiasConfig extends ProtoMessage {
+final class ModelEvaluation_BiasConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelEvaluation.BiasConfig';
 
@@ -62744,7 +62826,7 @@ final class ModelEvaluation_BiasConfig extends ProtoMessage {
 
 /// A collection of metrics calculated by comparing Model's predictions on a
 /// slice of the test data against ground truth annotations.
-final class ModelEvaluationSlice extends ProtoMessage {
+final class ModelEvaluationSlice extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelEvaluationSlice';
 
@@ -62823,7 +62905,7 @@ final class ModelEvaluationSlice extends ProtoMessage {
 }
 
 /// Definition of a slice.
-final class ModelEvaluationSlice_Slice extends ProtoMessage {
+final class ModelEvaluationSlice_Slice extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelEvaluationSlice.Slice';
 
@@ -62878,7 +62960,7 @@ final class ModelEvaluationSlice_Slice extends ProtoMessage {
 }
 
 /// Specification for how the data should be sliced.
-final class ModelEvaluationSlice_Slice_SliceSpec extends ProtoMessage {
+final class ModelEvaluationSlice_Slice_SliceSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelEvaluationSlice.Slice.SliceSpec';
 
@@ -62967,7 +63049,7 @@ final class ModelEvaluationSlice_Slice_SliceSpec extends ProtoMessage {
 /// "Canada" in another slice, and zip_code 12345 and country "Mexico" in
 /// another slice, totaling 3 slices.
 final class ModelEvaluationSlice_Slice_SliceSpec_SliceConfig
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelEvaluationSlice.Slice.SliceSpec.SliceConfig';
 
@@ -63022,7 +63104,8 @@ final class ModelEvaluationSlice_Slice_SliceSpec_SliceConfig
 
 /// A range of values for slice(s).
 /// `low` is inclusive, `high` is exclusive.
-final class ModelEvaluationSlice_Slice_SliceSpec_Range extends ProtoMessage {
+final class ModelEvaluationSlice_Slice_SliceSpec_Range
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelEvaluationSlice.Slice.SliceSpec.Range';
 
@@ -63063,7 +63146,8 @@ final class ModelEvaluationSlice_Slice_SliceSpec_Range extends ProtoMessage {
 }
 
 /// Single value that supports strings and floats.
-final class ModelEvaluationSlice_Slice_SliceSpec_Value extends ProtoMessage {
+final class ModelEvaluationSlice_Slice_SliceSpec_Value
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelEvaluationSlice.Slice.SliceSpec.Value';
 
@@ -63107,7 +63191,7 @@ final class ModelEvaluationSlice_Slice_SliceSpec_Value extends ProtoMessage {
 
 /// Request message for
 /// `ModelGardenService.GetPublisherModel`
-final class GetPublisherModelRequest extends ProtoMessage {
+final class GetPublisherModelRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetPublisherModelRequest';
 
@@ -63186,7 +63270,7 @@ final class GetPublisherModelRequest extends ProtoMessage {
 
 /// Request message for
 /// `ModelGardenService.ListPublisherModels`.
-final class ListPublisherModelsRequest extends ProtoMessage {
+final class ListPublisherModelsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListPublisherModelsRequest';
 
@@ -63279,7 +63363,7 @@ final class ListPublisherModelsRequest extends ProtoMessage {
 
 /// Response message for
 /// `ModelGardenService.ListPublisherModels`.
-final class ListPublisherModelsResponse extends ProtoMessage {
+final class ListPublisherModelsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListPublisherModelsResponse';
 
@@ -63323,7 +63407,7 @@ final class ListPublisherModelsResponse extends ProtoMessage {
 
 /// Request message for
 /// `ModelGardenService.Deploy`.
-final class DeployRequest extends ProtoMessage {
+final class DeployRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeployRequest';
 
@@ -63416,7 +63500,7 @@ final class DeployRequest extends ProtoMessage {
 
 /// The custom model to deploy from model weights in a Google Cloud Storage URI
 /// or Model Registry model.
-final class DeployRequest_CustomModel extends ProtoMessage {
+final class DeployRequest_CustomModel extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeployRequest.CustomModel';
 
@@ -63443,7 +63527,7 @@ final class DeployRequest_CustomModel extends ProtoMessage {
 }
 
 /// The model config to use for the deployment.
-final class DeployRequest_ModelConfig extends ProtoMessage {
+final class DeployRequest_ModelConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeployRequest.ModelConfig';
 
@@ -63527,7 +63611,7 @@ final class DeployRequest_ModelConfig extends ProtoMessage {
 }
 
 /// The endpoint config to use for the deployment.
-final class DeployRequest_EndpointConfig extends ProtoMessage {
+final class DeployRequest_EndpointConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeployRequest.EndpointConfig';
 
@@ -63632,7 +63716,7 @@ final class DeployRequest_EndpointConfig extends ProtoMessage {
 }
 
 /// The deploy config to use for the deployment.
-final class DeployRequest_DeployConfig extends ProtoMessage {
+final class DeployRequest_DeployConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeployRequest.DeployConfig';
 
@@ -63686,7 +63770,7 @@ final class DeployRequest_DeployConfig extends ProtoMessage {
 
 /// Request message for
 /// `ModelGardenService.DeployPublisherModel`.
-final class DeployPublisherModelRequest extends ProtoMessage {
+final class DeployPublisherModelRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeployPublisherModelRequest';
 
@@ -63782,7 +63866,7 @@ final class DeployPublisherModelRequest extends ProtoMessage {
 
 /// Response message for
 /// `ModelGardenService.Deploy`.
-final class DeployResponse extends ProtoMessage {
+final class DeployResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeployResponse';
 
@@ -63833,7 +63917,7 @@ final class DeployResponse extends ProtoMessage {
 
 /// Response message for
 /// `ModelGardenService.DeployPublisherModel`.
-final class DeployPublisherModelResponse extends ProtoMessage {
+final class DeployPublisherModelResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeployPublisherModelResponse';
 
@@ -63884,7 +63968,7 @@ final class DeployPublisherModelResponse extends ProtoMessage {
 
 /// Runtime operation information for
 /// `ModelGardenService.Deploy`.
-final class DeployOperationMetadata extends ProtoMessage {
+final class DeployOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeployOperationMetadata';
 
@@ -63950,7 +64034,8 @@ final class DeployOperationMetadata extends ProtoMessage {
 
 /// Runtime operation information for
 /// `ModelGardenService.DeployPublisherModel`.
-final class DeployPublisherModelOperationMetadata extends ProtoMessage {
+final class DeployPublisherModelOperationMetadata
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeployPublisherModelOperationMetadata';
 
@@ -64014,7 +64099,7 @@ final class DeployPublisherModelOperationMetadata extends ProtoMessage {
 
 /// Response message for
 /// `ModelGardenService.ExportPublisherModel`.
-final class ExportPublisherModelResponse extends ProtoMessage {
+final class ExportPublisherModelResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExportPublisherModelResponse';
 
@@ -64056,7 +64141,8 @@ final class ExportPublisherModelResponse extends ProtoMessage {
 
 /// Runtime operation information for
 /// `ModelGardenService.ExportPublisherModel`.
-final class ExportPublisherModelOperationMetadata extends ProtoMessage {
+final class ExportPublisherModelOperationMetadata
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExportPublisherModelOperationMetadata';
 
@@ -64090,7 +64176,7 @@ final class ExportPublisherModelOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `ModelGardenService.ExportPublisherModel`.
-final class ExportPublisherModelRequest extends ProtoMessage {
+final class ExportPublisherModelRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExportPublisherModelRequest';
 
@@ -64139,7 +64225,8 @@ final class ExportPublisherModelRequest extends ProtoMessage {
 
 /// Request message for
 /// `ModelGardenService.CheckPublisherModelEula`.
-final class CheckPublisherModelEulaAcceptanceRequest extends ProtoMessage {
+final class CheckPublisherModelEulaAcceptanceRequest
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CheckPublisherModelEulaAcceptanceRequest';
 
@@ -64187,7 +64274,7 @@ final class CheckPublisherModelEulaAcceptanceRequest extends ProtoMessage {
 
 /// Request message for
 /// `ModelGardenService.AcceptPublisherModelEula`.
-final class AcceptPublisherModelEulaRequest extends ProtoMessage {
+final class AcceptPublisherModelEulaRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AcceptPublisherModelEulaRequest';
 
@@ -64231,7 +64318,7 @@ final class AcceptPublisherModelEulaRequest extends ProtoMessage {
 
 /// Response message for
 /// `ModelGardenService.UpdatePublisherModelEula`.
-final class PublisherModelEulaAcceptance extends ProtoMessage {
+final class PublisherModelEulaAcceptance extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PublisherModelEulaAcceptance';
 
@@ -64284,7 +64371,7 @@ final class PublisherModelEulaAcceptance extends ProtoMessage {
 /// and visualization of data quality and performance related to models.
 /// ModelMonitor stands as a top level resource for overseeing your model
 /// monitoring tasks.
-final class ModelMonitor extends ProtoMessage {
+final class ModelMonitor extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitor';
 
@@ -64444,7 +64531,7 @@ final class ModelMonitor extends ProtoMessage {
 
 /// The monitoring target refers to the entity that is subject to analysis.
 /// e.g. Vertex AI Model version.
-final class ModelMonitor_ModelMonitoringTarget extends ProtoMessage {
+final class ModelMonitor_ModelMonitoringTarget extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitor.ModelMonitoringTarget';
 
@@ -64476,7 +64563,7 @@ final class ModelMonitor_ModelMonitoringTarget extends ProtoMessage {
 
 /// Model in Vertex AI Model Registry.
 final class ModelMonitor_ModelMonitoringTarget_VertexModelSource
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitor.ModelMonitoringTarget.VertexModelSource';
 
@@ -64520,7 +64607,7 @@ final class ModelMonitor_ModelMonitoringTarget_VertexModelSource
 }
 
 /// The Model Monitoring Schema definition.
-final class ModelMonitoringSchema extends ProtoMessage {
+final class ModelMonitoringSchema extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringSchema';
 
@@ -64602,7 +64689,7 @@ final class ModelMonitoringSchema extends ProtoMessage {
 }
 
 /// Schema field definition.
-final class ModelMonitoringSchema_FieldSchema extends ProtoMessage {
+final class ModelMonitoringSchema_FieldSchema extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringSchema.FieldSchema';
 
@@ -64654,7 +64741,7 @@ final class ModelMonitoringSchema_FieldSchema extends ProtoMessage {
 }
 
 /// The model monitoring configuration used for Batch Prediction Job.
-final class ModelMonitoringConfig extends ProtoMessage {
+final class ModelMonitoringConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringConfig';
 
@@ -64729,7 +64816,7 @@ final class ModelMonitoringConfig extends ProtoMessage {
 
 /// The objective configuration for model monitoring, including the information
 /// needed to detect anomalies for one particular model.
-final class ModelMonitoringObjectiveConfig extends ProtoMessage {
+final class ModelMonitoringObjectiveConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringObjectiveConfig';
 
@@ -64798,7 +64885,7 @@ final class ModelMonitoringObjectiveConfig extends ProtoMessage {
 
 /// Training Dataset information.
 final class ModelMonitoringObjectiveConfig_TrainingDataset
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringObjectiveConfig.TrainingDataset';
 
@@ -64887,7 +64974,7 @@ final class ModelMonitoringObjectiveConfig_TrainingDataset
 /// The config for Training & Prediction data skew detection. It specifies the
 /// training dataset sources and the skew detection parameters.
 final class ModelMonitoringObjectiveConfig_TrainingPredictionSkewDetectionConfig
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringObjectiveConfig.TrainingPredictionSkewDetectionConfig';
 
@@ -64951,7 +65038,7 @@ final class ModelMonitoringObjectiveConfig_TrainingPredictionSkewDetectionConfig
 
 /// The config for Prediction data drift detection.
 final class ModelMonitoringObjectiveConfig_PredictionDriftDetectionConfig
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringObjectiveConfig.PredictionDriftDetectionConfig';
 
@@ -65016,7 +65103,7 @@ final class ModelMonitoringObjectiveConfig_PredictionDriftDetectionConfig
 /// The config for integrating with Vertex Explainable AI. Only applicable if
 /// the Model has explanation_spec populated.
 final class ModelMonitoringObjectiveConfig_ExplanationConfig
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringObjectiveConfig.ExplanationConfig';
 
@@ -65072,7 +65159,7 @@ final class ModelMonitoringObjectiveConfig_ExplanationConfig
 /// for Model Monitoring baseline dataset, which can be used to generate
 /// baseline attribution scores.
 final class ModelMonitoringObjectiveConfig_ExplanationConfig_ExplanationBaseline
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringObjectiveConfig.ExplanationConfig.ExplanationBaseline';
 
@@ -65127,7 +65214,7 @@ final class ModelMonitoringObjectiveConfig_ExplanationConfig_ExplanationBaseline
 
 /// The storage format of the predictions generated BatchPrediction job.
 final class ModelMonitoringObjectiveConfig_ExplanationConfig_ExplanationBaseline_PredictionFormat
-    extends ProtoEnum {
+    extends protobuf.ProtoEnum {
   /// Should not be set.
   static const predictionFormatUnspecified =
       ModelMonitoringObjectiveConfig_ExplanationConfig_ExplanationBaseline_PredictionFormat(
@@ -65162,7 +65249,7 @@ final class ModelMonitoringObjectiveConfig_ExplanationConfig_ExplanationBaseline
 }
 
 /// The alert config for model monitoring.
-final class ModelMonitoringAlertConfig extends ProtoMessage {
+final class ModelMonitoringAlertConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringAlertConfig';
 
@@ -65219,7 +65306,8 @@ final class ModelMonitoringAlertConfig extends ProtoMessage {
 }
 
 /// The config for email alert.
-final class ModelMonitoringAlertConfig_EmailAlertConfig extends ProtoMessage {
+final class ModelMonitoringAlertConfig_EmailAlertConfig
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringAlertConfig.EmailAlertConfig';
 
@@ -65247,7 +65335,7 @@ final class ModelMonitoringAlertConfig_EmailAlertConfig extends ProtoMessage {
 }
 
 /// The config for feature monitoring threshold.
-final class ThresholdConfig extends ProtoMessage {
+final class ThresholdConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ThresholdConfig';
 
@@ -65281,7 +65369,7 @@ final class ThresholdConfig extends ProtoMessage {
 
 /// Sampling Strategy for logging, can be for both training and prediction
 /// dataset.
-final class SamplingStrategy extends ProtoMessage {
+final class SamplingStrategy extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SamplingStrategy';
 
@@ -65312,7 +65400,7 @@ final class SamplingStrategy extends ProtoMessage {
 }
 
 /// Requests are randomly selected.
-final class SamplingStrategy_RandomSampleConfig extends ProtoMessage {
+final class SamplingStrategy_RandomSampleConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SamplingStrategy.RandomSampleConfig';
 
@@ -65345,7 +65433,7 @@ final class SamplingStrategy_RandomSampleConfig extends ProtoMessage {
 }
 
 /// Monitoring alert triggered condition.
-final class ModelMonitoringAlertCondition extends ProtoMessage {
+final class ModelMonitoringAlertCondition extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringAlertCondition';
 
@@ -65374,7 +65462,7 @@ final class ModelMonitoringAlertCondition extends ProtoMessage {
 }
 
 /// Represents a single model monitoring anomaly.
-final class ModelMonitoringAnomaly extends ProtoMessage {
+final class ModelMonitoringAnomaly extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringAnomaly';
 
@@ -65425,7 +65513,8 @@ final class ModelMonitoringAnomaly extends ProtoMessage {
 }
 
 /// Tabular anomaly details.
-final class ModelMonitoringAnomaly_TabularAnomaly extends ProtoMessage {
+final class ModelMonitoringAnomaly_TabularAnomaly
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringAnomaly.TabularAnomaly';
 
@@ -65494,7 +65583,7 @@ final class ModelMonitoringAnomaly_TabularAnomaly extends ProtoMessage {
 /// Represents a single monitoring alert. This is currently used in the
 /// SearchModelMonitoringAlerts api, thus the alert wrapped in this message
 /// belongs to the resource asked in the request.
-final class ModelMonitoringAlert extends ProtoMessage {
+final class ModelMonitoringAlert extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringAlert';
 
@@ -65551,7 +65640,7 @@ final class ModelMonitoringAlert extends ProtoMessage {
 
 /// Represents a model monitoring job that analyze dataset using different
 /// monitoring algorithm.
-final class ModelMonitoringJob extends ProtoMessage {
+final class ModelMonitoringJob extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringJob';
 
@@ -65662,7 +65751,7 @@ final class ModelMonitoringJob extends ProtoMessage {
 }
 
 /// Represent the execution details of the job.
-final class ModelMonitoringJobExecutionDetail extends ProtoMessage {
+final class ModelMonitoringJobExecutionDetail extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringJobExecutionDetail';
 
@@ -65726,7 +65815,7 @@ final class ModelMonitoringJobExecutionDetail extends ProtoMessage {
 
 /// Processed dataset information.
 final class ModelMonitoringJobExecutionDetail_ProcessedDataset
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringJobExecutionDetail.ProcessedDataset';
 
@@ -65767,7 +65856,7 @@ final class ModelMonitoringJobExecutionDetail_ProcessedDataset
 
 /// Request message for
 /// `ModelMonitoringService.CreateModelMonitor`.
-final class CreateModelMonitorRequest extends ProtoMessage {
+final class CreateModelMonitorRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateModelMonitorRequest';
 
@@ -65820,7 +65909,7 @@ final class CreateModelMonitorRequest extends ProtoMessage {
 
 /// Runtime operation information for
 /// `ModelMonitoringService.CreateModelMonitor`.
-final class CreateModelMonitorOperationMetadata extends ProtoMessage {
+final class CreateModelMonitorOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateModelMonitorOperationMetadata';
 
@@ -65854,7 +65943,7 @@ final class CreateModelMonitorOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `ModelMonitoringService.UpdateModelMonitor`.
-final class UpdateModelMonitorRequest extends ProtoMessage {
+final class UpdateModelMonitorRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateModelMonitorRequest';
 
@@ -65889,7 +65978,7 @@ final class UpdateModelMonitorRequest extends ProtoMessage {
 
 /// Runtime operation information for
 /// `ModelMonitoringService.UpdateModelMonitor`.
-final class UpdateModelMonitorOperationMetadata extends ProtoMessage {
+final class UpdateModelMonitorOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateModelMonitorOperationMetadata';
 
@@ -65923,7 +66012,7 @@ final class UpdateModelMonitorOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `ModelMonitoringService.GetModelMonitor`.
-final class GetModelMonitorRequest extends ProtoMessage {
+final class GetModelMonitorRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetModelMonitorRequest';
 
@@ -65952,7 +66041,7 @@ final class GetModelMonitorRequest extends ProtoMessage {
 
 /// Request message for
 /// `ModelMonitoringService.ListModelMonitors`.
-final class ListModelMonitorsRequest extends ProtoMessage {
+final class ListModelMonitorsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListModelMonitorsRequest';
 
@@ -66016,7 +66105,7 @@ final class ListModelMonitorsRequest extends ProtoMessage {
 
 /// Response message for
 /// `ModelMonitoringService.ListModelMonitors`
-final class ListModelMonitorsResponse extends ProtoMessage {
+final class ListModelMonitorsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListModelMonitorsResponse';
 
@@ -66061,7 +66150,7 @@ final class ListModelMonitorsResponse extends ProtoMessage {
 
 /// Request message for
 /// `ModelMonitoringService.DeleteModelMonitor`.
-final class DeleteModelMonitorRequest extends ProtoMessage {
+final class DeleteModelMonitorRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteModelMonitorRequest';
 
@@ -66097,7 +66186,7 @@ final class DeleteModelMonitorRequest extends ProtoMessage {
 
 /// Request message for
 /// `ModelMonitoringService.CreateModelMonitoringJob`.
-final class CreateModelMonitoringJobRequest extends ProtoMessage {
+final class CreateModelMonitoringJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateModelMonitoringJobRequest';
 
@@ -66156,7 +66245,7 @@ final class CreateModelMonitoringJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `ModelMonitoringService.GetModelMonitoringJob`.
-final class GetModelMonitoringJobRequest extends ProtoMessage {
+final class GetModelMonitoringJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetModelMonitoringJobRequest';
 
@@ -66186,7 +66275,7 @@ final class GetModelMonitoringJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `ModelMonitoringService.ListModelMonitoringJobs`.
-final class ListModelMonitoringJobsRequest extends ProtoMessage {
+final class ListModelMonitoringJobsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListModelMonitoringJobsRequest';
 
@@ -66251,7 +66340,7 @@ final class ListModelMonitoringJobsRequest extends ProtoMessage {
 
 /// Response message for
 /// `ModelMonitoringService.ListModelMonitoringJobs`.
-final class ListModelMonitoringJobsResponse extends ProtoMessage {
+final class ListModelMonitoringJobsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListModelMonitoringJobsResponse';
 
@@ -66297,7 +66386,7 @@ final class ListModelMonitoringJobsResponse extends ProtoMessage {
 
 /// Request message for
 /// `ModelMonitoringService.DeleteModelMonitoringJob`.
-final class DeleteModelMonitoringJobRequest extends ProtoMessage {
+final class DeleteModelMonitoringJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteModelMonitoringJobRequest';
 
@@ -66327,7 +66416,7 @@ final class DeleteModelMonitoringJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `ModelMonitoringService.SearchModelMonitoringStats`.
-final class SearchModelMonitoringStatsRequest extends ProtoMessage {
+final class SearchModelMonitoringStatsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SearchModelMonitoringStatsRequest';
 
@@ -66397,7 +66486,7 @@ final class SearchModelMonitoringStatsRequest extends ProtoMessage {
 
 /// Response message for
 /// `ModelMonitoringService.SearchModelMonitoringStats`.
-final class SearchModelMonitoringStatsResponse extends ProtoMessage {
+final class SearchModelMonitoringStatsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SearchModelMonitoringStatsResponse';
 
@@ -66444,7 +66533,7 @@ final class SearchModelMonitoringStatsResponse extends ProtoMessage {
 
 /// Request message for
 /// `ModelMonitoringService.SearchModelMonitoringAlerts`.
-final class SearchModelMonitoringAlertsRequest extends ProtoMessage {
+final class SearchModelMonitoringAlertsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SearchModelMonitoringAlertsRequest';
 
@@ -66531,7 +66620,7 @@ final class SearchModelMonitoringAlertsRequest extends ProtoMessage {
 
 /// Response message for
 /// `ModelMonitoringService.SearchModelMonitoringAlerts`.
-final class SearchModelMonitoringAlertsResponse extends ProtoMessage {
+final class SearchModelMonitoringAlertsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SearchModelMonitoringAlertsResponse';
 
@@ -66589,7 +66678,7 @@ final class SearchModelMonitoringAlertsResponse extends ProtoMessage {
 
 /// Monitoring monitoring job spec. It outlines the specifications for monitoring
 /// objectives, notifications, and result exports.
-final class ModelMonitoringSpec extends ProtoMessage {
+final class ModelMonitoringSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringSpec';
 
@@ -66640,7 +66729,7 @@ final class ModelMonitoringSpec extends ProtoMessage {
 }
 
 /// Monitoring objectives spec.
-final class ModelMonitoringObjectiveSpec extends ProtoMessage {
+final class ModelMonitoringObjectiveSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringObjectiveSpec';
 
@@ -66709,7 +66798,8 @@ final class ModelMonitoringObjectiveSpec extends ProtoMessage {
 /// the recent production serving dataset and the training dataset, or to
 /// compare the recent production dataset with a dataset from a previous
 /// period.
-final class ModelMonitoringObjectiveSpec_DataDriftSpec extends ProtoMessage {
+final class ModelMonitoringObjectiveSpec_DataDriftSpec
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringObjectiveSpec.DataDriftSpec';
 
@@ -66799,7 +66889,7 @@ final class ModelMonitoringObjectiveSpec_DataDriftSpec extends ProtoMessage {
 
 /// Feature attribution monitoring spec.
 final class ModelMonitoringObjectiveSpec_FeatureAttributionSpec
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringObjectiveSpec.FeatureAttributionSpec';
 
@@ -66866,7 +66956,8 @@ final class ModelMonitoringObjectiveSpec_FeatureAttributionSpec
 }
 
 /// Tabular monitoring objective.
-final class ModelMonitoringObjectiveSpec_TabularObjective extends ProtoMessage {
+final class ModelMonitoringObjectiveSpec_TabularObjective
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringObjectiveSpec.TabularObjective';
 
@@ -66923,7 +67014,7 @@ final class ModelMonitoringObjectiveSpec_TabularObjective extends ProtoMessage {
 
 /// Specification for the export destination of monitoring results, including
 /// metrics, logs, etc.
-final class ModelMonitoringOutputSpec extends ProtoMessage {
+final class ModelMonitoringOutputSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringOutputSpec';
 
@@ -66955,7 +67046,7 @@ final class ModelMonitoringOutputSpec extends ProtoMessage {
 }
 
 /// Model monitoring data input spec.
-final class ModelMonitoringInput extends ProtoMessage {
+final class ModelMonitoringInput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringInput';
 
@@ -67024,7 +67115,8 @@ final class ModelMonitoringInput extends ProtoMessage {
 }
 
 /// Input dataset spec.
-final class ModelMonitoringInput_ModelMonitoringDataset extends ProtoMessage {
+final class ModelMonitoringInput_ModelMonitoringDataset
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringInput.ModelMonitoringDataset';
 
@@ -67090,7 +67182,7 @@ final class ModelMonitoringInput_ModelMonitoringDataset extends ProtoMessage {
 
 /// Dataset spec for data stored in Google Cloud Storage.
 final class ModelMonitoringInput_ModelMonitoringDataset_ModelMonitoringGcsSource
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringInput.ModelMonitoringDataset.ModelMonitoringGcsSource';
 
@@ -67141,7 +67233,7 @@ final class ModelMonitoringInput_ModelMonitoringDataset_ModelMonitoringGcsSource
 
 /// Supported data format.
 final class ModelMonitoringInput_ModelMonitoringDataset_ModelMonitoringGcsSource_DataFormat
-    extends ProtoEnum {
+    extends protobuf.ProtoEnum {
   /// Data format unspecified, used when this field is unset.
   static const dataFormatUnspecified =
       ModelMonitoringInput_ModelMonitoringDataset_ModelMonitoringGcsSource_DataFormat(
@@ -67183,7 +67275,7 @@ final class ModelMonitoringInput_ModelMonitoringDataset_ModelMonitoringGcsSource
 
 /// Dataset spec for data sotred in BigQuery.
 final class ModelMonitoringInput_ModelMonitoringDataset_ModelMonitoringBigQuerySource
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringInput.ModelMonitoringDataset.ModelMonitoringBigQuerySource';
 
@@ -67230,7 +67322,8 @@ final class ModelMonitoringInput_ModelMonitoringDataset_ModelMonitoringBigQueryS
 }
 
 /// Data from Vertex AI Batch prediction job output.
-final class ModelMonitoringInput_BatchPredictionOutput extends ProtoMessage {
+final class ModelMonitoringInput_BatchPredictionOutput
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringInput.BatchPredictionOutput';
 
@@ -67266,7 +67359,8 @@ final class ModelMonitoringInput_BatchPredictionOutput extends ProtoMessage {
 }
 
 /// Data from Vertex AI Endpoint request response logging.
-final class ModelMonitoringInput_VertexEndpointLogs extends ProtoMessage {
+final class ModelMonitoringInput_VertexEndpointLogs
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringInput.VertexEndpointLogs';
 
@@ -67297,7 +67391,7 @@ final class ModelMonitoringInput_VertexEndpointLogs extends ProtoMessage {
 }
 
 /// Time offset setting.
-final class ModelMonitoringInput_TimeOffset extends ProtoMessage {
+final class ModelMonitoringInput_TimeOffset extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringInput.TimeOffset';
 
@@ -67346,7 +67440,7 @@ final class ModelMonitoringInput_TimeOffset extends ProtoMessage {
 
 /// Notification spec(email, notification channel) for model monitoring
 /// statistics/alerts.
-final class ModelMonitoringNotificationSpec extends ProtoMessage {
+final class ModelMonitoringNotificationSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringNotificationSpec';
 
@@ -67404,7 +67498,8 @@ final class ModelMonitoringNotificationSpec extends ProtoMessage {
 }
 
 /// The config for email alerts.
-final class ModelMonitoringNotificationSpec_EmailConfig extends ProtoMessage {
+final class ModelMonitoringNotificationSpec_EmailConfig
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringNotificationSpec.EmailConfig';
 
@@ -67433,7 +67528,7 @@ final class ModelMonitoringNotificationSpec_EmailConfig extends ProtoMessage {
 
 /// Google Cloud Notification Channel config.
 final class ModelMonitoringNotificationSpec_NotificationChannelConfig
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringNotificationSpec.NotificationChannelConfig';
 
@@ -67473,7 +67568,7 @@ final class ModelMonitoringNotificationSpec_NotificationChannelConfig
 }
 
 /// Represents the collection of statistics for a metric.
-final class ModelMonitoringStats extends ProtoMessage {
+final class ModelMonitoringStats extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringStats';
 
@@ -67501,7 +67596,7 @@ final class ModelMonitoringStats extends ProtoMessage {
 }
 
 /// Represents a single statistics data point.
-final class ModelMonitoringStatsDataPoint extends ProtoMessage {
+final class ModelMonitoringStatsDataPoint extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringStatsDataPoint';
 
@@ -67589,7 +67684,8 @@ final class ModelMonitoringStatsDataPoint extends ProtoMessage {
 }
 
 /// Typed value of the statistics.
-final class ModelMonitoringStatsDataPoint_TypedValue extends ProtoMessage {
+final class ModelMonitoringStatsDataPoint_TypedValue
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringStatsDataPoint.TypedValue';
 
@@ -67637,7 +67733,7 @@ final class ModelMonitoringStatsDataPoint_TypedValue extends ProtoMessage {
 
 /// Summary statistics for a population of values.
 final class ModelMonitoringStatsDataPoint_TypedValue_DistributionDataValue
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringStatsDataPoint.TypedValue.DistributionDataValue';
 
@@ -67688,7 +67784,7 @@ final class ModelMonitoringStatsDataPoint_TypedValue_DistributionDataValue
 
 /// A collection of data points that describes the time-varying values of a
 /// tabular metric.
-final class ModelMonitoringTabularStats extends ProtoMessage {
+final class ModelMonitoringTabularStats extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelMonitoringTabularStats';
 
@@ -67742,7 +67838,7 @@ final class ModelMonitoringTabularStats extends ProtoMessage {
 }
 
 /// Filter for searching ModelMonitoringStats.
-final class SearchModelMonitoringStatsFilter extends ProtoMessage {
+final class SearchModelMonitoringStatsFilter extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SearchModelMonitoringStatsFilter';
 
@@ -67775,7 +67871,7 @@ final class SearchModelMonitoringStatsFilter extends ProtoMessage {
 
 /// Tabular statistics filter.
 final class SearchModelMonitoringStatsFilter_TabularStatsFilter
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SearchModelMonitoringStatsFilter.TabularStatsFilter';
 
@@ -67846,7 +67942,7 @@ final class SearchModelMonitoringStatsFilter_TabularStatsFilter
 
 /// Request message for
 /// `ModelService.UploadModel`.
-final class UploadModelRequest extends ProtoMessage {
+final class UploadModelRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UploadModelRequest';
 
@@ -67921,7 +68017,7 @@ final class UploadModelRequest extends ProtoMessage {
 /// Details of
 /// `ModelService.UploadModel`
 /// operation.
-final class UploadModelOperationMetadata extends ProtoMessage {
+final class UploadModelOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UploadModelOperationMetadata';
 
@@ -67954,7 +68050,7 @@ final class UploadModelOperationMetadata extends ProtoMessage {
 /// Response message of
 /// `ModelService.UploadModel`
 /// operation.
-final class UploadModelResponse extends ProtoMessage {
+final class UploadModelResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UploadModelResponse';
 
@@ -67995,7 +68091,7 @@ final class UploadModelResponse extends ProtoMessage {
 
 /// Request message for
 /// `ModelService.GetModel`.
-final class GetModelRequest extends ProtoMessage {
+final class GetModelRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetModelRequest';
 
@@ -68033,7 +68129,7 @@ final class GetModelRequest extends ProtoMessage {
 
 /// Request message for
 /// `ModelService.ListModels`.
-final class ListModelsRequest extends ProtoMessage {
+final class ListModelsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListModelsRequest';
 
@@ -68119,7 +68215,7 @@ final class ListModelsRequest extends ProtoMessage {
 
 /// Response message for
 /// `ModelService.ListModels`
-final class ListModelsResponse extends ProtoMessage {
+final class ListModelsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListModelsResponse';
 
@@ -68161,7 +68257,7 @@ final class ListModelsResponse extends ProtoMessage {
 
 /// Request message for
 /// `ModelService.ListModelVersions`.
-final class ListModelVersionsRequest extends ProtoMessage {
+final class ListModelVersionsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListModelVersionsRequest';
 
@@ -68252,7 +68348,7 @@ final class ListModelVersionsRequest extends ProtoMessage {
 
 /// Response message for
 /// `ModelService.ListModelVersions`
-final class ListModelVersionsResponse extends ProtoMessage {
+final class ListModelVersionsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListModelVersionsResponse';
 
@@ -68296,7 +68392,7 @@ final class ListModelVersionsResponse extends ProtoMessage {
 
 /// Request message for
 /// `ModelService.ListModelVersionCheckpoints`.
-final class ListModelVersionCheckpointsRequest extends ProtoMessage {
+final class ListModelVersionCheckpointsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListModelVersionCheckpointsRequest';
 
@@ -68358,7 +68454,7 @@ final class ListModelVersionCheckpointsRequest extends ProtoMessage {
 
 /// A proto representation of a Spanner-stored ModelVersionCheckpoint.
 /// The meaning of the fields is equivalent to their in-Spanner counterparts.
-final class ModelVersionCheckpoint extends ProtoMessage {
+final class ModelVersionCheckpoint extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ModelVersionCheckpoint';
 
@@ -68404,7 +68500,7 @@ final class ModelVersionCheckpoint extends ProtoMessage {
 
 /// Response message for
 /// `ModelService.ListModelVersionCheckpoints`
-final class ListModelVersionCheckpointsResponse extends ProtoMessage {
+final class ListModelVersionCheckpointsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListModelVersionCheckpointsResponse';
 
@@ -68451,7 +68547,7 @@ final class ListModelVersionCheckpointsResponse extends ProtoMessage {
 
 /// Request message for
 /// `ModelService.UpdateModel`.
-final class UpdateModelRequest extends ProtoMessage {
+final class UpdateModelRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateModelRequest';
 
@@ -68504,7 +68600,7 @@ final class UpdateModelRequest extends ProtoMessage {
 
 /// Request message for
 /// `ModelService.UpdateExplanationDataset`.
-final class UpdateExplanationDatasetRequest extends ProtoMessage {
+final class UpdateExplanationDatasetRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateExplanationDatasetRequest';
 
@@ -68542,7 +68638,8 @@ final class UpdateExplanationDatasetRequest extends ProtoMessage {
 
 /// Runtime operation information for
 /// `ModelService.UpdateExplanationDataset`.
-final class UpdateExplanationDatasetOperationMetadata extends ProtoMessage {
+final class UpdateExplanationDatasetOperationMetadata
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateExplanationDatasetOperationMetadata';
 
@@ -68576,7 +68673,7 @@ final class UpdateExplanationDatasetOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `ModelService.DeleteModel`.
-final class DeleteModelRequest extends ProtoMessage {
+final class DeleteModelRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteModelRequest';
 
@@ -68604,7 +68701,7 @@ final class DeleteModelRequest extends ProtoMessage {
 
 /// Request message for
 /// `ModelService.DeleteModelVersion`.
-final class DeleteModelVersionRequest extends ProtoMessage {
+final class DeleteModelVersionRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteModelVersionRequest';
 
@@ -68634,7 +68731,7 @@ final class DeleteModelVersionRequest extends ProtoMessage {
 
 /// Request message for
 /// `ModelService.MergeVersionAliases`.
-final class MergeVersionAliasesRequest extends ProtoMessage {
+final class MergeVersionAliasesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.MergeVersionAliasesRequest';
 
@@ -68685,7 +68782,7 @@ final class MergeVersionAliasesRequest extends ProtoMessage {
 
 /// Request message for
 /// `ModelService.ExportModel`.
-final class ExportModelRequest extends ProtoMessage {
+final class ExportModelRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExportModelRequest';
 
@@ -68726,7 +68823,7 @@ final class ExportModelRequest extends ProtoMessage {
 }
 
 /// Output configuration for the Model export.
-final class ExportModelRequest_OutputConfig extends ProtoMessage {
+final class ExportModelRequest_OutputConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExportModelRequest.OutputConfig';
 
@@ -68796,7 +68893,7 @@ final class ExportModelRequest_OutputConfig extends ProtoMessage {
 /// Details of
 /// `ModelService.ExportModel`
 /// operation.
-final class ExportModelOperationMetadata extends ProtoMessage {
+final class ExportModelOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExportModelOperationMetadata';
 
@@ -68837,7 +68934,8 @@ final class ExportModelOperationMetadata extends ProtoMessage {
 
 /// Further describes the output of the ExportModel. Supplements
 /// `ExportModelRequest.OutputConfig`.
-final class ExportModelOperationMetadata_OutputInfo extends ProtoMessage {
+final class ExportModelOperationMetadata_OutputInfo
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExportModelOperationMetadata.OutputInfo';
 
@@ -68885,7 +68983,7 @@ final class ExportModelOperationMetadata_OutputInfo extends ProtoMessage {
 /// Response message of
 /// `ModelService.UpdateExplanationDataset`
 /// operation.
-final class UpdateExplanationDatasetResponse extends ProtoMessage {
+final class UpdateExplanationDatasetResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateExplanationDatasetResponse';
 
@@ -68907,7 +69005,7 @@ final class UpdateExplanationDatasetResponse extends ProtoMessage {
 /// Response message of
 /// `ModelService.ExportModel`
 /// operation.
-final class ExportModelResponse extends ProtoMessage {
+final class ExportModelResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExportModelResponse';
 
@@ -68928,7 +69026,7 @@ final class ExportModelResponse extends ProtoMessage {
 
 /// Request message for
 /// `ModelService.CopyModel`.
-final class CopyModelRequest extends ProtoMessage {
+final class CopyModelRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CopyModelRequest';
 
@@ -69001,7 +69099,7 @@ final class CopyModelRequest extends ProtoMessage {
 /// Details of
 /// `ModelService.CopyModel`
 /// operation.
-final class CopyModelOperationMetadata extends ProtoMessage {
+final class CopyModelOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CopyModelOperationMetadata';
 
@@ -69034,7 +69132,7 @@ final class CopyModelOperationMetadata extends ProtoMessage {
 /// Response message of
 /// `ModelService.CopyModel`
 /// operation.
-final class CopyModelResponse extends ProtoMessage {
+final class CopyModelResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CopyModelResponse';
 
@@ -69075,7 +69173,7 @@ final class CopyModelResponse extends ProtoMessage {
 
 /// Request message for
 /// `ModelService.ImportModelEvaluation`
-final class ImportModelEvaluationRequest extends ProtoMessage {
+final class ImportModelEvaluationRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ImportModelEvaluationRequest';
 
@@ -69116,7 +69214,8 @@ final class ImportModelEvaluationRequest extends ProtoMessage {
 
 /// Request message for
 /// `ModelService.BatchImportModelEvaluationSlices`
-final class BatchImportModelEvaluationSlicesRequest extends ProtoMessage {
+final class BatchImportModelEvaluationSlicesRequest
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BatchImportModelEvaluationSlicesRequest';
 
@@ -69163,7 +69262,8 @@ final class BatchImportModelEvaluationSlicesRequest extends ProtoMessage {
 
 /// Response message for
 /// `ModelService.BatchImportModelEvaluationSlices`
-final class BatchImportModelEvaluationSlicesResponse extends ProtoMessage {
+final class BatchImportModelEvaluationSlicesResponse
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BatchImportModelEvaluationSlicesResponse';
 
@@ -69198,7 +69298,8 @@ final class BatchImportModelEvaluationSlicesResponse extends ProtoMessage {
 
 /// Request message for
 /// `ModelService.BatchImportEvaluatedAnnotations`
-final class BatchImportEvaluatedAnnotationsRequest extends ProtoMessage {
+final class BatchImportEvaluatedAnnotationsRequest
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BatchImportEvaluatedAnnotationsRequest';
 
@@ -69245,7 +69346,8 @@ final class BatchImportEvaluatedAnnotationsRequest extends ProtoMessage {
 
 /// Response message for
 /// `ModelService.BatchImportEvaluatedAnnotations`
-final class BatchImportEvaluatedAnnotationsResponse extends ProtoMessage {
+final class BatchImportEvaluatedAnnotationsResponse
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BatchImportEvaluatedAnnotationsResponse';
 
@@ -69285,7 +69387,7 @@ final class BatchImportEvaluatedAnnotationsResponse extends ProtoMessage {
 
 /// Request message for
 /// `ModelService.GetModelEvaluation`.
-final class GetModelEvaluationRequest extends ProtoMessage {
+final class GetModelEvaluationRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetModelEvaluationRequest';
 
@@ -69314,7 +69416,7 @@ final class GetModelEvaluationRequest extends ProtoMessage {
 
 /// Request message for
 /// `ModelService.ListModelEvaluations`.
-final class ListModelEvaluationsRequest extends ProtoMessage {
+final class ListModelEvaluationsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListModelEvaluationsRequest';
 
@@ -69382,7 +69484,7 @@ final class ListModelEvaluationsRequest extends ProtoMessage {
 
 /// Response message for
 /// `ModelService.ListModelEvaluations`.
-final class ListModelEvaluationsResponse extends ProtoMessage {
+final class ListModelEvaluationsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListModelEvaluationsResponse';
 
@@ -69428,7 +69530,7 @@ final class ListModelEvaluationsResponse extends ProtoMessage {
 
 /// Request message for
 /// `ModelService.GetModelEvaluationSlice`.
-final class GetModelEvaluationSliceRequest extends ProtoMessage {
+final class GetModelEvaluationSliceRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetModelEvaluationSliceRequest';
 
@@ -69458,7 +69560,7 @@ final class GetModelEvaluationSliceRequest extends ProtoMessage {
 
 /// Request message for
 /// `ModelService.ListModelEvaluationSlices`.
-final class ListModelEvaluationSlicesRequest extends ProtoMessage {
+final class ListModelEvaluationSlicesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListModelEvaluationSlicesRequest';
 
@@ -69529,7 +69631,7 @@ final class ListModelEvaluationSlicesRequest extends ProtoMessage {
 
 /// Response message for
 /// `ModelService.ListModelEvaluationSlices`.
-final class ListModelEvaluationSlicesResponse extends ProtoMessage {
+final class ListModelEvaluationSlicesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListModelEvaluationSlicesResponse';
 
@@ -69579,7 +69681,7 @@ final class ListModelEvaluationSlicesResponse extends ProtoMessage {
 
 /// Request message for
 /// `ModelService.RecommendSpec`.
-final class RecommendSpecRequest extends ProtoMessage {
+final class RecommendSpecRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RecommendSpecRequest';
 
@@ -69644,7 +69746,7 @@ final class RecommendSpecRequest extends ProtoMessage {
 
 /// Response message for
 /// `ModelService.RecommendSpec`.
-final class RecommendSpecResponse extends ProtoMessage {
+final class RecommendSpecResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RecommendSpecResponse';
 
@@ -69694,7 +69796,7 @@ final class RecommendSpecResponse extends ProtoMessage {
 
 /// A machine and model container spec.
 final class RecommendSpecResponse_MachineAndModelContainerSpec
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RecommendSpecResponse.MachineAndModelContainerSpec';
 
@@ -69733,7 +69835,7 @@ final class RecommendSpecResponse_MachineAndModelContainerSpec
 /// Recommendation of one deployment option for the given custom weights model
 /// in one region.
 /// Contains the machine and container spec, and user accelerator quota state.
-final class RecommendSpecResponse_Recommendation extends ProtoMessage {
+final class RecommendSpecResponse_Recommendation extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RecommendSpecResponse.Recommendation';
 
@@ -69788,7 +69890,8 @@ final class RecommendSpecResponse_Recommendation extends ProtoMessage {
 }
 
 /// The user accelerator quota state.
-final class RecommendSpecResponse_Recommendation_QuotaState extends ProtoEnum {
+final class RecommendSpecResponse_Recommendation_QuotaState
+    extends protobuf.ProtoEnum {
   /// Unspecified quota state. Quota information not available.
   static const quotaStateUnspecified =
       RecommendSpecResponse_Recommendation_QuotaState(
@@ -69818,7 +69921,7 @@ final class RecommendSpecResponse_Recommendation_QuotaState extends ProtoEnum {
 }
 
 /// Represents a Neural Architecture Search (NAS) job.
-final class NasJob extends ProtoMessage {
+final class NasJob extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.NasJob';
 
@@ -69958,7 +70061,7 @@ final class NasJob extends ProtoMessage {
 
 /// Represents a NasTrial details along with its parameters. If there is a
 /// corresponding train NasTrial, the train NasTrial is also returned.
-final class NasTrialDetail extends ProtoMessage {
+final class NasTrialDetail extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.NasTrialDetail';
 
@@ -70015,7 +70118,7 @@ final class NasTrialDetail extends ProtoMessage {
 }
 
 /// Represents the spec of a NasJob.
-final class NasJobSpec extends ProtoMessage {
+final class NasJobSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.NasJobSpec';
 
@@ -70069,7 +70172,7 @@ final class NasJobSpec extends ProtoMessage {
 }
 
 /// The spec of multi-trial Neural Architecture Search (NAS).
-final class NasJobSpec_MultiTrialAlgorithmSpec extends ProtoMessage {
+final class NasJobSpec_MultiTrialAlgorithmSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.NasJobSpec.MultiTrialAlgorithmSpec';
 
@@ -70142,7 +70245,8 @@ final class NasJobSpec_MultiTrialAlgorithmSpec extends ProtoMessage {
 }
 
 /// Represents a metric to optimize.
-final class NasJobSpec_MultiTrialAlgorithmSpec_MetricSpec extends ProtoMessage {
+final class NasJobSpec_MultiTrialAlgorithmSpec_MetricSpec
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.NasJobSpec.MultiTrialAlgorithmSpec.MetricSpec';
 
@@ -70187,7 +70291,7 @@ final class NasJobSpec_MultiTrialAlgorithmSpec_MetricSpec extends ProtoMessage {
 
 /// The available types of optimization goals.
 final class NasJobSpec_MultiTrialAlgorithmSpec_MetricSpec_GoalType
-    extends ProtoEnum {
+    extends protobuf.ProtoEnum {
   /// Goal Type will default to maximize.
   static const goalTypeUnspecified =
       NasJobSpec_MultiTrialAlgorithmSpec_MetricSpec_GoalType(
@@ -70214,7 +70318,7 @@ final class NasJobSpec_MultiTrialAlgorithmSpec_MetricSpec_GoalType
 
 /// Represent spec for search trials.
 final class NasJobSpec_MultiTrialAlgorithmSpec_SearchTrialSpec
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.NasJobSpec.MultiTrialAlgorithmSpec.SearchTrialSpec';
 
@@ -70285,7 +70389,7 @@ final class NasJobSpec_MultiTrialAlgorithmSpec_SearchTrialSpec
 
 /// Represent spec for train trials.
 final class NasJobSpec_MultiTrialAlgorithmSpec_TrainTrialSpec
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.NasJobSpec.MultiTrialAlgorithmSpec.TrainTrialSpec';
 
@@ -70345,7 +70449,7 @@ final class NasJobSpec_MultiTrialAlgorithmSpec_TrainTrialSpec
 
 /// The available types of multi-trial algorithms.
 final class NasJobSpec_MultiTrialAlgorithmSpec_MultiTrialAlgorithm
-    extends ProtoEnum {
+    extends protobuf.ProtoEnum {
   /// Defaults to `REINFORCEMENT_LEARNING`.
   static const multiTrialAlgorithmUnspecified =
       NasJobSpec_MultiTrialAlgorithmSpec_MultiTrialAlgorithm(
@@ -70375,7 +70479,7 @@ final class NasJobSpec_MultiTrialAlgorithmSpec_MultiTrialAlgorithm
 }
 
 /// Represents a uCAIP NasJob output.
-final class NasJobOutput extends ProtoMessage {
+final class NasJobOutput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.NasJobOutput';
 
@@ -70407,7 +70511,7 @@ final class NasJobOutput extends ProtoMessage {
 }
 
 /// The output of a multi-trial Neural Architecture Search (NAS) jobs.
-final class NasJobOutput_MultiTrialJobOutput extends ProtoMessage {
+final class NasJobOutput_MultiTrialJobOutput extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.NasJobOutput.MultiTrialJobOutput';
 
@@ -70440,7 +70544,7 @@ final class NasJobOutput_MultiTrialJobOutput extends ProtoMessage {
 }
 
 /// Represents a uCAIP NasJob trial.
-final class NasTrial extends ProtoMessage {
+final class NasTrial extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.NasTrial';
 
@@ -70501,7 +70605,7 @@ final class NasTrial extends ProtoMessage {
 }
 
 /// Describes a NasTrial state.
-final class NasTrial_State extends ProtoEnum {
+final class NasTrial_State extends protobuf.ProtoEnum {
   /// The NasTrial state is unspecified.
   static const stateUnspecified = NasTrial_State('STATE_UNSPECIFIED');
 
@@ -70532,7 +70636,7 @@ final class NasTrial_State extends ProtoEnum {
 }
 
 /// Network spec.
-final class NetworkSpec extends ProtoMessage {
+final class NetworkSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.NetworkSpec';
 
@@ -70582,7 +70686,7 @@ final class NetworkSpec extends ProtoMessage {
 }
 
 /// The euc configuration of NotebookRuntimeTemplate.
-final class NotebookEucConfig extends ProtoMessage {
+final class NotebookEucConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.NotebookEucConfig';
 
@@ -70629,7 +70733,7 @@ final class NotebookEucConfig extends ProtoMessage {
 }
 
 /// NotebookExecutionJob represents an instance of a notebook execution.
-final class NotebookExecutionJob extends ProtoMessage {
+final class NotebookExecutionJob extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.NotebookExecutionJob';
 
@@ -70835,7 +70939,8 @@ final class NotebookExecutionJob extends ProtoMessage {
 }
 
 /// The Dataform Repository containing the input notebook.
-final class NotebookExecutionJob_DataformRepositorySource extends ProtoMessage {
+final class NotebookExecutionJob_DataformRepositorySource
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.NotebookExecutionJob.DataformRepositorySource';
 
@@ -70882,7 +70987,8 @@ final class NotebookExecutionJob_DataformRepositorySource extends ProtoMessage {
 }
 
 /// The Cloud Storage uri for the input notebook.
-final class NotebookExecutionJob_GcsNotebookSource extends ProtoMessage {
+final class NotebookExecutionJob_GcsNotebookSource
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.NotebookExecutionJob.GcsNotebookSource';
 
@@ -70926,7 +71032,8 @@ final class NotebookExecutionJob_GcsNotebookSource extends ProtoMessage {
 }
 
 /// The content of the input notebook in ipynb format.
-final class NotebookExecutionJob_DirectNotebookSource extends ProtoMessage {
+final class NotebookExecutionJob_DirectNotebookSource
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.NotebookExecutionJob.DirectNotebookSource';
 
@@ -70957,7 +71064,8 @@ final class NotebookExecutionJob_DirectNotebookSource extends ProtoMessage {
 }
 
 /// Compute configuration to use for an execution job.
-final class NotebookExecutionJob_CustomEnvironmentSpec extends ProtoMessage {
+final class NotebookExecutionJob_CustomEnvironmentSpec
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.NotebookExecutionJob.CustomEnvironmentSpec';
 
@@ -71004,7 +71112,8 @@ final class NotebookExecutionJob_CustomEnvironmentSpec extends ProtoMessage {
 }
 
 /// Configuration for a Workbench Instances-based environment.
-final class NotebookExecutionJob_WorkbenchRuntime extends ProtoMessage {
+final class NotebookExecutionJob_WorkbenchRuntime
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.NotebookExecutionJob.WorkbenchRuntime';
 
@@ -71027,7 +71136,7 @@ final class NotebookExecutionJob_WorkbenchRuntime extends ProtoMessage {
 
 /// The idle shutdown configuration of NotebookRuntimeTemplate, which contains
 /// the idle_timeout as required field.
-final class NotebookIdleShutdownConfig extends ProtoMessage {
+final class NotebookIdleShutdownConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.NotebookIdleShutdownConfig';
 
@@ -71074,7 +71183,7 @@ final class NotebookIdleShutdownConfig extends ProtoMessage {
 /// A template that specifies runtime configurations such as machine type,
 /// runtime version, network configurations, etc.
 /// Multiple runtimes can be created from a runtime template.
-final class NotebookRuntimeTemplate extends ProtoMessage {
+final class NotebookRuntimeTemplate extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.NotebookRuntimeTemplate';
 
@@ -71279,7 +71388,7 @@ final class NotebookRuntimeTemplate extends ProtoMessage {
 /// particular Notebook file on temporary basis with lifetime. Default runtimes
 /// have a lifetime of 18 hours, while custom runtimes last for 6 months from
 /// their creation or last upgrade.
-final class NotebookRuntime extends ProtoMessage {
+final class NotebookRuntime extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.NotebookRuntime';
 
@@ -71550,7 +71659,7 @@ final class NotebookRuntime extends ProtoMessage {
 }
 
 /// The substate of the NotebookRuntime to display health information.
-final class NotebookRuntime_HealthState extends ProtoEnum {
+final class NotebookRuntime_HealthState extends protobuf.ProtoEnum {
   /// Unspecified health state.
   static const healthStateUnspecified = NotebookRuntime_HealthState(
     'HEALTH_STATE_UNSPECIFIED',
@@ -71573,7 +71682,7 @@ final class NotebookRuntime_HealthState extends ProtoEnum {
 
 /// The substate of the NotebookRuntime to display state of runtime.
 /// The resource of NotebookRuntime is in ACTIVE state for these sub state.
-final class NotebookRuntime_RuntimeState extends ProtoEnum {
+final class NotebookRuntime_RuntimeState extends protobuf.ProtoEnum {
   /// Unspecified runtime state.
   static const runtimeStateUnspecified = NotebookRuntime_RuntimeState(
     'RUNTIME_STATE_UNSPECIFIED',
@@ -71612,7 +71721,7 @@ final class NotebookRuntime_RuntimeState extends ProtoEnum {
 }
 
 /// Points to a NotebookRuntimeTemplateRef.
-final class NotebookRuntimeTemplateRef extends ProtoMessage {
+final class NotebookRuntimeTemplateRef extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.NotebookRuntimeTemplateRef';
 
@@ -71648,7 +71757,7 @@ final class NotebookRuntimeTemplateRef extends ProtoMessage {
 
 /// Request message for
 /// `NotebookService.CreateNotebookRuntimeTemplate`.
-final class CreateNotebookRuntimeTemplateRequest extends ProtoMessage {
+final class CreateNotebookRuntimeTemplateRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateNotebookRuntimeTemplateRequest';
 
@@ -71705,7 +71814,7 @@ final class CreateNotebookRuntimeTemplateRequest extends ProtoMessage {
 /// Metadata information for
 /// `NotebookService.CreateNotebookRuntimeTemplate`.
 final class CreateNotebookRuntimeTemplateOperationMetadata
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateNotebookRuntimeTemplateOperationMetadata';
 
@@ -71739,7 +71848,7 @@ final class CreateNotebookRuntimeTemplateOperationMetadata
 
 /// Request message for
 /// `NotebookService.GetNotebookRuntimeTemplate`
-final class GetNotebookRuntimeTemplateRequest extends ProtoMessage {
+final class GetNotebookRuntimeTemplateRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetNotebookRuntimeTemplateRequest';
 
@@ -71771,7 +71880,7 @@ final class GetNotebookRuntimeTemplateRequest extends ProtoMessage {
 
 /// Request message for
 /// `NotebookService.ListNotebookRuntimeTemplates`.
-final class ListNotebookRuntimeTemplatesRequest extends ProtoMessage {
+final class ListNotebookRuntimeTemplatesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListNotebookRuntimeTemplatesRequest';
 
@@ -71880,7 +71989,7 @@ final class ListNotebookRuntimeTemplatesRequest extends ProtoMessage {
 
 /// Response message for
 /// `NotebookService.ListNotebookRuntimeTemplates`.
-final class ListNotebookRuntimeTemplatesResponse extends ProtoMessage {
+final class ListNotebookRuntimeTemplatesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListNotebookRuntimeTemplatesResponse';
 
@@ -71930,7 +72039,7 @@ final class ListNotebookRuntimeTemplatesResponse extends ProtoMessage {
 
 /// Request message for
 /// `NotebookService.DeleteNotebookRuntimeTemplate`.
-final class DeleteNotebookRuntimeTemplateRequest extends ProtoMessage {
+final class DeleteNotebookRuntimeTemplateRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteNotebookRuntimeTemplateRequest';
 
@@ -71962,7 +72071,7 @@ final class DeleteNotebookRuntimeTemplateRequest extends ProtoMessage {
 
 /// Request message for
 /// `NotebookService.UpdateNotebookRuntimeTemplate`.
-final class UpdateNotebookRuntimeTemplateRequest extends ProtoMessage {
+final class UpdateNotebookRuntimeTemplateRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateNotebookRuntimeTemplateRequest';
 
@@ -72008,7 +72117,7 @@ final class UpdateNotebookRuntimeTemplateRequest extends ProtoMessage {
 
 /// Request message for
 /// `NotebookService.AssignNotebookRuntime`.
-final class AssignNotebookRuntimeRequest extends ProtoMessage {
+final class AssignNotebookRuntimeRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AssignNotebookRuntimeRequest';
 
@@ -72071,7 +72180,8 @@ final class AssignNotebookRuntimeRequest extends ProtoMessage {
 
 /// Metadata information for
 /// `NotebookService.AssignNotebookRuntime`.
-final class AssignNotebookRuntimeOperationMetadata extends ProtoMessage {
+final class AssignNotebookRuntimeOperationMetadata
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AssignNotebookRuntimeOperationMetadata';
 
@@ -72118,7 +72228,7 @@ final class AssignNotebookRuntimeOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `NotebookService.GetNotebookRuntime`
-final class GetNotebookRuntimeRequest extends ProtoMessage {
+final class GetNotebookRuntimeRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetNotebookRuntimeRequest';
 
@@ -72148,7 +72258,7 @@ final class GetNotebookRuntimeRequest extends ProtoMessage {
 
 /// Request message for
 /// `NotebookService.ListNotebookRuntimes`.
-final class ListNotebookRuntimesRequest extends ProtoMessage {
+final class ListNotebookRuntimesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListNotebookRuntimesRequest';
 
@@ -72269,7 +72379,7 @@ final class ListNotebookRuntimesRequest extends ProtoMessage {
 
 /// Response message for
 /// `NotebookService.ListNotebookRuntimes`.
-final class ListNotebookRuntimesResponse extends ProtoMessage {
+final class ListNotebookRuntimesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListNotebookRuntimesResponse';
 
@@ -72315,7 +72425,7 @@ final class ListNotebookRuntimesResponse extends ProtoMessage {
 
 /// Request message for
 /// `NotebookService.DeleteNotebookRuntime`.
-final class DeleteNotebookRuntimeRequest extends ProtoMessage {
+final class DeleteNotebookRuntimeRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteNotebookRuntimeRequest';
 
@@ -72346,7 +72456,7 @@ final class DeleteNotebookRuntimeRequest extends ProtoMessage {
 
 /// Request message for
 /// `NotebookService.UpgradeNotebookRuntime`.
-final class UpgradeNotebookRuntimeRequest extends ProtoMessage {
+final class UpgradeNotebookRuntimeRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpgradeNotebookRuntimeRequest';
 
@@ -72377,7 +72487,8 @@ final class UpgradeNotebookRuntimeRequest extends ProtoMessage {
 
 /// Metadata information for
 /// `NotebookService.UpgradeNotebookRuntime`.
-final class UpgradeNotebookRuntimeOperationMetadata extends ProtoMessage {
+final class UpgradeNotebookRuntimeOperationMetadata
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpgradeNotebookRuntimeOperationMetadata';
 
@@ -72424,7 +72535,7 @@ final class UpgradeNotebookRuntimeOperationMetadata extends ProtoMessage {
 
 /// Response message for
 /// `NotebookService.UpgradeNotebookRuntime`.
-final class UpgradeNotebookRuntimeResponse extends ProtoMessage {
+final class UpgradeNotebookRuntimeResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpgradeNotebookRuntimeResponse';
 
@@ -72445,7 +72556,7 @@ final class UpgradeNotebookRuntimeResponse extends ProtoMessage {
 
 /// Request message for
 /// `NotebookService.StartNotebookRuntime`.
-final class StartNotebookRuntimeRequest extends ProtoMessage {
+final class StartNotebookRuntimeRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StartNotebookRuntimeRequest';
 
@@ -72475,7 +72586,8 @@ final class StartNotebookRuntimeRequest extends ProtoMessage {
 
 /// Metadata information for
 /// `NotebookService.StartNotebookRuntime`.
-final class StartNotebookRuntimeOperationMetadata extends ProtoMessage {
+final class StartNotebookRuntimeOperationMetadata
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StartNotebookRuntimeOperationMetadata';
 
@@ -72522,7 +72634,7 @@ final class StartNotebookRuntimeOperationMetadata extends ProtoMessage {
 
 /// Response message for
 /// `NotebookService.StartNotebookRuntime`.
-final class StartNotebookRuntimeResponse extends ProtoMessage {
+final class StartNotebookRuntimeResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StartNotebookRuntimeResponse';
 
@@ -72543,7 +72655,7 @@ final class StartNotebookRuntimeResponse extends ProtoMessage {
 
 /// Request message for
 /// `NotebookService.StopNotebookRuntime`.
-final class StopNotebookRuntimeRequest extends ProtoMessage {
+final class StopNotebookRuntimeRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StopNotebookRuntimeRequest';
 
@@ -72573,7 +72685,7 @@ final class StopNotebookRuntimeRequest extends ProtoMessage {
 
 /// Metadata information for
 /// `NotebookService.StopNotebookRuntime`.
-final class StopNotebookRuntimeOperationMetadata extends ProtoMessage {
+final class StopNotebookRuntimeOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StopNotebookRuntimeOperationMetadata';
 
@@ -72607,7 +72719,7 @@ final class StopNotebookRuntimeOperationMetadata extends ProtoMessage {
 
 /// Response message for
 /// `NotebookService.StopNotebookRuntime`.
-final class StopNotebookRuntimeResponse extends ProtoMessage {
+final class StopNotebookRuntimeResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StopNotebookRuntimeResponse';
 
@@ -72627,7 +72739,7 @@ final class StopNotebookRuntimeResponse extends ProtoMessage {
 }
 
 /// Request message for [NotebookService.CreateNotebookExecutionJob]
-final class CreateNotebookExecutionJobRequest extends ProtoMessage {
+final class CreateNotebookExecutionJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateNotebookExecutionJobRequest';
 
@@ -72683,7 +72795,8 @@ final class CreateNotebookExecutionJobRequest extends ProtoMessage {
 
 /// Metadata information for
 /// `NotebookService.CreateNotebookExecutionJob`.
-final class CreateNotebookExecutionJobOperationMetadata extends ProtoMessage {
+final class CreateNotebookExecutionJobOperationMetadata
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateNotebookExecutionJobOperationMetadata';
 
@@ -72729,7 +72842,7 @@ final class CreateNotebookExecutionJobOperationMetadata extends ProtoMessage {
 }
 
 /// Request message for [NotebookService.GetNotebookExecutionJob]
-final class GetNotebookExecutionJobRequest extends ProtoMessage {
+final class GetNotebookExecutionJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetNotebookExecutionJobRequest';
 
@@ -72762,7 +72875,7 @@ final class GetNotebookExecutionJobRequest extends ProtoMessage {
 }
 
 /// Request message for [NotebookService.ListNotebookExecutionJobs]
-final class ListNotebookExecutionJobsRequest extends ProtoMessage {
+final class ListNotebookExecutionJobsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListNotebookExecutionJobsRequest';
 
@@ -72856,7 +72969,7 @@ final class ListNotebookExecutionJobsRequest extends ProtoMessage {
 }
 
 /// Response message for [NotebookService.CreateNotebookExecutionJob]
-final class ListNotebookExecutionJobsResponse extends ProtoMessage {
+final class ListNotebookExecutionJobsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListNotebookExecutionJobsResponse';
 
@@ -72905,7 +73018,7 @@ final class ListNotebookExecutionJobsResponse extends ProtoMessage {
 }
 
 /// Request message for [NotebookService.DeleteNotebookExecutionJob]
-final class DeleteNotebookExecutionJobRequest extends ProtoMessage {
+final class DeleteNotebookExecutionJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteNotebookExecutionJobRequest';
 
@@ -72933,7 +73046,7 @@ final class DeleteNotebookExecutionJobRequest extends ProtoMessage {
   }
 }
 
-final class PostStartupScriptConfig extends ProtoMessage {
+final class PostStartupScriptConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PostStartupScriptConfig';
 
@@ -72986,7 +73099,7 @@ final class PostStartupScriptConfig extends ProtoMessage {
 }
 
 final class PostStartupScriptConfig_PostStartupScriptBehavior
-    extends ProtoEnum {
+    extends protobuf.ProtoEnum {
   static const postStartupScriptBehaviorUnspecified =
       PostStartupScriptConfig_PostStartupScriptBehavior(
         'POST_STARTUP_SCRIPT_BEHAVIOR_UNSPECIFIED',
@@ -73015,7 +73128,7 @@ final class PostStartupScriptConfig_PostStartupScriptBehavior
 }
 
 /// Colab image of the runtime.
-final class ColabImage extends ProtoMessage {
+final class ColabImage extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ColabImage';
 
@@ -73057,7 +73170,7 @@ final class ColabImage extends ProtoMessage {
 
 /// Notebook Software Config. This is passed to the backend when user
 /// makes software configurations in UI.
-final class NotebookSoftwareConfig extends ProtoMessage {
+final class NotebookSoftwareConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.NotebookSoftwareConfig';
 
@@ -73105,7 +73218,7 @@ final class NotebookSoftwareConfig extends ProtoMessage {
 /// subset of an [OpenAPI 3.0 schema
 /// object](https://spec.openapis.org/oas/v3.0.3#schema-object). More fields may
 /// be added in the future as needed.
-final class Schema extends ProtoMessage {
+final class Schema extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Schema';
 
@@ -73338,7 +73451,7 @@ final class Schema extends ProtoMessage {
 }
 
 /// Generic Metadata shared by all operations.
-final class GenericOperationMetadata extends ProtoMessage {
+final class GenericOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GenericOperationMetadata';
 
@@ -73388,7 +73501,7 @@ final class GenericOperationMetadata extends ProtoMessage {
 }
 
 /// Details of operations that perform deletes of any entities.
-final class DeleteOperationMetadata extends ProtoMessage {
+final class DeleteOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteOperationMetadata';
 
@@ -73421,7 +73534,7 @@ final class DeleteOperationMetadata extends ProtoMessage {
 /// workloads.
 /// A PersistentResource can have multiple node pools and each node
 /// pool can have its own machine spec.
-final class PersistentResource extends ProtoMessage {
+final class PersistentResource extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PersistentResource';
 
@@ -73605,7 +73718,7 @@ final class PersistentResource extends ProtoMessage {
 }
 
 /// Describes the PersistentResource state.
-final class PersistentResource_State extends ProtoEnum {
+final class PersistentResource_State extends protobuf.ProtoEnum {
   /// Not set.
   static const stateUnspecified = PersistentResource_State('STATE_UNSPECIFIED');
 
@@ -73642,7 +73755,7 @@ final class PersistentResource_State extends ProtoEnum {
 
 /// Represents the spec of a group of resources of the same type,
 /// for example machine type, disk, and accelerators, in a PersistentResource.
-final class ResourcePool extends ProtoMessage {
+final class ResourcePool extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ResourcePool';
 
@@ -73715,7 +73828,7 @@ final class ResourcePool extends ProtoMessage {
 }
 
 /// The min/max number of replicas allowed if enabling autoscaling
-final class ResourcePool_AutoscalingSpec extends ProtoMessage {
+final class ResourcePool_AutoscalingSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ResourcePool.AutoscalingSpec';
 
@@ -73768,7 +73881,7 @@ final class ResourcePool_AutoscalingSpec extends ProtoMessage {
 ///
 /// * Service accounts used to run the workloads.
 /// * Whether to make it a dedicated Ray Cluster.
-final class ResourceRuntimeSpec extends ProtoMessage {
+final class ResourceRuntimeSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ResourceRuntimeSpec';
 
@@ -73809,7 +73922,7 @@ final class ResourceRuntimeSpec extends ProtoMessage {
 /// For experimental launch, Ray cluster creation and Persistent
 /// cluster creation are 1:1 mapping: We will provision all the nodes within the
 /// Persistent cluster as Ray nodes.
-final class RaySpec extends ProtoMessage {
+final class RaySpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RaySpec';
 
@@ -73892,7 +74005,7 @@ final class RaySpec extends ProtoMessage {
 }
 
 /// Persistent Cluster runtime information as output
-final class ResourceRuntime extends ProtoMessage {
+final class ResourceRuntime extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ResourceRuntime';
 
@@ -73941,7 +74054,7 @@ final class ResourceRuntime extends ProtoMessage {
 }
 
 /// Configuration for the use of custom service account to run the workloads.
-final class ServiceAccountSpec extends ProtoMessage {
+final class ServiceAccountSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ServiceAccountSpec';
 
@@ -73995,7 +74108,7 @@ final class ServiceAccountSpec extends ProtoMessage {
 }
 
 /// Configuration for the Ray metrics.
-final class RayMetricSpec extends ProtoMessage {
+final class RayMetricSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RayMetricSpec';
 
@@ -74021,7 +74134,7 @@ final class RayMetricSpec extends ProtoMessage {
 }
 
 /// Configuration for the Ray OSS Logs.
-final class RayLogsSpec extends ProtoMessage {
+final class RayLogsSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RayLogsSpec';
 
@@ -74048,7 +74161,7 @@ final class RayLogsSpec extends ProtoMessage {
 
 /// Request message for
 /// `PersistentResourceService.CreatePersistentResource`.
-final class CreatePersistentResourceRequest extends ProtoMessage {
+final class CreatePersistentResourceRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreatePersistentResourceRequest';
 
@@ -74105,7 +74218,8 @@ final class CreatePersistentResourceRequest extends ProtoMessage {
 }
 
 /// Details of operations that perform create PersistentResource.
-final class CreatePersistentResourceOperationMetadata extends ProtoMessage {
+final class CreatePersistentResourceOperationMetadata
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreatePersistentResourceOperationMetadata';
 
@@ -74150,7 +74264,8 @@ final class CreatePersistentResourceOperationMetadata extends ProtoMessage {
 }
 
 /// Details of operations that perform update PersistentResource.
-final class UpdatePersistentResourceOperationMetadata extends ProtoMessage {
+final class UpdatePersistentResourceOperationMetadata
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdatePersistentResourceOperationMetadata';
 
@@ -74195,7 +74310,8 @@ final class UpdatePersistentResourceOperationMetadata extends ProtoMessage {
 }
 
 /// Details of operations that perform reboot PersistentResource.
-final class RebootPersistentResourceOperationMetadata extends ProtoMessage {
+final class RebootPersistentResourceOperationMetadata
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RebootPersistentResourceOperationMetadata';
 
@@ -74241,7 +74357,7 @@ final class RebootPersistentResourceOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `PersistentResourceService.GetPersistentResource`.
-final class GetPersistentResourceRequest extends ProtoMessage {
+final class GetPersistentResourceRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetPersistentResourceRequest';
 
@@ -74270,7 +74386,7 @@ final class GetPersistentResourceRequest extends ProtoMessage {
 }
 
 /// Request message for `PersistentResourceService.ListPersistentResource`.
-final class ListPersistentResourcesRequest extends ProtoMessage {
+final class ListPersistentResourcesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListPersistentResourcesRequest';
 
@@ -74323,7 +74439,7 @@ final class ListPersistentResourcesRequest extends ProtoMessage {
 
 /// Response message for
 /// `PersistentResourceService.ListPersistentResources`
-final class ListPersistentResourcesResponse extends ProtoMessage {
+final class ListPersistentResourcesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListPersistentResourcesResponse';
 
@@ -74370,7 +74486,7 @@ final class ListPersistentResourcesResponse extends ProtoMessage {
 
 /// Request message for
 /// `PersistentResourceService.DeletePersistentResource`.
-final class DeletePersistentResourceRequest extends ProtoMessage {
+final class DeletePersistentResourceRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeletePersistentResourceRequest';
 
@@ -74399,7 +74515,7 @@ final class DeletePersistentResourceRequest extends ProtoMessage {
 }
 
 /// Request message for UpdatePersistentResource method.
-final class UpdatePersistentResourceRequest extends ProtoMessage {
+final class UpdatePersistentResourceRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdatePersistentResourceRequest';
 
@@ -74443,7 +74559,7 @@ final class UpdatePersistentResourceRequest extends ProtoMessage {
 
 /// Request message for
 /// `PersistentResourceService.RebootPersistentResource`.
-final class RebootPersistentResourceRequest extends ProtoMessage {
+final class RebootPersistentResourceRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RebootPersistentResourceRequest';
 
@@ -74472,7 +74588,7 @@ final class RebootPersistentResourceRequest extends ProtoMessage {
 }
 
 /// An instance of a machine learning PipelineJob.
-final class PipelineJob extends ProtoMessage {
+final class PipelineJob extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PipelineJob';
 
@@ -74737,7 +74853,7 @@ final class PipelineJob extends ProtoMessage {
 }
 
 /// The runtime config of a PipelineJob.
-final class PipelineJob_RuntimeConfig extends ProtoMessage {
+final class PipelineJob_RuntimeConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PipelineJob.RuntimeConfig';
 
@@ -74843,7 +74959,8 @@ final class PipelineJob_RuntimeConfig extends ProtoMessage {
 }
 
 /// The type of an input artifact.
-final class PipelineJob_RuntimeConfig_InputArtifact extends ProtoMessage {
+final class PipelineJob_RuntimeConfig_InputArtifact
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PipelineJob.RuntimeConfig.InputArtifact';
 
@@ -74882,7 +74999,7 @@ final class PipelineJob_RuntimeConfig_InputArtifact extends ProtoMessage {
 /// Persistent resource based runtime detail. For more information, refer to
 /// https://cloud.google.com/vertex-ai/docs/training/persistent-resource-overview
 final class PipelineJob_RuntimeConfig_PersistentResourceRuntimeDetail
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PipelineJob.RuntimeConfig.PersistentResourceRuntimeDetail';
 
@@ -74953,7 +75070,7 @@ final class PipelineJob_RuntimeConfig_PersistentResourceRuntimeDetail
 
 /// An enum that specifies the behavior to take if the timeout is reached.
 final class PipelineJob_RuntimeConfig_PersistentResourceRuntimeDetail_TaskResourceUnavailableTimeoutBehavior
-    extends ProtoEnum {
+    extends protobuf.ProtoEnum {
   /// Unspecified. Behavior is same as `FAIL`.
   static const taskResourceUnavailableTimeoutBehaviorUnspecified =
       PipelineJob_RuntimeConfig_PersistentResourceRuntimeDetail_TaskResourceUnavailableTimeoutBehavior(
@@ -74988,7 +75105,8 @@ final class PipelineJob_RuntimeConfig_PersistentResourceRuntimeDetail_TaskResour
 }
 
 /// The default runtime for the PipelineJob.
-final class PipelineJob_RuntimeConfig_DefaultRuntime extends ProtoMessage {
+final class PipelineJob_RuntimeConfig_DefaultRuntime
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PipelineJob.RuntimeConfig.DefaultRuntime';
 
@@ -75028,7 +75146,7 @@ final class PipelineJob_RuntimeConfig_DefaultRuntime extends ProtoMessage {
 /// `PipelineJob.template_uri`
 /// is from supported template registry. Currently, the only supported registry
 /// is Artifact Registry.
-final class PipelineTemplateMetadata extends ProtoMessage {
+final class PipelineTemplateMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PipelineTemplateMetadata';
 
@@ -75060,7 +75178,7 @@ final class PipelineTemplateMetadata extends ProtoMessage {
 }
 
 /// The runtime detail of PipelineJob.
-final class PipelineJobDetail extends ProtoMessage {
+final class PipelineJobDetail extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PipelineJobDetail';
 
@@ -75105,7 +75223,7 @@ final class PipelineJobDetail extends ProtoMessage {
 }
 
 /// The runtime detail of a task execution.
-final class PipelineTaskDetail extends ProtoMessage {
+final class PipelineTaskDetail extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PipelineTaskDetail';
 
@@ -75245,7 +75363,8 @@ final class PipelineTaskDetail extends ProtoMessage {
 }
 
 /// A single record of the task status.
-final class PipelineTaskDetail_PipelineTaskStatus extends ProtoMessage {
+final class PipelineTaskDetail_PipelineTaskStatus
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PipelineTaskDetail.PipelineTaskStatus';
 
@@ -75295,7 +75414,7 @@ final class PipelineTaskDetail_PipelineTaskStatus extends ProtoMessage {
 }
 
 /// A list of artifact metadata.
-final class PipelineTaskDetail_ArtifactList extends ProtoMessage {
+final class PipelineTaskDetail_ArtifactList extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PipelineTaskDetail.ArtifactList';
 
@@ -75320,7 +75439,7 @@ final class PipelineTaskDetail_ArtifactList extends ProtoMessage {
 }
 
 /// Specifies state of TaskExecution
-final class PipelineTaskDetail_State extends ProtoEnum {
+final class PipelineTaskDetail_State extends protobuf.ProtoEnum {
   /// Unspecified.
   static const stateUnspecified = PipelineTaskDetail_State('STATE_UNSPECIFIED');
 
@@ -75364,7 +75483,7 @@ final class PipelineTaskDetail_State extends ProtoEnum {
 }
 
 /// The runtime detail of a pipeline executor.
-final class PipelineTaskExecutorDetail extends ProtoMessage {
+final class PipelineTaskExecutorDetail extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PipelineTaskExecutorDetail';
 
@@ -75404,7 +75523,8 @@ final class PipelineTaskExecutorDetail extends ProtoMessage {
 
 /// The detail of a container execution. It contains the job names of the
 /// lifecycle of a container execution.
-final class PipelineTaskExecutorDetail_ContainerDetail extends ProtoMessage {
+final class PipelineTaskExecutorDetail_ContainerDetail
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PipelineTaskExecutorDetail.ContainerDetail';
 
@@ -75474,7 +75594,8 @@ final class PipelineTaskExecutorDetail_ContainerDetail extends ProtoMessage {
 }
 
 /// The detailed info for a custom job executor.
-final class PipelineTaskExecutorDetail_CustomJobDetail extends ProtoMessage {
+final class PipelineTaskExecutorDetail_CustomJobDetail
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PipelineTaskExecutorDetail.CustomJobDetail';
 
@@ -75517,7 +75638,7 @@ final class PipelineTaskExecutorDetail_CustomJobDetail extends ProtoMessage {
 /// User provided rerun config to submit a rerun pipelinejob. This includes
 /// 1. Which task to rerun
 /// 2. User override input parameters and artifacts.
-final class PipelineTaskRerunConfig extends ProtoMessage {
+final class PipelineTaskRerunConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PipelineTaskRerunConfig';
 
@@ -75580,7 +75701,7 @@ final class PipelineTaskRerunConfig extends ProtoMessage {
 }
 
 /// A list of artifact metadata.
-final class PipelineTaskRerunConfig_ArtifactList extends ProtoMessage {
+final class PipelineTaskRerunConfig_ArtifactList extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PipelineTaskRerunConfig.ArtifactList';
 
@@ -75608,7 +75729,7 @@ final class PipelineTaskRerunConfig_ArtifactList extends ProtoMessage {
 }
 
 /// Runtime inputs data of the task.
-final class PipelineTaskRerunConfig_Inputs extends ProtoMessage {
+final class PipelineTaskRerunConfig_Inputs extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PipelineTaskRerunConfig.Inputs';
 
@@ -75649,7 +75770,8 @@ final class PipelineTaskRerunConfig_Inputs extends ProtoMessage {
 
 /// Runtime operation information for
 /// `PipelineService.BatchCancelPipelineJobs`.
-final class BatchCancelPipelineJobsOperationMetadata extends ProtoMessage {
+final class BatchCancelPipelineJobsOperationMetadata
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BatchCancelPipelineJobsOperationMetadata';
 
@@ -75683,7 +75805,7 @@ final class BatchCancelPipelineJobsOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `PipelineService.CreateTrainingPipeline`.
-final class CreateTrainingPipelineRequest extends ProtoMessage {
+final class CreateTrainingPipelineRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateTrainingPipelineRequest';
 
@@ -75723,7 +75845,7 @@ final class CreateTrainingPipelineRequest extends ProtoMessage {
 
 /// Request message for
 /// `PipelineService.GetTrainingPipeline`.
-final class GetTrainingPipelineRequest extends ProtoMessage {
+final class GetTrainingPipelineRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetTrainingPipelineRequest';
 
@@ -75752,7 +75874,7 @@ final class GetTrainingPipelineRequest extends ProtoMessage {
 
 /// Request message for
 /// `PipelineService.ListTrainingPipelines`.
-final class ListTrainingPipelinesRequest extends ProtoMessage {
+final class ListTrainingPipelinesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListTrainingPipelinesRequest';
 
@@ -75839,7 +75961,7 @@ final class ListTrainingPipelinesRequest extends ProtoMessage {
 
 /// Response message for
 /// `PipelineService.ListTrainingPipelines`
-final class ListTrainingPipelinesResponse extends ProtoMessage {
+final class ListTrainingPipelinesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListTrainingPipelinesResponse';
 
@@ -75885,7 +76007,7 @@ final class ListTrainingPipelinesResponse extends ProtoMessage {
 
 /// Request message for
 /// `PipelineService.DeleteTrainingPipeline`.
-final class DeleteTrainingPipelineRequest extends ProtoMessage {
+final class DeleteTrainingPipelineRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteTrainingPipelineRequest';
 
@@ -75915,7 +76037,7 @@ final class DeleteTrainingPipelineRequest extends ProtoMessage {
 
 /// Request message for
 /// `PipelineService.CancelTrainingPipeline`.
-final class CancelTrainingPipelineRequest extends ProtoMessage {
+final class CancelTrainingPipelineRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CancelTrainingPipelineRequest';
 
@@ -75945,7 +76067,7 @@ final class CancelTrainingPipelineRequest extends ProtoMessage {
 
 /// Request message for
 /// `PipelineService.CreatePipelineJob`.
-final class CreatePipelineJobRequest extends ProtoMessage {
+final class CreatePipelineJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreatePipelineJobRequest';
 
@@ -75999,7 +76121,7 @@ final class CreatePipelineJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `PipelineService.GetPipelineJob`.
-final class GetPipelineJobRequest extends ProtoMessage {
+final class GetPipelineJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetPipelineJobRequest';
 
@@ -76028,7 +76150,7 @@ final class GetPipelineJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `PipelineService.ListPipelineJobs`.
-final class ListPipelineJobsRequest extends ProtoMessage {
+final class ListPipelineJobsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListPipelineJobsRequest';
 
@@ -76148,7 +76270,7 @@ final class ListPipelineJobsRequest extends ProtoMessage {
 
 /// Response message for
 /// `PipelineService.ListPipelineJobs`
-final class ListPipelineJobsResponse extends ProtoMessage {
+final class ListPipelineJobsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListPipelineJobsResponse';
 
@@ -76193,7 +76315,7 @@ final class ListPipelineJobsResponse extends ProtoMessage {
 
 /// Request message for
 /// `PipelineService.DeletePipelineJob`.
-final class DeletePipelineJobRequest extends ProtoMessage {
+final class DeletePipelineJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeletePipelineJobRequest';
 
@@ -76222,7 +76344,7 @@ final class DeletePipelineJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `PipelineService.BatchDeletePipelineJobs`.
-final class BatchDeletePipelineJobsRequest extends ProtoMessage {
+final class BatchDeletePipelineJobsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BatchDeletePipelineJobsRequest';
 
@@ -76260,7 +76382,7 @@ final class BatchDeletePipelineJobsRequest extends ProtoMessage {
 
 /// Response message for
 /// `PipelineService.BatchDeletePipelineJobs`.
-final class BatchDeletePipelineJobsResponse extends ProtoMessage {
+final class BatchDeletePipelineJobsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BatchDeletePipelineJobsResponse';
 
@@ -76290,7 +76412,7 @@ final class BatchDeletePipelineJobsResponse extends ProtoMessage {
 
 /// Request message for
 /// `PipelineService.CancelPipelineJob`.
-final class CancelPipelineJobRequest extends ProtoMessage {
+final class CancelPipelineJobRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CancelPipelineJobRequest';
 
@@ -76319,7 +76441,7 @@ final class CancelPipelineJobRequest extends ProtoMessage {
 
 /// Request message for
 /// `PipelineService.BatchCancelPipelineJobs`.
-final class BatchCancelPipelineJobsRequest extends ProtoMessage {
+final class BatchCancelPipelineJobsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BatchCancelPipelineJobsRequest';
 
@@ -76357,7 +76479,7 @@ final class BatchCancelPipelineJobsRequest extends ProtoMessage {
 
 /// Response message for
 /// `PipelineService.BatchCancelPipelineJobs`.
-final class BatchCancelPipelineJobsResponse extends ProtoMessage {
+final class BatchCancelPipelineJobsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BatchCancelPipelineJobsResponse';
 
@@ -76387,7 +76509,7 @@ final class BatchCancelPipelineJobsResponse extends ProtoMessage {
 
 /// Request message for
 /// `PredictionService.Predict`.
-final class PredictRequest extends ProtoMessage {
+final class PredictRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PredictRequest';
 
@@ -76457,7 +76579,7 @@ final class PredictRequest extends ProtoMessage {
 
 /// Response message for
 /// `PredictionService.Predict`.
-final class PredictResponse extends ProtoMessage {
+final class PredictResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PredictResponse';
 
@@ -76538,7 +76660,7 @@ final class PredictResponse extends ProtoMessage {
 
 /// Request message for
 /// `PredictionService.RawPredict`.
-final class RawPredictRequest extends ProtoMessage {
+final class RawPredictRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RawPredictRequest';
 
@@ -76591,7 +76713,7 @@ final class RawPredictRequest extends ProtoMessage {
 
 /// Request message for
 /// `PredictionService.StreamRawPredict`.
-final class StreamRawPredictRequest extends ProtoMessage {
+final class StreamRawPredictRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StreamRawPredictRequest';
 
@@ -76630,7 +76752,7 @@ final class StreamRawPredictRequest extends ProtoMessage {
 
 /// Request message for
 /// `PredictionService.DirectPredict`.
-final class DirectPredictRequest extends ProtoMessage {
+final class DirectPredictRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DirectPredictRequest';
 
@@ -76674,7 +76796,7 @@ final class DirectPredictRequest extends ProtoMessage {
 
 /// Response message for
 /// `PredictionService.DirectPredict`.
-final class DirectPredictResponse extends ProtoMessage {
+final class DirectPredictResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DirectPredictResponse';
 
@@ -76708,7 +76830,7 @@ final class DirectPredictResponse extends ProtoMessage {
 
 /// Request message for
 /// `PredictionService.DirectRawPredict`.
-final class DirectRawPredictRequest extends ProtoMessage {
+final class DirectRawPredictRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DirectRawPredictRequest';
 
@@ -76762,7 +76884,7 @@ final class DirectRawPredictRequest extends ProtoMessage {
 
 /// Response message for
 /// `PredictionService.DirectRawPredict`.
-final class DirectRawPredictResponse extends ProtoMessage {
+final class DirectRawPredictResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DirectRawPredictResponse';
 
@@ -76794,7 +76916,7 @@ final class DirectRawPredictResponse extends ProtoMessage {
 /// `endpoint`
 /// field and optionally `input`. The subsequent messages must contain
 /// `input`.
-final class StreamDirectPredictRequest extends ProtoMessage {
+final class StreamDirectPredictRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StreamDirectPredictRequest';
 
@@ -76838,7 +76960,7 @@ final class StreamDirectPredictRequest extends ProtoMessage {
 
 /// Response message for
 /// `PredictionService.StreamDirectPredict`.
-final class StreamDirectPredictResponse extends ProtoMessage {
+final class StreamDirectPredictResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StreamDirectPredictResponse';
 
@@ -76883,7 +77005,7 @@ final class StreamDirectPredictResponse extends ProtoMessage {
 /// `input`.
 /// `method_name`
 /// in the subsequent messages have no effect.
-final class StreamDirectRawPredictRequest extends ProtoMessage {
+final class StreamDirectRawPredictRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StreamDirectRawPredictRequest';
 
@@ -76937,7 +77059,7 @@ final class StreamDirectRawPredictRequest extends ProtoMessage {
 
 /// Response message for
 /// `PredictionService.StreamDirectRawPredict`.
-final class StreamDirectRawPredictResponse extends ProtoMessage {
+final class StreamDirectRawPredictResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StreamDirectRawPredictResponse';
 
@@ -76969,7 +77091,7 @@ final class StreamDirectRawPredictResponse extends ProtoMessage {
 /// `endpoint`
 /// field and optionally `input`. The subsequent messages must contain
 /// `input`.
-final class StreamingPredictRequest extends ProtoMessage {
+final class StreamingPredictRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StreamingPredictRequest';
 
@@ -77016,7 +77138,7 @@ final class StreamingPredictRequest extends ProtoMessage {
 
 /// Response message for
 /// `PredictionService.StreamingPredict`.
-final class StreamingPredictResponse extends ProtoMessage {
+final class StreamingPredictResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StreamingPredictResponse';
 
@@ -77061,7 +77183,7 @@ final class StreamingPredictResponse extends ProtoMessage {
 /// `input`.
 /// `method_name`
 /// in the subsequent messages have no effect.
-final class StreamingRawPredictRequest extends ProtoMessage {
+final class StreamingRawPredictRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StreamingRawPredictRequest';
 
@@ -77115,7 +77237,7 @@ final class StreamingRawPredictRequest extends ProtoMessage {
 
 /// Response message for
 /// `PredictionService.StreamingRawPredict`.
-final class StreamingRawPredictResponse extends ProtoMessage {
+final class StreamingRawPredictResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StreamingRawPredictResponse';
 
@@ -77142,7 +77264,7 @@ final class StreamingRawPredictResponse extends ProtoMessage {
 
 /// Request message for
 /// `PredictionService.Explain`.
-final class ExplainRequest extends ProtoMessage {
+final class ExplainRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExplainRequest';
 
@@ -77251,7 +77373,7 @@ final class ExplainRequest extends ProtoMessage {
 
 /// Response message for
 /// `PredictionService.Explain`.
-final class ExplainResponse extends ProtoMessage {
+final class ExplainResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExplainResponse';
 
@@ -77322,7 +77444,8 @@ final class ExplainResponse extends ProtoMessage {
 }
 
 /// This message is a wrapper grouping Concurrent Explanations.
-final class ExplainResponse_ConcurrentExplanation extends ProtoMessage {
+final class ExplainResponse_ConcurrentExplanation
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExplainResponse.ConcurrentExplanation';
 
@@ -77359,7 +77482,7 @@ final class ExplainResponse_ConcurrentExplanation extends ProtoMessage {
 
 /// Request message for
 /// `PredictionService.CountTokens`.
-final class CountTokensRequest extends ProtoMessage {
+final class CountTokensRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CountTokensRequest';
 
@@ -77452,7 +77575,7 @@ final class CountTokensRequest extends ProtoMessage {
 
 /// Response message for
 /// `PredictionService.CountTokens`.
-final class CountTokensResponse extends ProtoMessage {
+final class CountTokensResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CountTokensResponse';
 
@@ -77506,7 +77629,7 @@ final class CountTokensResponse extends ProtoMessage {
 }
 
 /// Request message for [PredictionService.GenerateContent].
-final class GenerateContentRequest extends ProtoMessage {
+final class GenerateContentRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GenerateContentRequest';
 
@@ -77638,7 +77761,7 @@ final class GenerateContentRequest extends ProtoMessage {
 }
 
 /// Response message for [PredictionService.GenerateContent].
-final class GenerateContentResponse extends ProtoMessage {
+final class GenerateContentResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GenerateContentResponse';
 
@@ -77712,7 +77835,8 @@ final class GenerateContentResponse extends ProtoMessage {
 }
 
 /// Content filter results for a prompt sent in the request.
-final class GenerateContentResponse_PromptFeedback extends ProtoMessage {
+final class GenerateContentResponse_PromptFeedback
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GenerateContentResponse.PromptFeedback';
 
@@ -77768,7 +77892,7 @@ final class GenerateContentResponse_PromptFeedback extends ProtoMessage {
 
 /// Blocked reason enumeration.
 final class GenerateContentResponse_PromptFeedback_BlockedReason
-    extends ProtoEnum {
+    extends protobuf.ProtoEnum {
   /// Unspecified blocked reason.
   static const blockedReasonUnspecified =
       GenerateContentResponse_PromptFeedback_BlockedReason(
@@ -77812,7 +77936,8 @@ final class GenerateContentResponse_PromptFeedback_BlockedReason
 }
 
 /// Usage metadata about response(s).
-final class GenerateContentResponse_UsageMetadata extends ProtoMessage {
+final class GenerateContentResponse_UsageMetadata
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GenerateContentResponse.UsageMetadata';
 
@@ -77914,7 +78039,7 @@ final class GenerateContentResponse_UsageMetadata extends ProtoMessage {
 }
 
 /// Request message for [PredictionService.ChatCompletions]
-final class ChatCompletionsRequest extends ProtoMessage {
+final class ChatCompletionsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ChatCompletionsRequest';
 
@@ -77950,7 +78075,7 @@ final class ChatCompletionsRequest extends ProtoMessage {
 }
 
 /// Response message for [PredictionService.PredictLongRunning]
-final class PredictLongRunningResponse extends ProtoMessage {
+final class PredictLongRunningResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PredictLongRunningResponse';
 
@@ -77982,7 +78107,7 @@ final class PredictLongRunningResponse extends ProtoMessage {
 }
 
 /// Metadata for PredictLongRunning long running operations.
-final class PredictLongRunningMetadata extends ProtoMessage {
+final class PredictLongRunningMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PredictLongRunningMetadata';
 
@@ -78002,7 +78127,7 @@ final class PredictLongRunningMetadata extends ProtoMessage {
 }
 
 /// Generate video response.
-final class GenerateVideoResponse extends ProtoMessage {
+final class GenerateVideoResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GenerateVideoResponse';
 
@@ -78051,7 +78176,7 @@ final class GenerateVideoResponse extends ProtoMessage {
 }
 
 /// A Model Garden Publisher Model.
-final class PublisherModel extends ProtoMessage {
+final class PublisherModel extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PublisherModel';
 
@@ -78171,7 +78296,7 @@ final class PublisherModel extends ProtoMessage {
 }
 
 /// Reference to a resource.
-final class PublisherModel_ResourceReference extends ProtoMessage {
+final class PublisherModel_ResourceReference extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PublisherModel.ResourceReference';
 
@@ -78226,7 +78351,7 @@ final class PublisherModel_ResourceReference extends ProtoMessage {
 }
 
 /// The information about the parent of a model.
-final class PublisherModel_Parent extends ProtoMessage {
+final class PublisherModel_Parent extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PublisherModel.Parent';
 
@@ -78268,7 +78393,7 @@ final class PublisherModel_Parent extends ProtoMessage {
 }
 
 /// A named piece of documentation.
-final class PublisherModel_Documentation extends ProtoMessage {
+final class PublisherModel_Documentation extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PublisherModel.Documentation';
 
@@ -78308,7 +78433,7 @@ final class PublisherModel_Documentation extends ProtoMessage {
 }
 
 /// Actions could take on this Publisher Model.
-final class PublisherModel_CallToAction extends ProtoMessage {
+final class PublisherModel_CallToAction extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PublisherModel.CallToAction';
 
@@ -78473,7 +78598,7 @@ final class PublisherModel_CallToAction extends ProtoMessage {
 /// The regional resource name or the URI. Key is region, e.g.,
 /// us-central1, europe-west2, global, etc..
 final class PublisherModel_CallToAction_RegionalResourceReferences
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PublisherModel.CallToAction.RegionalResourceReferences';
 
@@ -78541,7 +78666,8 @@ final class PublisherModel_CallToAction_RegionalResourceReferences
 }
 
 /// Rest API docs.
-final class PublisherModel_CallToAction_ViewRestApi extends ProtoMessage {
+final class PublisherModel_CallToAction_ViewRestApi
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PublisherModel.CallToAction.ViewRestApi';
 
@@ -78582,7 +78708,8 @@ final class PublisherModel_CallToAction_ViewRestApi extends ProtoMessage {
 }
 
 /// Open notebooks.
-final class PublisherModel_CallToAction_OpenNotebooks extends ProtoMessage {
+final class PublisherModel_CallToAction_OpenNotebooks
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PublisherModel.CallToAction.OpenNotebooks';
 
@@ -78614,7 +78741,7 @@ final class PublisherModel_CallToAction_OpenNotebooks extends ProtoMessage {
 
 /// Open fine tuning pipelines.
 final class PublisherModel_CallToAction_OpenFineTuningPipelines
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PublisherModel.CallToAction.OpenFineTuningPipelines';
 
@@ -78650,7 +78777,8 @@ final class PublisherModel_CallToAction_OpenFineTuningPipelines
 }
 
 /// Multiple setups to deploy the PublisherModel.
-final class PublisherModel_CallToAction_DeployVertex extends ProtoMessage {
+final class PublisherModel_CallToAction_DeployVertex
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PublisherModel.CallToAction.DeployVertex';
 
@@ -78685,7 +78813,7 @@ final class PublisherModel_CallToAction_DeployVertex extends ProtoMessage {
 
 /// Model metadata that is needed for UploadModel or
 /// DeployModel/CreateEndpoint requests.
-final class PublisherModel_CallToAction_Deploy extends ProtoMessage {
+final class PublisherModel_CallToAction_Deploy extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PublisherModel.CallToAction.Deploy';
 
@@ -78812,7 +78940,7 @@ final class PublisherModel_CallToAction_Deploy extends ProtoMessage {
 /// Metadata information about the deployment for managing deployment
 /// config.
 final class PublisherModel_CallToAction_Deploy_DeployMetadata
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PublisherModel.CallToAction.Deploy.DeployMetadata';
 
@@ -78855,7 +78983,8 @@ final class PublisherModel_CallToAction_Deploy_DeployMetadata
 }
 
 /// Configurations for PublisherModel GKE deployment
-final class PublisherModel_CallToAction_DeployGke extends ProtoMessage {
+final class PublisherModel_CallToAction_DeployGke
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PublisherModel.CallToAction.DeployGke';
 
@@ -78883,7 +79012,7 @@ final class PublisherModel_CallToAction_DeployGke extends ProtoMessage {
 }
 
 /// An enum representing the open source category of a PublisherModel.
-final class PublisherModel_OpenSourceCategory extends ProtoEnum {
+final class PublisherModel_OpenSourceCategory extends protobuf.ProtoEnum {
   /// The open source category is unspecified, which should not be used.
   static const openSourceCategoryUnspecified =
       PublisherModel_OpenSourceCategory('OPEN_SOURCE_CATEGORY_UNSPECIFIED');
@@ -78926,7 +79055,7 @@ final class PublisherModel_OpenSourceCategory extends ProtoEnum {
 }
 
 /// An enum representing the launch stage of a PublisherModel.
-final class PublisherModel_LaunchStage extends ProtoEnum {
+final class PublisherModel_LaunchStage extends protobuf.ProtoEnum {
   /// The model launch stage is unspecified.
   static const launchStageUnspecified = PublisherModel_LaunchStage(
     'LAUNCH_STAGE_UNSPECIFIED',
@@ -78961,7 +79090,7 @@ final class PublisherModel_LaunchStage extends ProtoEnum {
 }
 
 /// An enum representing the state of the PublicModelVersion.
-final class PublisherModel_VersionState extends ProtoEnum {
+final class PublisherModel_VersionState extends protobuf.ProtoEnum {
   /// The version state is unspecified.
   static const versionStateUnspecified = PublisherModel_VersionState(
     'VERSION_STATE_UNSPECIFIED',
@@ -78987,7 +79116,7 @@ final class PublisherModel_VersionState extends ProtoEnum {
 }
 
 /// ReasoningEngine configurations
-final class ReasoningEngineSpec extends ProtoMessage {
+final class ReasoningEngineSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ReasoningEngineSpec';
 
@@ -79077,7 +79206,7 @@ final class ReasoningEngineSpec extends ProtoMessage {
 
 /// User-provided package specification, containing pickled object and package
 /// requirements.
-final class ReasoningEngineSpec_PackageSpec extends ProtoMessage {
+final class ReasoningEngineSpec_PackageSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ReasoningEngineSpec.PackageSpec';
 
@@ -79135,7 +79264,7 @@ final class ReasoningEngineSpec_PackageSpec extends ProtoMessage {
 }
 
 /// The specification of a Reasoning Engine deployment.
-final class ReasoningEngineSpec_DeploymentSpec extends ProtoMessage {
+final class ReasoningEngineSpec_DeploymentSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ReasoningEngineSpec.DeploymentSpec';
 
@@ -79234,7 +79363,7 @@ final class ReasoningEngineSpec_DeploymentSpec extends ProtoMessage {
 }
 
 /// Specification for deploying from source code.
-final class ReasoningEngineSpec_SourceCodeSpec extends ProtoMessage {
+final class ReasoningEngineSpec_SourceCodeSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ReasoningEngineSpec.SourceCodeSpec';
 
@@ -79276,7 +79405,7 @@ final class ReasoningEngineSpec_SourceCodeSpec extends ProtoMessage {
 
 /// Specifies source code provided as a byte stream.
 final class ReasoningEngineSpec_SourceCodeSpec_InlineSource
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ReasoningEngineSpec.SourceCodeSpec.InlineSource';
 
@@ -79313,7 +79442,8 @@ final class ReasoningEngineSpec_SourceCodeSpec_InlineSource
 }
 
 /// Specification for running a Python application from source.
-final class ReasoningEngineSpec_SourceCodeSpec_PythonSpec extends ProtoMessage {
+final class ReasoningEngineSpec_SourceCodeSpec_PythonSpec
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ReasoningEngineSpec.SourceCodeSpec.PythonSpec';
 
@@ -79381,7 +79511,7 @@ final class ReasoningEngineSpec_SourceCodeSpec_PythonSpec extends ProtoMessage {
 
 /// ReasoningEngine provides a customizable runtime for models to determine
 /// which actions to take and in which order.
-final class ReasoningEngine extends ProtoMessage {
+final class ReasoningEngine extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ReasoningEngine';
 
@@ -79481,7 +79611,7 @@ final class ReasoningEngine extends ProtoMessage {
 }
 
 /// Configuration for how Agent Engine sub-resources should manage context.
-final class ReasoningEngineContextSpec extends ProtoMessage {
+final class ReasoningEngineContextSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ReasoningEngineContextSpec';
 
@@ -79514,7 +79644,8 @@ final class ReasoningEngineContextSpec extends ProtoMessage {
 }
 
 /// Specification for a Memory Bank.
-final class ReasoningEngineContextSpec_MemoryBankConfig extends ProtoMessage {
+final class ReasoningEngineContextSpec_MemoryBankConfig
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ReasoningEngineContextSpec.MemoryBankConfig';
 
@@ -79578,7 +79709,7 @@ final class ReasoningEngineContextSpec_MemoryBankConfig extends ProtoMessage {
 /// Configuration for automatically setting the TTL ("time-to-live") of the
 /// memories in the Memory Bank.
 final class ReasoningEngineContextSpec_MemoryBankConfig_TtlConfig
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ReasoningEngineContextSpec.MemoryBankConfig.TtlConfig';
 
@@ -79625,7 +79756,7 @@ final class ReasoningEngineContextSpec_MemoryBankConfig_TtlConfig
 /// Configuration for TTL of the memories in the Memory Bank based on the
 /// action that created or updated the memory.
 final class ReasoningEngineContextSpec_MemoryBankConfig_TtlConfig_GranularTtlConfig
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ReasoningEngineContextSpec.MemoryBankConfig.TtlConfig.GranularTtlConfig';
 
@@ -79682,7 +79813,7 @@ final class ReasoningEngineContextSpec_MemoryBankConfig_TtlConfig_GranularTtlCon
 
 /// Configuration for how to generate memories.
 final class ReasoningEngineContextSpec_MemoryBankConfig_GenerationConfig
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ReasoningEngineContextSpec.MemoryBankConfig.GenerationConfig';
 
@@ -79716,7 +79847,7 @@ final class ReasoningEngineContextSpec_MemoryBankConfig_GenerationConfig
 
 /// Configuration for how to perform similarity search on memories.
 final class ReasoningEngineContextSpec_MemoryBankConfig_SimilaritySearchConfig
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ReasoningEngineContextSpec.MemoryBankConfig.SimilaritySearchConfig';
 
@@ -79752,7 +79883,7 @@ final class ReasoningEngineContextSpec_MemoryBankConfig_SimilaritySearchConfig
 }
 
 /// Request message for `ReasoningEngineExecutionService.Query`.
-final class QueryReasoningEngineRequest extends ProtoMessage {
+final class QueryReasoningEngineRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.QueryReasoningEngineRequest';
 
@@ -79803,7 +79934,7 @@ final class QueryReasoningEngineRequest extends ProtoMessage {
 }
 
 /// Response message for `ReasoningEngineExecutionService.Query`
-final class QueryReasoningEngineResponse extends ProtoMessage {
+final class QueryReasoningEngineResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.QueryReasoningEngineResponse';
 
@@ -79828,7 +79959,7 @@ final class QueryReasoningEngineResponse extends ProtoMessage {
 }
 
 /// Request message for `ReasoningEngineExecutionService.StreamQuery`.
-final class StreamQueryReasoningEngineRequest extends ProtoMessage {
+final class StreamQueryReasoningEngineRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StreamQueryReasoningEngineRequest';
 
@@ -79882,7 +80013,7 @@ final class StreamQueryReasoningEngineRequest extends ProtoMessage {
 
 /// Request message for
 /// `ReasoningEngineService.CreateReasoningEngine`.
-final class CreateReasoningEngineRequest extends ProtoMessage {
+final class CreateReasoningEngineRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateReasoningEngineRequest';
 
@@ -79923,7 +80054,8 @@ final class CreateReasoningEngineRequest extends ProtoMessage {
 /// Details of
 /// `ReasoningEngineService.CreateReasoningEngine`
 /// operation.
-final class CreateReasoningEngineOperationMetadata extends ProtoMessage {
+final class CreateReasoningEngineOperationMetadata
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateReasoningEngineOperationMetadata';
 
@@ -79957,7 +80089,7 @@ final class CreateReasoningEngineOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `ReasoningEngineService.GetReasoningEngine`.
-final class GetReasoningEngineRequest extends ProtoMessage {
+final class GetReasoningEngineRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetReasoningEngineRequest';
 
@@ -79986,7 +80118,7 @@ final class GetReasoningEngineRequest extends ProtoMessage {
 
 /// Request message for
 /// `ReasoningEngineService.UpdateReasoningEngine`.
-final class UpdateReasoningEngineRequest extends ProtoMessage {
+final class UpdateReasoningEngineRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateReasoningEngineRequest';
 
@@ -80024,7 +80156,8 @@ final class UpdateReasoningEngineRequest extends ProtoMessage {
 /// Details of
 /// `ReasoningEngineService.UpdateReasoningEngine`
 /// operation.
-final class UpdateReasoningEngineOperationMetadata extends ProtoMessage {
+final class UpdateReasoningEngineOperationMetadata
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateReasoningEngineOperationMetadata';
 
@@ -80058,7 +80191,7 @@ final class UpdateReasoningEngineOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `ReasoningEngineService.ListReasoningEngines`.
-final class ListReasoningEnginesRequest extends ProtoMessage {
+final class ListReasoningEnginesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListReasoningEnginesRequest';
 
@@ -80116,7 +80249,7 @@ final class ListReasoningEnginesRequest extends ProtoMessage {
 
 /// Response message for
 /// `ReasoningEngineService.ListReasoningEngines`
-final class ListReasoningEnginesResponse extends ProtoMessage {
+final class ListReasoningEnginesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListReasoningEnginesResponse';
 
@@ -80162,7 +80295,7 @@ final class ListReasoningEnginesResponse extends ProtoMessage {
 
 /// Request message for
 /// `ReasoningEngineService.DeleteReasoningEngine`.
-final class DeleteReasoningEngineRequest extends ProtoMessage {
+final class DeleteReasoningEngineRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteReasoningEngineRequest';
 
@@ -80204,7 +80337,7 @@ final class DeleteReasoningEngineRequest extends ProtoMessage {
 /// A ReservationAffinity can be used to configure a Vertex AI resource (e.g., a
 /// DeployedModel) to draw its Compute Engine resources from a Shared
 /// Reservation, or exclusively from on-demand capacity.
-final class ReservationAffinity extends ProtoMessage {
+final class ReservationAffinity extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ReservationAffinity';
 
@@ -80257,7 +80390,7 @@ final class ReservationAffinity extends ProtoMessage {
 }
 
 /// Identifies a type of reservation affinity.
-final class ReservationAffinity_Type extends ProtoEnum {
+final class ReservationAffinity_Type extends protobuf.ProtoEnum {
   /// Default value. This should not be used.
   static const typeUnspecified = ReservationAffinity_Type('TYPE_UNSPECIFIED');
 
@@ -80284,7 +80417,7 @@ final class ReservationAffinity_Type extends ProtoEnum {
 
 /// A SavedQuery is a view of the dataset. It references a subset of annotations
 /// by problem type and filters.
-final class SavedQuery extends ProtoMessage {
+final class SavedQuery extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SavedQuery';
 
@@ -80399,7 +80532,7 @@ final class SavedQuery extends ProtoMessage {
 
 /// An instance of a Schedule periodically schedules runs to make API calls based
 /// on user specified time specification and API request type.
-final class Schedule extends ProtoMessage {
+final class Schedule extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Schedule';
 
@@ -80621,7 +80754,7 @@ final class Schedule extends ProtoMessage {
 }
 
 /// Status of a scheduled run.
-final class Schedule_RunResponse extends ProtoMessage {
+final class Schedule_RunResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Schedule.RunResponse';
 
@@ -80663,7 +80796,7 @@ final class Schedule_RunResponse extends ProtoMessage {
 }
 
 /// Possible state of the schedule.
-final class Schedule_State extends ProtoEnum {
+final class Schedule_State extends protobuf.ProtoEnum {
   /// Unspecified.
   static const stateUnspecified = Schedule_State('STATE_UNSPECIFIED');
 
@@ -80690,7 +80823,7 @@ final class Schedule_State extends ProtoEnum {
 
 /// Request message for
 /// `ScheduleService.CreateSchedule`.
-final class CreateScheduleRequest extends ProtoMessage {
+final class CreateScheduleRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateScheduleRequest';
 
@@ -80725,7 +80858,7 @@ final class CreateScheduleRequest extends ProtoMessage {
 
 /// Request message for
 /// `ScheduleService.GetSchedule`.
-final class GetScheduleRequest extends ProtoMessage {
+final class GetScheduleRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetScheduleRequest';
 
@@ -80754,7 +80887,7 @@ final class GetScheduleRequest extends ProtoMessage {
 
 /// Request message for
 /// `ScheduleService.ListSchedules`.
-final class ListSchedulesRequest extends ProtoMessage {
+final class ListSchedulesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListSchedulesRequest';
 
@@ -80869,7 +81002,7 @@ final class ListSchedulesRequest extends ProtoMessage {
 
 /// Response message for
 /// `ScheduleService.ListSchedules`
-final class ListSchedulesResponse extends ProtoMessage {
+final class ListSchedulesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListSchedulesResponse';
 
@@ -80911,7 +81044,7 @@ final class ListSchedulesResponse extends ProtoMessage {
 
 /// Request message for
 /// `ScheduleService.DeleteSchedule`.
-final class DeleteScheduleRequest extends ProtoMessage {
+final class DeleteScheduleRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteScheduleRequest';
 
@@ -80940,7 +81073,7 @@ final class DeleteScheduleRequest extends ProtoMessage {
 
 /// Request message for
 /// `ScheduleService.PauseSchedule`.
-final class PauseScheduleRequest extends ProtoMessage {
+final class PauseScheduleRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PauseScheduleRequest';
 
@@ -80969,7 +81102,7 @@ final class PauseScheduleRequest extends ProtoMessage {
 
 /// Request message for
 /// `ScheduleService.ResumeSchedule`.
-final class ResumeScheduleRequest extends ProtoMessage {
+final class ResumeScheduleRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ResumeScheduleRequest';
 
@@ -81009,7 +81142,7 @@ final class ResumeScheduleRequest extends ProtoMessage {
 
 /// Request message for
 /// `ScheduleService.UpdateSchedule`.
-final class UpdateScheduleRequest extends ProtoMessage {
+final class UpdateScheduleRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateScheduleRequest';
 
@@ -81049,7 +81182,7 @@ final class UpdateScheduleRequest extends ProtoMessage {
 
 /// PSC config that is used to automatically create PSC endpoints in the user
 /// projects.
-final class PscautomationConfig extends ProtoMessage {
+final class PscautomationConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PSCAutomationConfig';
 
@@ -81121,7 +81254,7 @@ final class PscautomationConfig extends ProtoMessage {
 }
 
 /// Represents configuration for private service connect.
-final class PrivateServiceConnectConfig extends ProtoMessage {
+final class PrivateServiceConnectConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PrivateServiceConnectConfig';
 
@@ -81198,7 +81331,7 @@ final class PrivateServiceConnectConfig extends ProtoMessage {
 
 /// PscAutomatedEndpoints defines the output of the forwarding rule
 /// automatically created by each PscAutomationConfig.
-final class PscAutomatedEndpoints extends ProtoMessage {
+final class PscAutomatedEndpoints extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PscAutomatedEndpoints';
 
@@ -81243,7 +81376,7 @@ final class PscAutomatedEndpoints extends ProtoMessage {
 }
 
 /// Configuration for PSC-I.
-final class PscInterfaceConfig extends ProtoMessage {
+final class PscInterfaceConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PscInterfaceConfig';
 
@@ -81298,7 +81431,7 @@ final class PscInterfaceConfig extends ProtoMessage {
 /// DNS peering zones in the Vertex tenant project VPC, enabling resolution
 /// of records within the specified domain hosted in the target network's
 /// Cloud DNS.
-final class DnsPeeringConfig extends ProtoMessage {
+final class DnsPeeringConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DnsPeeringConfig';
 
@@ -81348,7 +81481,7 @@ final class DnsPeeringConfig extends ProtoMessage {
 }
 
 /// A session contains a set of actions between users and Vertex agents.
-final class Session extends ProtoMessage {
+final class Session extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Session';
 
@@ -81433,7 +81566,7 @@ final class Session extends ProtoMessage {
 }
 
 /// An event represents a message from either the user or agent.
-final class SessionEvent extends ProtoMessage {
+final class SessionEvent extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SessionEvent';
 
@@ -81521,7 +81654,7 @@ final class SessionEvent extends ProtoMessage {
 }
 
 /// Metadata relating to a LLM response event.
-final class EventMetadata extends ProtoMessage {
+final class EventMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.EventMetadata';
 
@@ -81610,7 +81743,7 @@ final class EventMetadata extends ProtoMessage {
 }
 
 /// Actions are parts of events that are executed by the agent.
-final class EventActions extends ProtoMessage {
+final class EventActions extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.EventActions';
 
@@ -81694,7 +81827,7 @@ final class EventActions extends ProtoMessage {
 
 /// Request message for
 /// `SessionService.CreateSession`.
-final class CreateSessionRequest extends ProtoMessage {
+final class CreateSessionRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateSessionRequest';
 
@@ -81731,7 +81864,7 @@ final class CreateSessionRequest extends ProtoMessage {
 /// Metadata associated with the
 /// `SessionService.CreateSession`
 /// operation.
-final class CreateSessionOperationMetadata extends ProtoMessage {
+final class CreateSessionOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateSessionOperationMetadata';
 
@@ -81763,7 +81896,7 @@ final class CreateSessionOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `SessionService.GetSession`.
-final class GetSessionRequest extends ProtoMessage {
+final class GetSessionRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetSessionRequest';
 
@@ -81792,7 +81925,7 @@ final class GetSessionRequest extends ProtoMessage {
 
 /// Request message for
 /// `SessionService.ListSessions`.
-final class ListSessionsRequest extends ProtoMessage {
+final class ListSessionsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListSessionsRequest';
 
@@ -81872,7 +82005,7 @@ final class ListSessionsRequest extends ProtoMessage {
 
 /// Response message for
 /// `SessionService.ListSessions`.
-final class ListSessionsResponse extends ProtoMessage {
+final class ListSessionsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListSessionsResponse';
 
@@ -81914,7 +82047,7 @@ final class ListSessionsResponse extends ProtoMessage {
 
 /// Request message for
 /// `SessionService.UpdateSession`.
-final class UpdateSessionRequest extends ProtoMessage {
+final class UpdateSessionRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateSessionRequest';
 
@@ -81951,7 +82084,7 @@ final class UpdateSessionRequest extends ProtoMessage {
 
 /// Request message for
 /// `SessionService.DeleteSession`.
-final class DeleteSessionRequest extends ProtoMessage {
+final class DeleteSessionRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteSessionRequest';
 
@@ -81980,7 +82113,7 @@ final class DeleteSessionRequest extends ProtoMessage {
 
 /// Request message for
 /// `SessionService.ListEvents`.
-final class ListEventsRequest extends ProtoMessage {
+final class ListEventsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListEventsRequest';
 
@@ -82049,7 +82182,7 @@ final class ListEventsRequest extends ProtoMessage {
 
 /// Response message for
 /// `SessionService.ListEvents`.
-final class ListEventsResponse extends ProtoMessage {
+final class ListEventsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListEventsResponse';
 
@@ -82095,7 +82228,7 @@ final class ListEventsResponse extends ProtoMessage {
 
 /// Request message for
 /// `SessionService.AppendEvent`.
-final class AppendEventRequest extends ProtoMessage {
+final class AppendEventRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AppendEventRequest';
 
@@ -82131,7 +82264,7 @@ final class AppendEventRequest extends ProtoMessage {
 
 /// Response message for
 /// `SessionService.AppendEvent`.
-final class AppendEventResponse extends ProtoMessage {
+final class AppendEventResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AppendEventResponse';
 
@@ -82156,7 +82289,7 @@ final class AppendEventResponse extends ProtoMessage {
 /// customers' data labeling jobs associated with this pool. Customers create
 /// specialist pool as well as start data labeling jobs on Cloud, managers and
 /// workers handle the jobs using CrowdCompute console.
-final class SpecialistPool extends ProtoMessage {
+final class SpecialistPool extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SpecialistPool';
 
@@ -82231,7 +82364,7 @@ final class SpecialistPool extends ProtoMessage {
 
 /// Request message for
 /// `SpecialistPoolService.CreateSpecialistPool`.
-final class CreateSpecialistPoolRequest extends ProtoMessage {
+final class CreateSpecialistPoolRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateSpecialistPoolRequest';
 
@@ -82268,7 +82401,8 @@ final class CreateSpecialistPoolRequest extends ProtoMessage {
 
 /// Runtime operation information for
 /// `SpecialistPoolService.CreateSpecialistPool`.
-final class CreateSpecialistPoolOperationMetadata extends ProtoMessage {
+final class CreateSpecialistPoolOperationMetadata
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateSpecialistPoolOperationMetadata';
 
@@ -82302,7 +82436,7 @@ final class CreateSpecialistPoolOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `SpecialistPoolService.GetSpecialistPool`.
-final class GetSpecialistPoolRequest extends ProtoMessage {
+final class GetSpecialistPoolRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetSpecialistPoolRequest';
 
@@ -82331,7 +82465,7 @@ final class GetSpecialistPoolRequest extends ProtoMessage {
 
 /// Request message for
 /// `SpecialistPoolService.ListSpecialistPools`.
-final class ListSpecialistPoolsRequest extends ProtoMessage {
+final class ListSpecialistPoolsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListSpecialistPoolsRequest';
 
@@ -82392,7 +82526,7 @@ final class ListSpecialistPoolsRequest extends ProtoMessage {
 
 /// Response message for
 /// `SpecialistPoolService.ListSpecialistPools`.
-final class ListSpecialistPoolsResponse extends ProtoMessage {
+final class ListSpecialistPoolsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListSpecialistPoolsResponse';
 
@@ -82435,7 +82569,7 @@ final class ListSpecialistPoolsResponse extends ProtoMessage {
 
 /// Request message for
 /// `SpecialistPoolService.DeleteSpecialistPool`.
-final class DeleteSpecialistPoolRequest extends ProtoMessage {
+final class DeleteSpecialistPoolRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteSpecialistPoolRequest';
 
@@ -82475,7 +82609,7 @@ final class DeleteSpecialistPoolRequest extends ProtoMessage {
 
 /// Request message for
 /// `SpecialistPoolService.UpdateSpecialistPool`.
-final class UpdateSpecialistPoolRequest extends ProtoMessage {
+final class UpdateSpecialistPoolRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateSpecialistPoolRequest';
 
@@ -82509,7 +82643,8 @@ final class UpdateSpecialistPoolRequest extends ProtoMessage {
 
 /// Runtime operation metadata for
 /// `SpecialistPoolService.UpdateSpecialistPool`.
-final class UpdateSpecialistPoolOperationMetadata extends ProtoMessage {
+final class UpdateSpecialistPoolOperationMetadata
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateSpecialistPoolOperationMetadata';
 
@@ -82556,7 +82691,7 @@ final class UpdateSpecialistPoolOperationMetadata extends ProtoMessage {
 }
 
 /// A message representing a Study.
-final class Study extends ProtoMessage {
+final class Study extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Study';
 
@@ -82625,7 +82760,7 @@ final class Study extends ProtoMessage {
 }
 
 /// Describes the Study state.
-final class Study_State extends ProtoEnum {
+final class Study_State extends protobuf.ProtoEnum {
   /// The study state is unspecified.
   static const stateUnspecified = Study_State('STATE_UNSPECIFIED');
 
@@ -82650,7 +82785,7 @@ final class Study_State extends ProtoEnum {
 /// A message representing a Trial. A Trial contains a unique set of Parameters
 /// that has been or will be evaluated, along with the objective metrics got by
 /// running the Trial.
-final class Trial extends ProtoMessage {
+final class Trial extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Trial';
 
@@ -82788,7 +82923,7 @@ final class Trial extends ProtoMessage {
 }
 
 /// A message representing a parameter to be tuned.
-final class Trial_Parameter extends ProtoMessage {
+final class Trial_Parameter extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Trial.Parameter';
 
@@ -82831,7 +82966,7 @@ final class Trial_Parameter extends ProtoMessage {
 }
 
 /// Describes a Trial state.
-final class Trial_State extends ProtoEnum {
+final class Trial_State extends protobuf.ProtoEnum {
   /// The Trial state is unspecified.
   static const stateUnspecified = Trial_State('STATE_UNSPECIFIED');
 
@@ -82861,7 +82996,7 @@ final class Trial_State extends ProtoEnum {
   String toString() => 'State.$value';
 }
 
-final class TrialContext extends ProtoMessage {
+final class TrialContext extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TrialContext';
 
@@ -82910,7 +83045,7 @@ final class TrialContext extends ProtoMessage {
 }
 
 /// Time-based Constraint for Study
-final class StudyTimeConstraint extends ProtoMessage {
+final class StudyTimeConstraint extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StudyTimeConstraint';
 
@@ -82946,7 +83081,7 @@ final class StudyTimeConstraint extends ProtoMessage {
 }
 
 /// Represents specification of a Study.
-final class StudySpec extends ProtoMessage {
+final class StudySpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StudySpec';
 
@@ -83086,7 +83221,7 @@ final class StudySpec extends ProtoMessage {
 }
 
 /// Represents a metric to optimize.
-final class StudySpec_MetricSpec extends ProtoMessage {
+final class StudySpec_MetricSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StudySpec.MetricSpec';
 
@@ -83135,7 +83270,8 @@ final class StudySpec_MetricSpec extends ProtoMessage {
 }
 
 /// Used in safe optimization to specify threshold levels and risk tolerance.
-final class StudySpec_MetricSpec_SafetyMetricConfig extends ProtoMessage {
+final class StudySpec_MetricSpec_SafetyMetricConfig
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StudySpec.MetricSpec.SafetyMetricConfig';
 
@@ -83191,7 +83327,7 @@ final class StudySpec_MetricSpec_SafetyMetricConfig extends ProtoMessage {
 }
 
 /// The available types of optimization goals.
-final class StudySpec_MetricSpec_GoalType extends ProtoEnum {
+final class StudySpec_MetricSpec_GoalType extends protobuf.ProtoEnum {
   /// Goal Type will default to maximize.
   static const goalTypeUnspecified = StudySpec_MetricSpec_GoalType(
     'GOAL_TYPE_UNSPECIFIED',
@@ -83213,7 +83349,7 @@ final class StudySpec_MetricSpec_GoalType extends ProtoEnum {
 }
 
 /// Represents a single parameter to optimize.
-final class StudySpec_ParameterSpec extends ProtoMessage {
+final class StudySpec_ParameterSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StudySpec.ParameterSpec';
 
@@ -83313,7 +83449,8 @@ final class StudySpec_ParameterSpec extends ProtoMessage {
 }
 
 /// Value specification for a parameter in `DOUBLE` type.
-final class StudySpec_ParameterSpec_DoubleValueSpec extends ProtoMessage {
+final class StudySpec_ParameterSpec_DoubleValueSpec
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StudySpec.ParameterSpec.DoubleValueSpec';
 
@@ -83368,7 +83505,8 @@ final class StudySpec_ParameterSpec_DoubleValueSpec extends ProtoMessage {
 }
 
 /// Value specification for a parameter in `INTEGER` type.
-final class StudySpec_ParameterSpec_IntegerValueSpec extends ProtoMessage {
+final class StudySpec_ParameterSpec_IntegerValueSpec
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StudySpec.ParameterSpec.IntegerValueSpec';
 
@@ -83423,7 +83561,8 @@ final class StudySpec_ParameterSpec_IntegerValueSpec extends ProtoMessage {
 }
 
 /// Value specification for a parameter in `CATEGORICAL` type.
-final class StudySpec_ParameterSpec_CategoricalValueSpec extends ProtoMessage {
+final class StudySpec_ParameterSpec_CategoricalValueSpec
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StudySpec.ParameterSpec.CategoricalValueSpec';
 
@@ -83468,7 +83607,8 @@ final class StudySpec_ParameterSpec_CategoricalValueSpec extends ProtoMessage {
 }
 
 /// Value specification for a parameter in `DISCRETE` type.
-final class StudySpec_ParameterSpec_DiscreteValueSpec extends ProtoMessage {
+final class StudySpec_ParameterSpec_DiscreteValueSpec
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StudySpec.ParameterSpec.DiscreteValueSpec';
 
@@ -83518,7 +83658,7 @@ final class StudySpec_ParameterSpec_DiscreteValueSpec extends ProtoMessage {
 
 /// Represents a parameter spec with condition from its parent parameter.
 final class StudySpec_ParameterSpec_ConditionalParameterSpec
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StudySpec.ParameterSpec.ConditionalParameterSpec';
 
@@ -83591,7 +83731,7 @@ final class StudySpec_ParameterSpec_ConditionalParameterSpec
 
 /// Represents the spec to match discrete values from parent parameter.
 final class StudySpec_ParameterSpec_ConditionalParameterSpec_DiscreteValueCondition
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StudySpec.ParameterSpec.ConditionalParameterSpec.DiscreteValueCondition';
 
@@ -83624,7 +83764,7 @@ final class StudySpec_ParameterSpec_ConditionalParameterSpec_DiscreteValueCondit
 
 /// Represents the spec to match integer values from parent parameter.
 final class StudySpec_ParameterSpec_ConditionalParameterSpec_IntValueCondition
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StudySpec.ParameterSpec.ConditionalParameterSpec.IntValueCondition';
 
@@ -83655,7 +83795,7 @@ final class StudySpec_ParameterSpec_ConditionalParameterSpec_IntValueCondition
 
 /// Represents the spec to match categorical values from parent parameter.
 final class StudySpec_ParameterSpec_ConditionalParameterSpec_CategoricalValueCondition
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StudySpec.ParameterSpec.ConditionalParameterSpec.CategoricalValueCondition';
 
@@ -83686,7 +83826,7 @@ final class StudySpec_ParameterSpec_ConditionalParameterSpec_CategoricalValueCon
 }
 
 /// The type of scaling that should be applied to this parameter.
-final class StudySpec_ParameterSpec_ScaleType extends ProtoEnum {
+final class StudySpec_ParameterSpec_ScaleType extends protobuf.ProtoEnum {
   /// By default, no scaling is applied.
   static const scaleTypeUnspecified = StudySpec_ParameterSpec_ScaleType(
     'SCALE_TYPE_UNSPECIFIED',
@@ -83725,7 +83865,8 @@ final class StudySpec_ParameterSpec_ScaleType extends ProtoEnum {
 /// already completed Trials and the intermediate measurements of the current
 /// Trial. Early stopping is requested for the current Trial if there is very
 /// low probability to exceed the optimal value found so far.
-final class StudySpec_DecayCurveAutomatedStoppingSpec extends ProtoMessage {
+final class StudySpec_DecayCurveAutomatedStoppingSpec
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StudySpec.DecayCurveAutomatedStoppingSpec';
 
@@ -83768,7 +83909,8 @@ final class StudySpec_DecayCurveAutomatedStoppingSpec extends ProtoMessage {
 /// completed Trials reported up to the Trial's last measurement.
 /// Currently, 'performance' refers to the running average of the objective
 /// values reported by the Trial in each measurement.
-final class StudySpec_MedianAutomatedStoppingSpec extends ProtoMessage {
+final class StudySpec_MedianAutomatedStoppingSpec
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StudySpec.MedianAutomatedStoppingSpec';
 
@@ -83816,7 +83958,8 @@ final class StudySpec_MedianAutomatedStoppingSpec extends ProtoMessage {
 /// trials, this pending trial will be early-stopped, but a last measurement
 /// will be added to the pending trial with max_num_steps and predicted
 /// objective value from the autoregression model.
-final class StudySpec_ConvexAutomatedStoppingSpec extends ProtoMessage {
+final class StudySpec_ConvexAutomatedStoppingSpec
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StudySpec.ConvexAutomatedStoppingSpec';
 
@@ -83920,7 +84063,7 @@ final class StudySpec_ConvexAutomatedStoppingSpec extends ProtoMessage {
 }
 
 /// Configuration for ConvexStopPolicy.
-final class StudySpec_ConvexStopConfig extends ProtoMessage {
+final class StudySpec_ConvexStopConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StudySpec.ConvexStopConfig';
 
@@ -84007,7 +84150,7 @@ final class StudySpec_ConvexStopConfig extends ProtoMessage {
 /// This contains flag for manually disabling transfer learning for a study.
 /// The names of prior studies being used for transfer learning (if any)
 /// are also listed here.
-final class StudySpec_TransferLearningConfig extends ProtoMessage {
+final class StudySpec_TransferLearningConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StudySpec.TransferLearningConfig';
 
@@ -84052,7 +84195,7 @@ final class StudySpec_TransferLearningConfig extends ProtoMessage {
 
 /// The configuration (stopping conditions) for automated stopping of a Study.
 /// Conditions include trial budgets, time budgets, and convergence detection.
-final class StudySpec_StudyStoppingConfig extends ProtoMessage {
+final class StudySpec_StudyStoppingConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StudySpec.StudyStoppingConfig';
 
@@ -84173,7 +84316,7 @@ final class StudySpec_StudyStoppingConfig extends ProtoMessage {
 }
 
 /// The available search algorithms for the Study.
-final class StudySpec_Algorithm extends ProtoEnum {
+final class StudySpec_Algorithm extends protobuf.ProtoEnum {
   /// The default algorithm used by Vertex AI for [hyperparameter
   /// tuning](https://cloud.google.com/vertex-ai/docs/training/hyperparameter-tuning-overview)
   /// and [Vertex AI Vizier](https://cloud.google.com/vertex-ai/docs/vizier).
@@ -84201,7 +84344,7 @@ final class StudySpec_Algorithm extends ProtoEnum {
 ///
 /// "Noisy" means that the repeated observations with the same Trial parameters
 /// may lead to different metric evaluations.
-final class StudySpec_ObservationNoise extends ProtoEnum {
+final class StudySpec_ObservationNoise extends protobuf.ProtoEnum {
   /// The default noise level chosen by Vertex AI.
   static const observationNoiseUnspecified = StudySpec_ObservationNoise(
     'OBSERVATION_NOISE_UNSPECIFIED',
@@ -84238,7 +84381,7 @@ final class StudySpec_ObservationNoise extends ProtoEnum {
 ///     may be better to choose LAST_MEASUREMENT.
 ///  If both or neither of (A) and (B) apply, it doesn't matter which
 ///  selection type is chosen.
-final class StudySpec_MeasurementSelectionType extends ProtoEnum {
+final class StudySpec_MeasurementSelectionType extends protobuf.ProtoEnum {
   /// Will be treated as LAST_MEASUREMENT.
   static const measurementSelectionTypeUnspecified =
       StudySpec_MeasurementSelectionType(
@@ -84267,7 +84410,7 @@ final class StudySpec_MeasurementSelectionType extends ProtoEnum {
 /// A message representing a Measurement of a Trial. A Measurement contains
 /// the Metrics got by executing a Trial using suggested hyperparameter
 /// values.
-final class Measurement extends ProtoMessage {
+final class Measurement extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Measurement';
 
@@ -84314,7 +84457,7 @@ final class Measurement extends ProtoMessage {
 }
 
 /// A message representing a metric in the measurement.
-final class Measurement_Metric extends ProtoMessage {
+final class Measurement_Metric extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Measurement.Metric';
 
@@ -84355,7 +84498,7 @@ final class Measurement_Metric extends ProtoMessage {
 /// Tensorboard is a physical database that stores users' training metrics.
 /// A default Tensorboard is provided in each region of a Google Cloud project.
 /// If needed users can also create extra Tensorboards in their projects.
-final class Tensorboard extends ProtoMessage {
+final class Tensorboard extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Tensorboard';
 
@@ -84491,7 +84634,7 @@ final class Tensorboard extends ProtoMessage {
 }
 
 /// All the data stored in a TensorboardTimeSeries.
-final class TimeSeriesData extends ProtoMessage {
+final class TimeSeriesData extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TimeSeriesData';
 
@@ -84542,7 +84685,7 @@ final class TimeSeriesData extends ProtoMessage {
 }
 
 /// A TensorboardTimeSeries data point.
-final class TimeSeriesDataPoint extends ProtoMessage {
+final class TimeSeriesDataPoint extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TimeSeriesDataPoint';
 
@@ -84598,7 +84741,7 @@ final class TimeSeriesDataPoint extends ProtoMessage {
 }
 
 /// One point viewable on a scalar metric plot.
-final class Scalar extends ProtoMessage {
+final class Scalar extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Scalar';
 
@@ -84624,7 +84767,7 @@ final class Scalar extends ProtoMessage {
 }
 
 /// One point viewable on a tensor metric plot.
-final class TensorboardTensor extends ProtoMessage {
+final class TensorboardTensor extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TensorboardTensor';
 
@@ -84666,7 +84809,7 @@ final class TensorboardTensor extends ProtoMessage {
 
 /// One point viewable on a blob metric plot, but mostly just a wrapper message
 /// to work around repeated fields can't be used directly within `oneof` fields.
-final class TensorboardBlobSequence extends ProtoMessage {
+final class TensorboardBlobSequence extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TensorboardBlobSequence';
 
@@ -84691,7 +84834,7 @@ final class TensorboardBlobSequence extends ProtoMessage {
 }
 
 /// One blob (e.g, image, graph) viewable on a blob metric plot.
-final class TensorboardBlob extends ProtoMessage {
+final class TensorboardBlob extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TensorboardBlob';
 
@@ -84729,7 +84872,7 @@ final class TensorboardBlob extends ProtoMessage {
 
 /// A TensorboardExperiment is a group of TensorboardRuns, that are typically the
 /// results of a training job run, in a Tensorboard.
-final class TensorboardExperiment extends ProtoMessage {
+final class TensorboardExperiment extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TensorboardExperiment';
 
@@ -84830,7 +84973,7 @@ final class TensorboardExperiment extends ProtoMessage {
 
 /// TensorboardRun maps to a specific execution of a training job with a given
 /// set of hyperparameter values, model definition, dataset, etc
-final class TensorboardRun extends ProtoMessage {
+final class TensorboardRun extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TensorboardRun';
 
@@ -84926,7 +85069,7 @@ final class TensorboardRun extends ProtoMessage {
 
 /// Request message for
 /// `TensorboardService.CreateTensorboard`.
-final class CreateTensorboardRequest extends ProtoMessage {
+final class CreateTensorboardRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateTensorboardRequest';
 
@@ -84961,7 +85104,7 @@ final class CreateTensorboardRequest extends ProtoMessage {
 
 /// Request message for
 /// `TensorboardService.GetTensorboard`.
-final class GetTensorboardRequest extends ProtoMessage {
+final class GetTensorboardRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetTensorboardRequest';
 
@@ -84990,7 +85133,7 @@ final class GetTensorboardRequest extends ProtoMessage {
 
 /// Request message for
 /// `TensorboardService.ListTensorboards`.
-final class ListTensorboardsRequest extends ProtoMessage {
+final class ListTensorboardsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListTensorboardsRequest';
 
@@ -85070,7 +85213,7 @@ final class ListTensorboardsRequest extends ProtoMessage {
 
 /// Response message for
 /// `TensorboardService.ListTensorboards`.
-final class ListTensorboardsResponse extends ProtoMessage {
+final class ListTensorboardsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListTensorboardsResponse';
 
@@ -85115,7 +85258,7 @@ final class ListTensorboardsResponse extends ProtoMessage {
 
 /// Request message for
 /// `TensorboardService.UpdateTensorboard`.
-final class UpdateTensorboardRequest extends ProtoMessage {
+final class UpdateTensorboardRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateTensorboardRequest';
 
@@ -85156,7 +85299,7 @@ final class UpdateTensorboardRequest extends ProtoMessage {
 
 /// Request message for
 /// `TensorboardService.DeleteTensorboard`.
-final class DeleteTensorboardRequest extends ProtoMessage {
+final class DeleteTensorboardRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteTensorboardRequest';
 
@@ -85185,7 +85328,7 @@ final class DeleteTensorboardRequest extends ProtoMessage {
 
 /// Request message for
 /// `TensorboardService.ReadTensorboardUsage`.
-final class ReadTensorboardUsageRequest extends ProtoMessage {
+final class ReadTensorboardUsageRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ReadTensorboardUsageRequest';
 
@@ -85215,7 +85358,7 @@ final class ReadTensorboardUsageRequest extends ProtoMessage {
 
 /// Response message for
 /// `TensorboardService.ReadTensorboardUsage`.
-final class ReadTensorboardUsageResponse extends ProtoMessage {
+final class ReadTensorboardUsageResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ReadTensorboardUsageResponse';
 
@@ -85248,7 +85391,8 @@ final class ReadTensorboardUsageResponse extends ProtoMessage {
 }
 
 /// Per user usage data.
-final class ReadTensorboardUsageResponse_PerUserUsageData extends ProtoMessage {
+final class ReadTensorboardUsageResponse_PerUserUsageData
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ReadTensorboardUsageResponse.PerUserUsageData';
 
@@ -85290,7 +85434,7 @@ final class ReadTensorboardUsageResponse_PerUserUsageData extends ProtoMessage {
 
 /// Per month usage data
 final class ReadTensorboardUsageResponse_PerMonthUsageData
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ReadTensorboardUsageResponse.PerMonthUsageData';
 
@@ -85324,7 +85468,7 @@ final class ReadTensorboardUsageResponse_PerMonthUsageData
 
 /// Request message for
 /// `TensorboardService.ReadTensorboardSize`.
-final class ReadTensorboardSizeRequest extends ProtoMessage {
+final class ReadTensorboardSizeRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ReadTensorboardSizeRequest';
 
@@ -85354,7 +85498,7 @@ final class ReadTensorboardSizeRequest extends ProtoMessage {
 
 /// Response message for
 /// `TensorboardService.ReadTensorboardSize`.
-final class ReadTensorboardSizeResponse extends ProtoMessage {
+final class ReadTensorboardSizeResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ReadTensorboardSizeResponse';
 
@@ -85389,7 +85533,7 @@ final class ReadTensorboardSizeResponse extends ProtoMessage {
 
 /// Request message for
 /// `TensorboardService.CreateTensorboardExperiment`.
-final class CreateTensorboardExperimentRequest extends ProtoMessage {
+final class CreateTensorboardExperimentRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateTensorboardExperimentRequest';
 
@@ -85450,7 +85594,7 @@ final class CreateTensorboardExperimentRequest extends ProtoMessage {
 
 /// Request message for
 /// `TensorboardService.GetTensorboardExperiment`.
-final class GetTensorboardExperimentRequest extends ProtoMessage {
+final class GetTensorboardExperimentRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetTensorboardExperimentRequest';
 
@@ -85480,7 +85624,7 @@ final class GetTensorboardExperimentRequest extends ProtoMessage {
 
 /// Request message for
 /// `TensorboardService.ListTensorboardExperiments`.
-final class ListTensorboardExperimentsRequest extends ProtoMessage {
+final class ListTensorboardExperimentsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListTensorboardExperimentsRequest';
 
@@ -85562,7 +85706,7 @@ final class ListTensorboardExperimentsRequest extends ProtoMessage {
 
 /// Response message for
 /// `TensorboardService.ListTensorboardExperiments`.
-final class ListTensorboardExperimentsResponse extends ProtoMessage {
+final class ListTensorboardExperimentsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListTensorboardExperimentsResponse';
 
@@ -85612,7 +85756,7 @@ final class ListTensorboardExperimentsResponse extends ProtoMessage {
 
 /// Request message for
 /// `TensorboardService.UpdateTensorboardExperiment`.
-final class UpdateTensorboardExperimentRequest extends ProtoMessage {
+final class UpdateTensorboardExperimentRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateTensorboardExperimentRequest';
 
@@ -85660,7 +85804,7 @@ final class UpdateTensorboardExperimentRequest extends ProtoMessage {
 
 /// Request message for
 /// `TensorboardService.DeleteTensorboardExperiment`.
-final class DeleteTensorboardExperimentRequest extends ProtoMessage {
+final class DeleteTensorboardExperimentRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteTensorboardExperimentRequest';
 
@@ -85692,7 +85836,7 @@ final class DeleteTensorboardExperimentRequest extends ProtoMessage {
 
 /// Request message for
 /// `TensorboardService.BatchCreateTensorboardRuns`.
-final class BatchCreateTensorboardRunsRequest extends ProtoMessage {
+final class BatchCreateTensorboardRunsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BatchCreateTensorboardRunsRequest';
 
@@ -85739,7 +85883,7 @@ final class BatchCreateTensorboardRunsRequest extends ProtoMessage {
 
 /// Response message for
 /// `TensorboardService.BatchCreateTensorboardRuns`.
-final class BatchCreateTensorboardRunsResponse extends ProtoMessage {
+final class BatchCreateTensorboardRunsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BatchCreateTensorboardRunsResponse';
 
@@ -85774,7 +85918,7 @@ final class BatchCreateTensorboardRunsResponse extends ProtoMessage {
 
 /// Request message for
 /// `TensorboardService.CreateTensorboardRun`.
-final class CreateTensorboardRunRequest extends ProtoMessage {
+final class CreateTensorboardRunRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateTensorboardRunRequest';
 
@@ -85828,7 +85972,7 @@ final class CreateTensorboardRunRequest extends ProtoMessage {
 
 /// Request message for
 /// `TensorboardService.GetTensorboardRun`.
-final class GetTensorboardRunRequest extends ProtoMessage {
+final class GetTensorboardRunRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetTensorboardRunRequest';
 
@@ -85857,7 +86001,7 @@ final class GetTensorboardRunRequest extends ProtoMessage {
 
 /// Request message for
 /// `TensorboardService.ReadTensorboardBlobData`.
-final class ReadTensorboardBlobDataRequest extends ProtoMessage {
+final class ReadTensorboardBlobDataRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ReadTensorboardBlobDataRequest';
 
@@ -85893,7 +86037,7 @@ final class ReadTensorboardBlobDataRequest extends ProtoMessage {
 
 /// Response message for
 /// `TensorboardService.ReadTensorboardBlobData`.
-final class ReadTensorboardBlobDataResponse extends ProtoMessage {
+final class ReadTensorboardBlobDataResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ReadTensorboardBlobDataResponse';
 
@@ -85919,7 +86063,7 @@ final class ReadTensorboardBlobDataResponse extends ProtoMessage {
 
 /// Request message for
 /// `TensorboardService.ListTensorboardRuns`.
-final class ListTensorboardRunsRequest extends ProtoMessage {
+final class ListTensorboardRunsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListTensorboardRunsRequest';
 
@@ -85999,7 +86143,7 @@ final class ListTensorboardRunsRequest extends ProtoMessage {
 
 /// Response message for
 /// `TensorboardService.ListTensorboardRuns`.
-final class ListTensorboardRunsResponse extends ProtoMessage {
+final class ListTensorboardRunsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListTensorboardRunsResponse';
 
@@ -86045,7 +86189,7 @@ final class ListTensorboardRunsResponse extends ProtoMessage {
 
 /// Request message for
 /// `TensorboardService.UpdateTensorboardRun`.
-final class UpdateTensorboardRunRequest extends ProtoMessage {
+final class UpdateTensorboardRunRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateTensorboardRunRequest';
 
@@ -86086,7 +86230,7 @@ final class UpdateTensorboardRunRequest extends ProtoMessage {
 
 /// Request message for
 /// `TensorboardService.DeleteTensorboardRun`.
-final class DeleteTensorboardRunRequest extends ProtoMessage {
+final class DeleteTensorboardRunRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteTensorboardRunRequest';
 
@@ -86115,7 +86259,8 @@ final class DeleteTensorboardRunRequest extends ProtoMessage {
 
 /// Request message for
 /// `TensorboardService.BatchCreateTensorboardTimeSeries`.
-final class BatchCreateTensorboardTimeSeriesRequest extends ProtoMessage {
+final class BatchCreateTensorboardTimeSeriesRequest
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BatchCreateTensorboardTimeSeriesRequest';
 
@@ -86164,7 +86309,8 @@ final class BatchCreateTensorboardTimeSeriesRequest extends ProtoMessage {
 
 /// Response message for
 /// `TensorboardService.BatchCreateTensorboardTimeSeries`.
-final class BatchCreateTensorboardTimeSeriesResponse extends ProtoMessage {
+final class BatchCreateTensorboardTimeSeriesResponse
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BatchCreateTensorboardTimeSeriesResponse';
 
@@ -86199,7 +86345,7 @@ final class BatchCreateTensorboardTimeSeriesResponse extends ProtoMessage {
 
 /// Request message for
 /// `TensorboardService.CreateTensorboardTimeSeries`.
-final class CreateTensorboardTimeSeriesRequest extends ProtoMessage {
+final class CreateTensorboardTimeSeriesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateTensorboardTimeSeriesRequest';
 
@@ -86260,7 +86406,7 @@ final class CreateTensorboardTimeSeriesRequest extends ProtoMessage {
 
 /// Request message for
 /// `TensorboardService.GetTensorboardTimeSeries`.
-final class GetTensorboardTimeSeriesRequest extends ProtoMessage {
+final class GetTensorboardTimeSeriesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetTensorboardTimeSeriesRequest';
 
@@ -86290,7 +86436,7 @@ final class GetTensorboardTimeSeriesRequest extends ProtoMessage {
 
 /// Request message for
 /// `TensorboardService.ListTensorboardTimeSeries`.
-final class ListTensorboardTimeSeriesRequest extends ProtoMessage {
+final class ListTensorboardTimeSeriesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListTensorboardTimeSeriesRequest';
 
@@ -86370,7 +86516,7 @@ final class ListTensorboardTimeSeriesRequest extends ProtoMessage {
 
 /// Response message for
 /// `TensorboardService.ListTensorboardTimeSeries`.
-final class ListTensorboardTimeSeriesResponse extends ProtoMessage {
+final class ListTensorboardTimeSeriesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListTensorboardTimeSeriesResponse';
 
@@ -86420,7 +86566,7 @@ final class ListTensorboardTimeSeriesResponse extends ProtoMessage {
 
 /// Request message for
 /// `TensorboardService.UpdateTensorboardTimeSeries`.
-final class UpdateTensorboardTimeSeriesRequest extends ProtoMessage {
+final class UpdateTensorboardTimeSeriesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateTensorboardTimeSeriesRequest';
 
@@ -86469,7 +86615,7 @@ final class UpdateTensorboardTimeSeriesRequest extends ProtoMessage {
 
 /// Request message for
 /// `TensorboardService.DeleteTensorboardTimeSeries`.
-final class DeleteTensorboardTimeSeriesRequest extends ProtoMessage {
+final class DeleteTensorboardTimeSeriesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteTensorboardTimeSeriesRequest';
 
@@ -86501,7 +86647,8 @@ final class DeleteTensorboardTimeSeriesRequest extends ProtoMessage {
 
 /// Request message for
 /// `TensorboardService.BatchReadTensorboardTimeSeriesData`.
-final class BatchReadTensorboardTimeSeriesDataRequest extends ProtoMessage {
+final class BatchReadTensorboardTimeSeriesDataRequest
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BatchReadTensorboardTimeSeriesDataRequest';
 
@@ -86549,7 +86696,8 @@ final class BatchReadTensorboardTimeSeriesDataRequest extends ProtoMessage {
 
 /// Response message for
 /// `TensorboardService.BatchReadTensorboardTimeSeriesData`.
-final class BatchReadTensorboardTimeSeriesDataResponse extends ProtoMessage {
+final class BatchReadTensorboardTimeSeriesDataResponse
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BatchReadTensorboardTimeSeriesDataResponse';
 
@@ -86583,7 +86731,7 @@ final class BatchReadTensorboardTimeSeriesDataResponse extends ProtoMessage {
 
 /// Request message for
 /// `TensorboardService.ReadTensorboardTimeSeriesData`.
-final class ReadTensorboardTimeSeriesDataRequest extends ProtoMessage {
+final class ReadTensorboardTimeSeriesDataRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ReadTensorboardTimeSeriesDataRequest';
 
@@ -86639,7 +86787,8 @@ final class ReadTensorboardTimeSeriesDataRequest extends ProtoMessage {
 
 /// Response message for
 /// `TensorboardService.ReadTensorboardTimeSeriesData`.
-final class ReadTensorboardTimeSeriesDataResponse extends ProtoMessage {
+final class ReadTensorboardTimeSeriesDataResponse
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ReadTensorboardTimeSeriesDataResponse';
 
@@ -86670,7 +86819,8 @@ final class ReadTensorboardTimeSeriesDataResponse extends ProtoMessage {
 
 /// Request message for
 /// `TensorboardService.WriteTensorboardExperimentData`.
-final class WriteTensorboardExperimentDataRequest extends ProtoMessage {
+final class WriteTensorboardExperimentDataRequest
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.WriteTensorboardExperimentDataRequest';
 
@@ -86717,7 +86867,8 @@ final class WriteTensorboardExperimentDataRequest extends ProtoMessage {
 
 /// Response message for
 /// `TensorboardService.WriteTensorboardExperimentData`.
-final class WriteTensorboardExperimentDataResponse extends ProtoMessage {
+final class WriteTensorboardExperimentDataResponse
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.WriteTensorboardExperimentDataResponse';
 
@@ -86740,7 +86891,7 @@ final class WriteTensorboardExperimentDataResponse extends ProtoMessage {
 
 /// Request message for
 /// `TensorboardService.WriteTensorboardRunData`.
-final class WriteTensorboardRunDataRequest extends ProtoMessage {
+final class WriteTensorboardRunDataRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.WriteTensorboardRunDataRequest';
 
@@ -86788,7 +86939,7 @@ final class WriteTensorboardRunDataRequest extends ProtoMessage {
 
 /// Response message for
 /// `TensorboardService.WriteTensorboardRunData`.
-final class WriteTensorboardRunDataResponse extends ProtoMessage {
+final class WriteTensorboardRunDataResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.WriteTensorboardRunDataResponse';
 
@@ -86809,7 +86960,8 @@ final class WriteTensorboardRunDataResponse extends ProtoMessage {
 
 /// Request message for
 /// `TensorboardService.ExportTensorboardTimeSeriesData`.
-final class ExportTensorboardTimeSeriesDataRequest extends ProtoMessage {
+final class ExportTensorboardTimeSeriesDataRequest
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExportTensorboardTimeSeriesDataRequest';
 
@@ -86886,7 +87038,8 @@ final class ExportTensorboardTimeSeriesDataRequest extends ProtoMessage {
 
 /// Response message for
 /// `TensorboardService.ExportTensorboardTimeSeriesData`.
-final class ExportTensorboardTimeSeriesDataResponse extends ProtoMessage {
+final class ExportTensorboardTimeSeriesDataResponse
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExportTensorboardTimeSeriesDataResponse';
 
@@ -86935,7 +87088,7 @@ final class ExportTensorboardTimeSeriesDataResponse extends ProtoMessage {
 }
 
 /// Details of operations that perform create Tensorboard.
-final class CreateTensorboardOperationMetadata extends ProtoMessage {
+final class CreateTensorboardOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateTensorboardOperationMetadata';
 
@@ -86968,7 +87121,7 @@ final class CreateTensorboardOperationMetadata extends ProtoMessage {
 }
 
 /// Details of operations that perform update Tensorboard.
-final class UpdateTensorboardOperationMetadata extends ProtoMessage {
+final class UpdateTensorboardOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateTensorboardOperationMetadata';
 
@@ -87001,7 +87154,7 @@ final class UpdateTensorboardOperationMetadata extends ProtoMessage {
 }
 
 /// TensorboardTimeSeries maps to times series produced in training runs
-final class TensorboardTimeSeries extends ProtoMessage {
+final class TensorboardTimeSeries extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TensorboardTimeSeries';
 
@@ -87106,7 +87259,7 @@ final class TensorboardTimeSeries extends ProtoMessage {
 }
 
 /// Describes metadata for a TensorboardTimeSeries.
-final class TensorboardTimeSeries_Metadata extends ProtoMessage {
+final class TensorboardTimeSeries_Metadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TensorboardTimeSeries.Metadata';
 
@@ -87161,7 +87314,7 @@ final class TensorboardTimeSeries_Metadata extends ProtoMessage {
 }
 
 /// An enum representing the value type of a TensorboardTimeSeries.
-final class TensorboardTimeSeries_ValueType extends ProtoEnum {
+final class TensorboardTimeSeries_ValueType extends protobuf.ProtoEnum {
   /// The value type is unspecified.
   static const valueTypeUnspecified = TensorboardTimeSeries_ValueType(
     'VALUE_TYPE_UNSPECIFIED',
@@ -87195,7 +87348,7 @@ final class TensorboardTimeSeries_ValueType extends ProtoEnum {
 /// knowledge and scope of the model. A Tool object should contain exactly
 /// one type of Tool (e.g FunctionDeclaration, Retrieval or
 /// GoogleSearchRetrieval).
-final class Tool extends ProtoMessage {
+final class Tool extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Tool';
 
@@ -87304,7 +87457,7 @@ final class Tool extends ProtoMessage {
 
 /// GoogleSearch tool type.
 /// Tool to support Google Search in Model. Powered by Google.
-final class Tool_GoogleSearch extends ProtoMessage {
+final class Tool_GoogleSearch extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Tool.GoogleSearch';
 
@@ -87353,7 +87506,7 @@ final class Tool_GoogleSearch extends ProtoMessage {
 ///
 /// See also [ExecutableCode]and [CodeExecutionResult] which are input and
 /// output to this tool.
-final class Tool_CodeExecution extends ProtoMessage {
+final class Tool_CodeExecution extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Tool.CodeExecution';
 
@@ -87373,7 +87526,7 @@ final class Tool_CodeExecution extends ProtoMessage {
 }
 
 /// Tool to support computer use.
-final class Tool_ComputerUse extends ProtoMessage {
+final class Tool_ComputerUse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Tool.ComputerUse';
 
@@ -87406,7 +87559,7 @@ final class Tool_ComputerUse extends ProtoMessage {
 }
 
 /// Represents the environment being operated, such as a web browser.
-final class Tool_ComputerUse_Environment extends ProtoEnum {
+final class Tool_ComputerUse_Environment extends protobuf.ProtoEnum {
   /// Defaults to browser.
   static const environmentUnspecified = Tool_ComputerUse_Environment(
     'ENVIRONMENT_UNSPECIFIED',
@@ -87430,7 +87583,7 @@ final class Tool_ComputerUse_Environment extends ProtoEnum {
 /// with chosen confidence and above. For understanding different confidence of
 /// webrisk, please refer to
 /// https://cloud.google.com/web-risk/docs/reference/rpc/google.cloud.webrisk.v1eap1#confidencelevel
-final class Tool_PhishBlockThreshold extends ProtoEnum {
+final class Tool_PhishBlockThreshold extends protobuf.ProtoEnum {
   /// Defaults to unspecified.
   static const phishBlockThresholdUnspecified = Tool_PhishBlockThreshold(
     'PHISH_BLOCK_THRESHOLD_UNSPECIFIED',
@@ -87476,7 +87629,7 @@ final class Tool_PhishBlockThreshold extends ProtoEnum {
 }
 
 /// Tool to support URL context.
-final class UrlContext extends ProtoMessage {
+final class UrlContext extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UrlContext';
 
@@ -87496,7 +87649,7 @@ final class UrlContext extends ProtoMessage {
 }
 
 /// A single example of the tool usage.
-final class ToolUseExample extends ProtoMessage {
+final class ToolUseExample extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ToolUseExample';
 
@@ -87579,7 +87732,7 @@ final class ToolUseExample extends ProtoMessage {
 }
 
 /// Identifies one operation of the extension.
-final class ToolUseExample_ExtensionOperation extends ProtoMessage {
+final class ToolUseExample_ExtensionOperation extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ToolUseExample.ExtensionOperation';
 
@@ -87624,7 +87777,7 @@ final class ToolUseExample_ExtensionOperation extends ProtoMessage {
 /// in this declaration are the function name, description, parameters and
 /// response type. This FunctionDeclaration is a representation of a block of
 /// code that can be used as a `Tool` by the model and executed by the client.
-final class FunctionDeclaration extends ProtoMessage {
+final class FunctionDeclaration extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FunctionDeclaration';
 
@@ -87738,7 +87891,7 @@ final class FunctionDeclaration extends ProtoMessage {
 /// A predicted [FunctionCall] returned from the model that contains a string
 /// representing the [FunctionDeclaration.name] and a structured JSON object
 /// containing the parameters and their values.
-final class FunctionCall extends ProtoMessage {
+final class FunctionCall extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FunctionCall';
 
@@ -87787,7 +87940,7 @@ final class FunctionCall extends ProtoMessage {
 /// the [FunctionDeclaration.name] and a structured JSON object containing any
 /// output from the function is used as context to the model. This should contain
 /// the result of a [FunctionCall] made based on model prediction.
-final class FunctionResponse extends ProtoMessage {
+final class FunctionResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FunctionResponse';
 
@@ -87840,7 +87993,7 @@ final class FunctionResponse extends ProtoMessage {
 ///
 /// Generated when using the [FunctionDeclaration] tool and
 /// [FunctionCallingConfig] mode is set to [Mode.CODE].
-final class ExecutableCode extends ProtoMessage {
+final class ExecutableCode extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ExecutableCode';
 
@@ -87878,7 +88031,7 @@ final class ExecutableCode extends ProtoMessage {
 }
 
 /// Supported programming languages for the generated code.
-final class ExecutableCode_Language extends ProtoEnum {
+final class ExecutableCode_Language extends protobuf.ProtoEnum {
   /// Unspecified language. This value should not be used.
   static const languageUnspecified = ExecutableCode_Language(
     'LANGUAGE_UNSPECIFIED',
@@ -87899,7 +88052,7 @@ final class ExecutableCode_Language extends ProtoEnum {
 /// Result of executing the [ExecutableCode].
 ///
 /// Always follows a `part` containing the [ExecutableCode].
-final class CodeExecutionResult extends ProtoMessage {
+final class CodeExecutionResult extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CodeExecutionResult';
 
@@ -87941,7 +88094,7 @@ final class CodeExecutionResult extends ProtoMessage {
 }
 
 /// Enumeration of possible outcomes of the code execution.
-final class CodeExecutionResult_Outcome extends ProtoEnum {
+final class CodeExecutionResult_Outcome extends protobuf.ProtoEnum {
   /// Unspecified status. This value should not be used.
   static const outcomeUnspecified = CodeExecutionResult_Outcome(
     'OUTCOME_UNSPECIFIED',
@@ -87970,7 +88123,7 @@ final class CodeExecutionResult_Outcome extends ProtoEnum {
 }
 
 /// Defines a retrieval tool that model can call to access external knowledge.
-final class Retrieval extends ProtoMessage {
+final class Retrieval extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Retrieval';
 
@@ -88014,7 +88167,7 @@ final class Retrieval extends ProtoMessage {
 }
 
 /// Retrieve from Vertex RAG Store for grounding.
-final class VertexRagStore extends ProtoMessage {
+final class VertexRagStore extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.VertexRagStore';
 
@@ -88099,7 +88252,7 @@ final class VertexRagStore extends ProtoMessage {
 }
 
 /// The definition of the Rag resource.
-final class VertexRagStore_RagResource extends ProtoMessage {
+final class VertexRagStore_RagResource extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.VertexRagStore.RagResource';
 
@@ -88140,7 +88293,7 @@ final class VertexRagStore_RagResource extends ProtoMessage {
 /// Retrieve from Vertex AI Search datastore or engine for grounding.
 /// datastore and engine are mutually exclusive.
 /// See https://cloud.google.com/products/agent-builder
-final class VertexAisearch extends ProtoMessage {
+final class VertexAisearch extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.VertexAISearch';
 
@@ -88215,7 +88368,7 @@ final class VertexAisearch extends ProtoMessage {
 /// Define data stores within engine to filter on in a search call and
 /// configurations for those data stores. For more information, see
 /// https://cloud.google.com/generative-ai-app-builder/docs/reference/rpc/google.cloud.discoveryengine.v1#datastorespec
-final class VertexAisearch_DataStoreSpec extends ProtoMessage {
+final class VertexAisearch_DataStoreSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.VertexAISearch.DataStoreSpec';
 
@@ -88258,7 +88411,7 @@ final class VertexAisearch_DataStoreSpec extends ProtoMessage {
 }
 
 /// Tool to retrieve public web data for grounding, powered by Google.
-final class GoogleSearchRetrieval extends ProtoMessage {
+final class GoogleSearchRetrieval extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GoogleSearchRetrieval';
 
@@ -88290,7 +88443,7 @@ final class GoogleSearchRetrieval extends ProtoMessage {
 }
 
 /// Tool to retrieve public maps data for grounding, powered by Google.
-final class GoogleMaps extends ProtoMessage {
+final class GoogleMaps extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GoogleMaps';
 
@@ -88319,7 +88472,7 @@ final class GoogleMaps extends ProtoMessage {
 
 /// Tool to search public web data, powered by Vertex AI Search and Sec4
 /// compliance.
-final class EnterpriseWebSearch extends ProtoMessage {
+final class EnterpriseWebSearch extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.EnterpriseWebSearch';
 
@@ -88363,7 +88516,7 @@ final class EnterpriseWebSearch extends ProtoMessage {
 }
 
 /// Describes the options to customize dynamic retrieval.
-final class DynamicRetrievalConfig extends ProtoMessage {
+final class DynamicRetrievalConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DynamicRetrievalConfig';
 
@@ -88404,7 +88557,7 @@ final class DynamicRetrievalConfig extends ProtoMessage {
 }
 
 /// The mode of the predictor to be used in dynamic retrieval.
-final class DynamicRetrievalConfig_Mode extends ProtoEnum {
+final class DynamicRetrievalConfig_Mode extends protobuf.ProtoEnum {
   /// Always trigger retrieval.
   static const modeUnspecified = DynamicRetrievalConfig_Mode(
     'MODE_UNSPECIFIED',
@@ -88423,7 +88576,7 @@ final class DynamicRetrievalConfig_Mode extends ProtoEnum {
 }
 
 /// Tool config. This config is shared for all tools provided in the request.
-final class ToolConfig extends ProtoMessage {
+final class ToolConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ToolConfig';
 
@@ -88463,7 +88616,7 @@ final class ToolConfig extends ProtoMessage {
 }
 
 /// Function calling config.
-final class FunctionCallingConfig extends ProtoMessage {
+final class FunctionCallingConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FunctionCallingConfig';
 
@@ -88502,7 +88655,7 @@ final class FunctionCallingConfig extends ProtoMessage {
 }
 
 /// Function calling mode.
-final class FunctionCallingConfig_Mode extends ProtoEnum {
+final class FunctionCallingConfig_Mode extends protobuf.ProtoEnum {
   /// Unspecified function calling mode. This value should not be used.
   static const modeUnspecified = FunctionCallingConfig_Mode('MODE_UNSPECIFIED');
 
@@ -88539,7 +88692,7 @@ final class FunctionCallingConfig_Mode extends ProtoEnum {
 }
 
 /// Retrieval config.
-final class RetrievalConfig extends ProtoMessage {
+final class RetrievalConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RetrievalConfig';
 
@@ -88576,7 +88729,7 @@ final class RetrievalConfig extends ProtoMessage {
 }
 
 /// Specifies the context retrieval config.
-final class RagRetrievalConfig extends ProtoMessage {
+final class RagRetrievalConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagRetrievalConfig';
 
@@ -88625,7 +88778,7 @@ final class RagRetrievalConfig extends ProtoMessage {
 }
 
 /// Config for Hybrid Search.
-final class RagRetrievalConfig_HybridSearch extends ProtoMessage {
+final class RagRetrievalConfig_HybridSearch extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagRetrievalConfig.HybridSearch';
 
@@ -88654,7 +88807,7 @@ final class RagRetrievalConfig_HybridSearch extends ProtoMessage {
 }
 
 /// Config for filters.
-final class RagRetrievalConfig_Filter extends ProtoMessage {
+final class RagRetrievalConfig_Filter extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagRetrievalConfig.Filter';
 
@@ -88710,7 +88863,7 @@ final class RagRetrievalConfig_Filter extends ProtoMessage {
 }
 
 /// Config for ranking and reranking.
-final class RagRetrievalConfig_Ranking extends ProtoMessage {
+final class RagRetrievalConfig_Ranking extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagRetrievalConfig.Ranking';
 
@@ -88749,7 +88902,8 @@ final class RagRetrievalConfig_Ranking extends ProtoMessage {
 }
 
 /// Config for Rank Service.
-final class RagRetrievalConfig_Ranking_RankService extends ProtoMessage {
+final class RagRetrievalConfig_Ranking_RankService
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagRetrievalConfig.Ranking.RankService';
 
@@ -88779,7 +88933,7 @@ final class RagRetrievalConfig_Ranking_RankService extends ProtoMessage {
 }
 
 /// Config for LlmRanker.
-final class RagRetrievalConfig_Ranking_LlmRanker extends ProtoMessage {
+final class RagRetrievalConfig_Ranking_LlmRanker extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagRetrievalConfig.Ranking.LlmRanker';
 
@@ -88813,7 +88967,7 @@ final class RagRetrievalConfig_Ranking_LlmRanker extends ProtoMessage {
 /// export data from Vertex AI's Dataset which becomes the training input,
 /// `upload` the Model
 /// to Vertex AI, and evaluate the Model.
-final class TrainingPipeline extends ProtoMessage {
+final class TrainingPipeline extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TrainingPipeline';
 
@@ -89023,7 +89177,7 @@ final class TrainingPipeline extends ProtoMessage {
 
 /// Specifies Vertex AI owned input data to be used for training, and
 /// possibly evaluating, the Model.
-final class InputDataConfig extends ProtoMessage {
+final class InputDataConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.InputDataConfig';
 
@@ -89244,7 +89398,7 @@ final class InputDataConfig extends ProtoMessage {
 /// provided ones sum to less than 1, the remainder is assigned to sets as
 /// decided by Vertex AI. If none of the fractions are set, by default roughly
 /// 80% of data is used for training, 10% for validation, and 10% for test.
-final class FractionSplit extends ProtoMessage {
+final class FractionSplit extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FractionSplit';
 
@@ -89300,7 +89454,7 @@ final class FractionSplit extends ProtoMessage {
 /// set as '-' (the minus sign).
 ///
 /// Supported only for unstructured Datasets.
-final class FilterSplit extends ProtoMessage {
+final class FilterSplit extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FilterSplit';
 
@@ -89366,7 +89520,7 @@ final class FilterSplit extends ProtoMessage {
 /// value of a provided key.
 ///
 /// Supported only for tabular Datasets.
-final class PredefinedSplit extends ProtoMessage {
+final class PredefinedSplit extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PredefinedSplit';
 
@@ -89401,7 +89555,7 @@ final class PredefinedSplit extends ProtoMessage {
 /// next to validation set, and the oldest to the test set.
 ///
 /// Supported only for tabular Datasets.
-final class TimestampSplit extends ProtoMessage {
+final class TimestampSplit extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TimestampSplit';
 
@@ -89478,7 +89632,7 @@ final class TimestampSplit extends ProtoMessage {
 /// a specific value, those rows are randomly assigned.
 ///
 /// Supported only for tabular Datasets.
-final class StratifiedSplit extends ProtoMessage {
+final class StratifiedSplit extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StratifiedSplit';
 
@@ -89536,7 +89690,7 @@ final class StratifiedSplit extends ProtoMessage {
 }
 
 /// Represents a TuningJob that runs with Google owned models.
-final class TuningJob extends ProtoMessage {
+final class TuningJob extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TuningJob';
 
@@ -89787,7 +89941,7 @@ final class TuningJob extends ProtoMessage {
 
 /// The Model Registry Model and Online Prediction Endpoint associated with
 /// this `TuningJob`.
-final class TunedModel extends ProtoMessage {
+final class TunedModel extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TunedModel';
 
@@ -89846,7 +90000,7 @@ final class TunedModel extends ProtoMessage {
 }
 
 /// Dataset distribution for Supervised Tuning.
-final class SupervisedTuningDatasetDistribution extends ProtoMessage {
+final class SupervisedTuningDatasetDistribution extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SupervisedTuningDatasetDistribution';
 
@@ -89942,7 +90096,7 @@ final class SupervisedTuningDatasetDistribution extends ProtoMessage {
 /// Dataset bucket used to create a histogram for the distribution given a
 /// population of values.
 final class SupervisedTuningDatasetDistribution_DatasetBucket
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SupervisedTuningDatasetDistribution.DatasetBucket';
 
@@ -89992,7 +90146,7 @@ final class SupervisedTuningDatasetDistribution_DatasetBucket
 }
 
 /// Tuning data statistics for Supervised Tuning.
-final class SupervisedTuningDataStats extends ProtoMessage {
+final class SupervisedTuningDataStats extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SupervisedTuningDataStats';
 
@@ -90135,7 +90289,7 @@ final class SupervisedTuningDataStats extends ProtoMessage {
 }
 
 /// Distribution computed over a tuning dataset.
-final class DatasetDistribution extends ProtoMessage {
+final class DatasetDistribution extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DatasetDistribution';
 
@@ -90221,7 +90375,8 @@ final class DatasetDistribution extends ProtoMessage {
 
 /// Dataset bucket used to create a histogram for the distribution given a
 /// population of values.
-final class DatasetDistribution_DistributionBucket extends ProtoMessage {
+final class DatasetDistribution_DistributionBucket
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DatasetDistribution.DistributionBucket';
 
@@ -90268,7 +90423,7 @@ final class DatasetDistribution_DistributionBucket extends ProtoMessage {
 }
 
 /// Statistics computed over a tuning dataset.
-final class DatasetStats extends ProtoMessage {
+final class DatasetStats extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DatasetStats';
 
@@ -90373,7 +90528,7 @@ final class DatasetStats extends ProtoMessage {
 }
 
 /// Statistics computed for datasets used for distillation.
-final class DistillationDataStats extends ProtoMessage {
+final class DistillationDataStats extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DistillationDataStats';
 
@@ -90406,7 +90561,7 @@ final class DistillationDataStats extends ProtoMessage {
 
 /// The tuning data statistic values for
 /// `TuningJob`.
-final class TuningDataStats extends ProtoMessage {
+final class TuningDataStats extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TuningDataStats';
 
@@ -90447,7 +90602,7 @@ final class TuningDataStats extends ProtoMessage {
 }
 
 /// Hyperparameters for SFT.
-final class SupervisedHyperParameters extends ProtoMessage {
+final class SupervisedHyperParameters extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SupervisedHyperParameters';
 
@@ -90519,7 +90674,7 @@ final class SupervisedHyperParameters extends ProtoMessage {
 }
 
 /// Supported adapter sizes for tuning.
-final class SupervisedHyperParameters_AdapterSize extends ProtoEnum {
+final class SupervisedHyperParameters_AdapterSize extends protobuf.ProtoEnum {
   /// Adapter size is unspecified.
   static const adapterSizeUnspecified = SupervisedHyperParameters_AdapterSize(
     'ADAPTER_SIZE_UNSPECIFIED',
@@ -90565,7 +90720,7 @@ final class SupervisedHyperParameters_AdapterSize extends ProtoEnum {
 }
 
 /// Tuning Spec for Supervised Tuning for first party models.
-final class SupervisedTuningSpec extends ProtoMessage {
+final class SupervisedTuningSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SupervisedTuningSpec';
 
@@ -90652,7 +90807,7 @@ final class SupervisedTuningSpec extends ProtoMessage {
 }
 
 /// Supported tuning modes.
-final class SupervisedTuningSpec_TuningMode extends ProtoEnum {
+final class SupervisedTuningSpec_TuningMode extends protobuf.ProtoEnum {
   /// Tuning mode is unspecified.
   static const tuningModeUnspecified = SupervisedTuningSpec_TuningMode(
     'TUNING_MODE_UNSPECIFIED',
@@ -90678,7 +90833,7 @@ final class SupervisedTuningSpec_TuningMode extends ProtoEnum {
 }
 
 /// Tuning Spec for Distillation.
-final class DistillationSpec extends ProtoMessage {
+final class DistillationSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DistillationSpec';
 
@@ -90768,7 +90923,7 @@ final class DistillationSpec extends ProtoMessage {
 }
 
 /// Hyperparameters for Distillation.
-final class DistillationHyperParameters extends ProtoMessage {
+final class DistillationHyperParameters extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DistillationHyperParameters';
 
@@ -90822,7 +90977,7 @@ final class DistillationHyperParameters extends ProtoMessage {
 }
 
 /// Tuning spec for Partner models.
-final class PartnerModelTuningSpec extends ProtoMessage {
+final class PartnerModelTuningSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PartnerModelTuningSpec';
 
@@ -90878,7 +91033,7 @@ final class PartnerModelTuningSpec extends ProtoMessage {
 }
 
 /// TunedModel Reference for legacy model migration.
-final class TunedModelRef extends ProtoMessage {
+final class TunedModelRef extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TunedModelRef';
 
@@ -90925,7 +91080,7 @@ final class TunedModelRef extends ProtoMessage {
 }
 
 /// Hyperparameters for Veo.
-final class VeoHyperParameters extends ProtoMessage {
+final class VeoHyperParameters extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.VeoHyperParameters';
 
@@ -90979,7 +91134,7 @@ final class VeoHyperParameters extends ProtoMessage {
 }
 
 /// An enum defining the tuning task used for Veo.
-final class VeoHyperParameters_TuningTask extends ProtoEnum {
+final class VeoHyperParameters_TuningTask extends protobuf.ProtoEnum {
   /// Default value. This value is unused.
   static const tuningTaskUnspecified = VeoHyperParameters_TuningTask(
     'TUNING_TASK_UNSPECIFIED',
@@ -91001,7 +91156,7 @@ final class VeoHyperParameters_TuningTask extends ProtoEnum {
 }
 
 /// Tuning Spec for Veo Model Tuning.
-final class VeoTuningSpec extends ProtoMessage {
+final class VeoTuningSpec extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.VeoTuningSpec';
 
@@ -91057,7 +91212,7 @@ final class VeoTuningSpec extends ProtoMessage {
 }
 
 /// Evaluation Config for Tuning Job.
-final class EvaluationConfig extends ProtoMessage {
+final class EvaluationConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.EvaluationConfig';
 
@@ -91098,7 +91253,7 @@ final class EvaluationConfig extends ProtoMessage {
 }
 
 /// Evaluate Dataset Run Result for Tuning Job.
-final class EvaluateDatasetRun extends ProtoMessage {
+final class EvaluateDatasetRun extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.EvaluateDatasetRun';
 
@@ -91157,7 +91312,7 @@ final class EvaluateDatasetRun extends ProtoMessage {
 }
 
 /// TunedModelCheckpoint for the Tuned Model of a Tuning Job.
-final class TunedModelCheckpoint extends ProtoMessage {
+final class TunedModelCheckpoint extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.TunedModelCheckpoint';
 
@@ -91213,7 +91368,7 @@ final class TunedModelCheckpoint extends ProtoMessage {
 }
 
 /// A pre-tuned model for continuous tuning.
-final class PreTunedModel extends ProtoMessage {
+final class PreTunedModel extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.PreTunedModel';
 
@@ -91270,7 +91425,7 @@ final class PreTunedModel extends ProtoMessage {
 }
 
 /// A list of boolean values.
-final class BoolArray extends ProtoMessage {
+final class BoolArray extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.BoolArray';
 
@@ -91293,7 +91448,7 @@ final class BoolArray extends ProtoMessage {
 }
 
 /// A list of double values.
-final class DoubleArray extends ProtoMessage {
+final class DoubleArray extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DoubleArray';
 
@@ -91316,7 +91471,7 @@ final class DoubleArray extends ProtoMessage {
 }
 
 /// A list of int64 values.
-final class Int64Array extends ProtoMessage {
+final class Int64Array extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Int64Array';
 
@@ -91339,7 +91494,7 @@ final class Int64Array extends ProtoMessage {
 }
 
 /// A list of string values.
-final class StringArray extends ProtoMessage {
+final class StringArray extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StringArray';
 
@@ -91362,7 +91517,7 @@ final class StringArray extends ProtoMessage {
 }
 
 /// A tensor value type.
-final class Tensor extends ProtoMessage {
+final class Tensor extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Tensor';
 
@@ -91484,7 +91639,7 @@ final class Tensor extends ProtoMessage {
 }
 
 /// Data type of the tensor.
-final class Tensor_DataType extends ProtoEnum {
+final class Tensor_DataType extends protobuf.ProtoEnum {
   /// Not a legal value for DataType. Used to indicate a DataType field has not
   /// been set.
   static const dataTypeUnspecified = Tensor_DataType('DATA_TYPE_UNSPECIFIED');
@@ -91524,7 +91679,7 @@ final class Tensor_DataType extends ProtoEnum {
 }
 
 /// The definition of a artifact type in MLMD.
-final class ArtifactTypeSchema extends ProtoMessage {
+final class ArtifactTypeSchema extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ArtifactTypeSchema';
 
@@ -91590,7 +91745,7 @@ final class ArtifactTypeSchema extends ProtoMessage {
 }
 
 /// The definition of a runtime artifact.
-final class RuntimeArtifact extends ProtoMessage {
+final class RuntimeArtifact extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RuntimeArtifact';
 
@@ -91666,7 +91821,7 @@ final class RuntimeArtifact extends ProtoMessage {
 
 /// Contains model information necessary to perform batch prediction without
 /// requiring a full model import.
-final class UnmanagedContainerModel extends ProtoMessage {
+final class UnmanagedContainerModel extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UnmanagedContainerModel';
 
@@ -91718,7 +91873,7 @@ final class UnmanagedContainerModel extends ProtoMessage {
 
 /// References an API call. It contains more information about long running
 /// operation and Jobs that are triggered by the API call.
-final class UserActionReference extends ProtoMessage {
+final class UserActionReference extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UserActionReference';
 
@@ -91770,7 +91925,7 @@ final class UserActionReference extends ProtoMessage {
 }
 
 /// Value is the value of the field.
-final class Value extends ProtoMessage {
+final class Value extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Value';
 
@@ -91815,7 +91970,7 @@ final class Value extends ProtoMessage {
 }
 
 /// Config for the embedding model to use for RAG.
-final class RagEmbeddingModelConfig extends ProtoMessage {
+final class RagEmbeddingModelConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagEmbeddingModelConfig';
 
@@ -91864,7 +92019,7 @@ final class RagEmbeddingModelConfig extends ProtoMessage {
 
 /// Config representing a model hosted on Vertex Prediction Endpoint.
 final class RagEmbeddingModelConfig_VertexPredictionEndpoint
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagEmbeddingModelConfig.VertexPredictionEndpoint';
 
@@ -91922,7 +92077,8 @@ final class RagEmbeddingModelConfig_VertexPredictionEndpoint
 }
 
 /// Configuration for sparse emebdding generation.
-final class RagEmbeddingModelConfig_SparseEmbeddingConfig extends ProtoMessage {
+final class RagEmbeddingModelConfig_SparseEmbeddingConfig
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagEmbeddingModelConfig.SparseEmbeddingConfig';
 
@@ -91954,7 +92110,7 @@ final class RagEmbeddingModelConfig_SparseEmbeddingConfig extends ProtoMessage {
 
 /// Message for BM25 parameters.
 final class RagEmbeddingModelConfig_SparseEmbeddingConfig_Bm25
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagEmbeddingModelConfig.SparseEmbeddingConfig.Bm25';
 
@@ -92008,7 +92164,8 @@ final class RagEmbeddingModelConfig_SparseEmbeddingConfig_Bm25
 }
 
 /// Config for hybrid search.
-final class RagEmbeddingModelConfig_HybridSearchConfig extends ProtoMessage {
+final class RagEmbeddingModelConfig_HybridSearchConfig
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagEmbeddingModelConfig.HybridSearchConfig';
 
@@ -92058,7 +92215,7 @@ final class RagEmbeddingModelConfig_HybridSearchConfig extends ProtoMessage {
 }
 
 /// Config for the Vector DB to use for RAG.
-final class RagVectorDbConfig extends ProtoMessage {
+final class RagVectorDbConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagVectorDbConfig';
 
@@ -92138,7 +92295,7 @@ final class RagVectorDbConfig extends ProtoMessage {
 }
 
 /// The config for the default RAG-managed Vector DB.
-final class RagVectorDbConfig_RagManagedDb extends ProtoMessage {
+final class RagVectorDbConfig_RagManagedDb extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagVectorDbConfig.RagManagedDb';
 
@@ -92173,7 +92330,7 @@ final class RagVectorDbConfig_RagManagedDb extends ProtoMessage {
 }
 
 /// Config for KNN search.
-final class RagVectorDbConfig_RagManagedDb_Knn extends ProtoMessage {
+final class RagVectorDbConfig_RagManagedDb_Knn extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagVectorDbConfig.RagManagedDb.KNN';
 
@@ -92200,7 +92357,7 @@ final class RagVectorDbConfig_RagManagedDb_Knn extends ProtoMessage {
 /// facilitate faster searches. As a tradeoff, it requires longer indexing
 /// time and manual triggering of index rebuild via the ImportRagFiles and
 /// UpdateRagCorpus API.
-final class RagVectorDbConfig_RagManagedDb_Ann extends ProtoMessage {
+final class RagVectorDbConfig_RagManagedDb_Ann extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagVectorDbConfig.RagManagedDb.ANN';
 
@@ -92253,7 +92410,7 @@ final class RagVectorDbConfig_RagManagedDb_Ann extends ProtoMessage {
 }
 
 /// The config for the Weaviate.
-final class RagVectorDbConfig_Weaviate extends ProtoMessage {
+final class RagVectorDbConfig_Weaviate extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagVectorDbConfig.Weaviate';
 
@@ -92295,7 +92452,7 @@ final class RagVectorDbConfig_Weaviate extends ProtoMessage {
 }
 
 /// The config for the Pinecone.
-final class RagVectorDbConfig_Pinecone extends ProtoMessage {
+final class RagVectorDbConfig_Pinecone extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagVectorDbConfig.Pinecone';
 
@@ -92322,7 +92479,7 @@ final class RagVectorDbConfig_Pinecone extends ProtoMessage {
 }
 
 /// The config for the Vertex Feature Store.
-final class RagVectorDbConfig_VertexFeatureStore extends ProtoMessage {
+final class RagVectorDbConfig_VertexFeatureStore extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagVectorDbConfig.VertexFeatureStore';
 
@@ -92361,7 +92518,7 @@ final class RagVectorDbConfig_VertexFeatureStore extends ProtoMessage {
 }
 
 /// The config for the Vertex Vector Search.
-final class RagVectorDbConfig_VertexVectorSearch extends ProtoMessage {
+final class RagVectorDbConfig_VertexVectorSearch extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagVectorDbConfig.VertexVectorSearch';
 
@@ -92406,7 +92563,7 @@ final class RagVectorDbConfig_VertexVectorSearch extends ProtoMessage {
 }
 
 /// RagFile status.
-final class FileStatus extends ProtoMessage {
+final class FileStatus extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.FileStatus';
 
@@ -92444,7 +92601,7 @@ final class FileStatus extends ProtoMessage {
 }
 
 /// RagFile state.
-final class FileStatus_State extends ProtoEnum {
+final class FileStatus_State extends protobuf.ProtoEnum {
   /// RagFile state is unspecified.
   static const stateUnspecified = FileStatus_State('STATE_UNSPECIFIED');
 
@@ -92464,7 +92621,7 @@ final class FileStatus_State extends ProtoEnum {
 }
 
 /// Config for the Vertex AI Search.
-final class VertexAiSearchConfig extends ProtoMessage {
+final class VertexAiSearchConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.VertexAiSearchConfig';
 
@@ -92495,7 +92652,7 @@ final class VertexAiSearchConfig extends ProtoMessage {
 }
 
 /// RagCorpus status.
-final class CorpusStatus extends ProtoMessage {
+final class CorpusStatus extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CorpusStatus';
 
@@ -92533,7 +92690,7 @@ final class CorpusStatus extends ProtoMessage {
 }
 
 /// RagCorpus life state.
-final class CorpusStatus_State extends ProtoEnum {
+final class CorpusStatus_State extends protobuf.ProtoEnum {
   /// This state is not supposed to happen.
   static const unknown = CorpusStatus_State('UNKNOWN');
 
@@ -92557,7 +92714,7 @@ final class CorpusStatus_State extends ProtoEnum {
 
 /// A RagCorpus is a RagFile container and a project can have multiple
 /// RagCorpora.
-final class RagCorpus extends ProtoMessage {
+final class RagCorpus extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagCorpus';
 
@@ -92690,7 +92847,7 @@ final class RagCorpus extends ProtoMessage {
 }
 
 /// The config for the corpus type of the RagCorpus.
-final class RagCorpus_CorpusTypeConfig extends ProtoMessage {
+final class RagCorpus_CorpusTypeConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagCorpus.CorpusTypeConfig';
 
@@ -92729,7 +92886,8 @@ final class RagCorpus_CorpusTypeConfig extends ProtoMessage {
 }
 
 /// Config for the document corpus.
-final class RagCorpus_CorpusTypeConfig_DocumentCorpus extends ProtoMessage {
+final class RagCorpus_CorpusTypeConfig_DocumentCorpus
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagCorpus.CorpusTypeConfig.DocumentCorpus';
 
@@ -92751,7 +92909,8 @@ final class RagCorpus_CorpusTypeConfig_DocumentCorpus extends ProtoMessage {
 }
 
 /// Config for the memory corpus.
-final class RagCorpus_CorpusTypeConfig_MemoryCorpus extends ProtoMessage {
+final class RagCorpus_CorpusTypeConfig_MemoryCorpus
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagCorpus.CorpusTypeConfig.MemoryCorpus';
 
@@ -92782,7 +92941,7 @@ final class RagCorpus_CorpusTypeConfig_MemoryCorpus extends ProtoMessage {
 }
 
 /// A RagFile contains user data for chunking, embedding and indexing.
-final class RagFile extends ProtoMessage {
+final class RagFile extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagFile';
 
@@ -92926,7 +93085,7 @@ final class RagFile extends ProtoMessage {
 }
 
 /// The type of the RagFile.
-final class RagFile_RagFileType extends ProtoEnum {
+final class RagFile_RagFileType extends protobuf.ProtoEnum {
   /// RagFile type is unspecified.
   static const ragFileTypeUnspecified = RagFile_RagFileType(
     'RAG_FILE_TYPE_UNSPECIFIED',
@@ -92949,7 +93108,7 @@ final class RagFile_RagFileType extends ProtoEnum {
 
 /// A RagChunk includes the content of a chunk of a RagFile, and associated
 /// metadata.
-final class RagChunk extends ProtoMessage {
+final class RagChunk extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagChunk';
 
@@ -92984,7 +93143,7 @@ final class RagChunk extends ProtoMessage {
 }
 
 /// Represents where the chunk starts and ends in the document.
-final class RagChunk_PageSpan extends ProtoMessage {
+final class RagChunk_PageSpan extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagChunk.PageSpan';
 
@@ -93023,7 +93182,7 @@ final class RagChunk_PageSpan extends ProtoMessage {
 }
 
 /// Specifies the size and overlap of chunks for RagFiles.
-final class RagFileChunkingConfig extends ProtoMessage {
+final class RagFileChunkingConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagFileChunkingConfig';
 
@@ -93074,7 +93233,8 @@ final class RagFileChunkingConfig extends ProtoMessage {
 }
 
 /// Specifies the fixed length chunking config.
-final class RagFileChunkingConfig_FixedLengthChunking extends ProtoMessage {
+final class RagFileChunkingConfig_FixedLengthChunking
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagFileChunkingConfig.FixedLengthChunking';
 
@@ -93115,7 +93275,7 @@ final class RagFileChunkingConfig_FixedLengthChunking extends ProtoMessage {
 }
 
 /// Specifies the transformation config for RagFiles.
-final class RagFileTransformationConfig extends ProtoMessage {
+final class RagFileTransformationConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagFileTransformationConfig';
 
@@ -93147,7 +93307,7 @@ final class RagFileTransformationConfig extends ProtoMessage {
 }
 
 /// Specifies the parsing config for RagFiles.
-final class RagFileParsingConfig extends ProtoMessage {
+final class RagFileParsingConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagFileParsingConfig';
 
@@ -93210,7 +93370,7 @@ final class RagFileParsingConfig extends ProtoMessage {
 }
 
 /// Specifies the advanced parsing for RagFiles.
-final class RagFileParsingConfig_AdvancedParser extends ProtoMessage {
+final class RagFileParsingConfig_AdvancedParser extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagFileParsingConfig.AdvancedParser';
 
@@ -93247,7 +93407,7 @@ final class RagFileParsingConfig_AdvancedParser extends ProtoMessage {
 }
 
 /// Document AI Layout Parser config.
-final class RagFileParsingConfig_LayoutParser extends ProtoMessage {
+final class RagFileParsingConfig_LayoutParser extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagFileParsingConfig.LayoutParser';
 
@@ -93316,7 +93476,7 @@ final class RagFileParsingConfig_LayoutParser extends ProtoMessage {
 }
 
 /// Specifies the LLM parsing for RagFiles.
-final class RagFileParsingConfig_LlmParser extends ProtoMessage {
+final class RagFileParsingConfig_LlmParser extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagFileParsingConfig.LlmParser';
 
@@ -93390,7 +93550,7 @@ final class RagFileParsingConfig_LlmParser extends ProtoMessage {
 }
 
 /// Metadata config for RagFile.
-final class RagFileMetadataConfig extends ProtoMessage {
+final class RagFileMetadataConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagFileMetadataConfig';
 
@@ -93489,7 +93649,7 @@ final class RagFileMetadataConfig extends ProtoMessage {
 }
 
 /// Config for uploading RagFile.
-final class UploadRagFileConfig extends ProtoMessage {
+final class UploadRagFileConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UploadRagFileConfig';
 
@@ -93555,7 +93715,7 @@ final class UploadRagFileConfig extends ProtoMessage {
 }
 
 /// Config for importing RagFiles.
-final class ImportRagFilesConfig extends ProtoMessage {
+final class ImportRagFilesConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ImportRagFilesConfig';
 
@@ -93759,7 +93919,7 @@ final class ImportRagFilesConfig extends ProtoMessage {
 }
 
 /// Configuration message for RagManagedDb used by RagEngine.
-final class RagManagedDbConfig extends ProtoMessage {
+final class RagManagedDbConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagManagedDbConfig';
 
@@ -93817,7 +93977,7 @@ final class RagManagedDbConfig extends ProtoMessage {
 /// Enterprise tier offers production grade performance along with
 /// autoscaling functionality. It is suitable for customers with large
 /// amounts of data or performance sensitive workloads.
-final class RagManagedDbConfig_Enterprise extends ProtoMessage {
+final class RagManagedDbConfig_Enterprise extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagManagedDbConfig.Enterprise';
 
@@ -93839,7 +93999,7 @@ final class RagManagedDbConfig_Enterprise extends ProtoMessage {
 /// Scaled tier offers production grade performance along with
 /// autoscaling functionality. It is suitable for customers with large
 /// amounts of data or performance sensitive workloads.
-final class RagManagedDbConfig_Scaled extends ProtoMessage {
+final class RagManagedDbConfig_Scaled extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagManagedDbConfig.Scaled';
 
@@ -93866,7 +94026,7 @@ final class RagManagedDbConfig_Scaled extends ProtoMessage {
 /// * Only using RAG Engine with external vector DBs.
 ///
 /// NOTE: This is the default tier if not explicitly chosen.
-final class RagManagedDbConfig_Basic extends ProtoMessage {
+final class RagManagedDbConfig_Basic extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagManagedDbConfig.Basic';
 
@@ -93891,7 +94051,7 @@ final class RagManagedDbConfig_Basic extends ProtoMessage {
 /// NOTE: Once deleted the data cannot be recovered. To start using
 /// RAG Engine again, you will need to update the tier by calling the
 /// UpdateRagEngineConfig API.
-final class RagManagedDbConfig_Unprovisioned extends ProtoMessage {
+final class RagManagedDbConfig_Unprovisioned extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagManagedDbConfig.Unprovisioned';
 
@@ -93911,7 +94071,7 @@ final class RagManagedDbConfig_Unprovisioned extends ProtoMessage {
 }
 
 /// Config for RagEngine.
-final class RagEngineConfig extends ProtoMessage {
+final class RagEngineConfig extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagEngineConfig';
 
@@ -93954,7 +94114,7 @@ final class RagEngineConfig extends ProtoMessage {
 
 /// Request message for
 /// `VertexRagDataService.CreateRagCorpus`.
-final class CreateRagCorpusRequest extends ProtoMessage {
+final class CreateRagCorpusRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateRagCorpusRequest';
 
@@ -93989,7 +94149,7 @@ final class CreateRagCorpusRequest extends ProtoMessage {
 
 /// Request message for
 /// `VertexRagDataService.GetRagCorpus`
-final class GetRagCorpusRequest extends ProtoMessage {
+final class GetRagCorpusRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetRagCorpusRequest';
 
@@ -94018,7 +94178,7 @@ final class GetRagCorpusRequest extends ProtoMessage {
 
 /// Request message for
 /// `VertexRagDataService.ListRagCorpora`.
-final class ListRagCorporaRequest extends ProtoMessage {
+final class ListRagCorporaRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListRagCorporaRequest';
 
@@ -94070,7 +94230,7 @@ final class ListRagCorporaRequest extends ProtoMessage {
 
 /// Response message for
 /// `VertexRagDataService.ListRagCorpora`.
-final class ListRagCorporaResponse extends ProtoMessage {
+final class ListRagCorporaResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListRagCorporaResponse';
 
@@ -94112,7 +94272,7 @@ final class ListRagCorporaResponse extends ProtoMessage {
 
 /// Request message for
 /// `VertexRagDataService.DeleteRagCorpus`.
-final class DeleteRagCorpusRequest extends ProtoMessage {
+final class DeleteRagCorpusRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteRagCorpusRequest';
 
@@ -94150,7 +94310,7 @@ final class DeleteRagCorpusRequest extends ProtoMessage {
 
 /// Request message for
 /// `VertexRagDataService.UploadRagFile`.
-final class UploadRagFileRequest extends ProtoMessage {
+final class UploadRagFileRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UploadRagFileRequest';
 
@@ -94202,7 +94362,7 @@ final class UploadRagFileRequest extends ProtoMessage {
 
 /// Response message for
 /// `VertexRagDataService.UploadRagFile`.
-final class UploadRagFileResponse extends ProtoMessage {
+final class UploadRagFileResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UploadRagFileResponse';
 
@@ -94235,7 +94395,7 @@ final class UploadRagFileResponse extends ProtoMessage {
 
 /// Request message for
 /// `VertexRagDataService.ImportRagFiles`.
-final class ImportRagFilesRequest extends ProtoMessage {
+final class ImportRagFilesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ImportRagFilesRequest';
 
@@ -94280,7 +94440,7 @@ final class ImportRagFilesRequest extends ProtoMessage {
 
 /// Response message for
 /// `VertexRagDataService.ImportRagFiles`.
-final class ImportRagFilesResponse extends ProtoMessage {
+final class ImportRagFilesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ImportRagFilesResponse';
 
@@ -94354,7 +94514,7 @@ final class ImportRagFilesResponse extends ProtoMessage {
 
 /// Request message for
 /// `VertexRagDataService.GetRagFile`
-final class GetRagFileRequest extends ProtoMessage {
+final class GetRagFileRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetRagFileRequest';
 
@@ -94383,7 +94543,7 @@ final class GetRagFileRequest extends ProtoMessage {
 
 /// Request message for
 /// `VertexRagDataService.ListRagFiles`.
-final class ListRagFilesRequest extends ProtoMessage {
+final class ListRagFilesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListRagFilesRequest';
 
@@ -94436,7 +94596,7 @@ final class ListRagFilesRequest extends ProtoMessage {
 
 /// Response message for
 /// `VertexRagDataService.ListRagFiles`.
-final class ListRagFilesResponse extends ProtoMessage {
+final class ListRagFilesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListRagFilesResponse';
 
@@ -94478,7 +94638,7 @@ final class ListRagFilesResponse extends ProtoMessage {
 
 /// Request message for
 /// `VertexRagDataService.DeleteRagFile`.
-final class DeleteRagFileRequest extends ProtoMessage {
+final class DeleteRagFileRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteRagFileRequest';
 
@@ -94518,7 +94678,7 @@ final class DeleteRagFileRequest extends ProtoMessage {
 
 /// Runtime operation information for
 /// `VertexRagDataService.CreateRagCorpus`.
-final class CreateRagCorpusOperationMetadata extends ProtoMessage {
+final class CreateRagCorpusOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateRagCorpusOperationMetadata';
 
@@ -94550,7 +94710,7 @@ final class CreateRagCorpusOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `VertexRagDataService.GetRagEngineConfig`
-final class GetRagEngineConfigRequest extends ProtoMessage {
+final class GetRagEngineConfigRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetRagEngineConfigRequest';
 
@@ -94579,7 +94739,7 @@ final class GetRagEngineConfigRequest extends ProtoMessage {
 
 /// Request message for
 /// `VertexRagDataService.UpdateRagCorpus`.
-final class UpdateRagCorpusRequest extends ProtoMessage {
+final class UpdateRagCorpusRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateRagCorpusRequest';
 
@@ -94605,7 +94765,7 @@ final class UpdateRagCorpusRequest extends ProtoMessage {
 
 /// Runtime operation information for
 /// `VertexRagDataService.UpdateRagCorpus`.
-final class UpdateRagCorpusOperationMetadata extends ProtoMessage {
+final class UpdateRagCorpusOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateRagCorpusOperationMetadata';
 
@@ -94637,7 +94797,7 @@ final class UpdateRagCorpusOperationMetadata extends ProtoMessage {
 
 /// Runtime operation information for
 /// `VertexRagDataService.ImportRagFiles`.
-final class ImportRagFilesOperationMetadata extends ProtoMessage {
+final class ImportRagFilesOperationMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ImportRagFilesOperationMetadata';
 
@@ -94700,7 +94860,7 @@ final class ImportRagFilesOperationMetadata extends ProtoMessage {
 
 /// Request message for
 /// `VertexRagDataService.UpdateRagEngineConfig`.
-final class UpdateRagEngineConfigRequest extends ProtoMessage {
+final class UpdateRagEngineConfigRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateRagEngineConfigRequest';
 
@@ -94733,7 +94893,8 @@ final class UpdateRagEngineConfigRequest extends ProtoMessage {
 
 /// Runtime operation information for
 /// `VertexRagDataService.UpdateRagEngineConfig`.
-final class UpdateRagEngineConfigOperationMetadata extends ProtoMessage {
+final class UpdateRagEngineConfigOperationMetadata
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.UpdateRagEngineConfigOperationMetadata';
 
@@ -94766,7 +94927,7 @@ final class UpdateRagEngineConfigOperationMetadata extends ProtoMessage {
 }
 
 /// A query to retrieve relevant contexts.
-final class RagQuery extends ProtoMessage {
+final class RagQuery extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagQuery';
 
@@ -94823,7 +94984,7 @@ final class RagQuery extends ProtoMessage {
 }
 
 /// Configurations for hybrid search results ranking.
-final class RagQuery_Ranking extends ProtoMessage {
+final class RagQuery_Ranking extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagQuery.Ranking';
 
@@ -94853,7 +95014,7 @@ final class RagQuery_Ranking extends ProtoMessage {
 
 /// Request message for
 /// `VertexRagService.RetrieveContexts`.
-final class RetrieveContextsRequest extends ProtoMessage {
+final class RetrieveContextsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RetrieveContextsRequest';
 
@@ -94903,7 +95064,8 @@ final class RetrieveContextsRequest extends ProtoMessage {
 }
 
 /// The data source for Vertex RagStore.
-final class RetrieveContextsRequest_VertexRagStore extends ProtoMessage {
+final class RetrieveContextsRequest_VertexRagStore
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RetrieveContextsRequest.VertexRagStore';
 
@@ -94962,7 +95124,7 @@ final class RetrieveContextsRequest_VertexRagStore extends ProtoMessage {
 
 /// The definition of the Rag resource.
 final class RetrieveContextsRequest_VertexRagStore_RagResource
-    extends ProtoMessage {
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RetrieveContextsRequest.VertexRagStore.RagResource';
 
@@ -95005,7 +95167,7 @@ final class RetrieveContextsRequest_VertexRagStore_RagResource
 }
 
 /// Relevant contexts for one query.
-final class RagContexts extends ProtoMessage {
+final class RagContexts extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagContexts';
 
@@ -95033,7 +95195,7 @@ final class RagContexts extends ProtoMessage {
 }
 
 /// A context of the query.
-final class RagContexts_Context extends ProtoMessage {
+final class RagContexts_Context extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RagContexts.Context';
 
@@ -95121,7 +95283,7 @@ final class RagContexts_Context extends ProtoMessage {
 
 /// Response message for
 /// `VertexRagService.RetrieveContexts`.
-final class RetrieveContextsResponse extends ProtoMessage {
+final class RetrieveContextsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.RetrieveContextsResponse';
 
@@ -95146,7 +95308,7 @@ final class RetrieveContextsResponse extends ProtoMessage {
 }
 
 /// Request message for AugmentPrompt.
-final class AugmentPromptRequest extends ProtoMessage {
+final class AugmentPromptRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AugmentPromptRequest';
 
@@ -95199,7 +95361,7 @@ final class AugmentPromptRequest extends ProtoMessage {
 }
 
 /// Metadata of the backend deployed model.
-final class AugmentPromptRequest_Model extends ProtoMessage {
+final class AugmentPromptRequest_Model extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AugmentPromptRequest.Model';
 
@@ -95239,7 +95401,7 @@ final class AugmentPromptRequest_Model extends ProtoMessage {
 }
 
 /// Response message for AugmentPrompt.
-final class AugmentPromptResponse extends ProtoMessage {
+final class AugmentPromptResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AugmentPromptResponse';
 
@@ -95276,7 +95438,7 @@ final class AugmentPromptResponse extends ProtoMessage {
 }
 
 /// Request message for CorroborateContent.
-final class CorroborateContentRequest extends ProtoMessage {
+final class CorroborateContentRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CorroborateContentRequest';
 
@@ -95335,7 +95497,7 @@ final class CorroborateContentRequest extends ProtoMessage {
 }
 
 /// Parameters that can be overrided per request.
-final class CorroborateContentRequest_Parameters extends ProtoMessage {
+final class CorroborateContentRequest_Parameters extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CorroborateContentRequest.Parameters';
 
@@ -95372,7 +95534,7 @@ final class CorroborateContentRequest_Parameters extends ProtoMessage {
 }
 
 /// Response message for CorroborateContent.
-final class CorroborateContentResponse extends ProtoMessage {
+final class CorroborateContentResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CorroborateContentResponse';
 
@@ -95413,7 +95575,7 @@ final class CorroborateContentResponse extends ProtoMessage {
 }
 
 /// The fact used in grounding.
-final class Fact extends ProtoMessage {
+final class Fact extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Fact';
 
@@ -95496,7 +95658,7 @@ final class Fact extends ProtoMessage {
 }
 
 /// Claim that is extracted from the input text and facts that support it.
-final class Claim extends ProtoMessage {
+final class Claim extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.Claim';
 
@@ -95547,7 +95709,7 @@ final class Claim extends ProtoMessage {
 
 /// Request message for
 /// `VizierService.GetStudy`.
-final class GetStudyRequest extends ProtoMessage {
+final class GetStudyRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetStudyRequest';
 
@@ -95575,7 +95737,7 @@ final class GetStudyRequest extends ProtoMessage {
 
 /// Request message for
 /// `VizierService.CreateStudy`.
-final class CreateStudyRequest extends ProtoMessage {
+final class CreateStudyRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateStudyRequest';
 
@@ -95610,7 +95772,7 @@ final class CreateStudyRequest extends ProtoMessage {
 
 /// Request message for
 /// `VizierService.ListStudies`.
-final class ListStudiesRequest extends ProtoMessage {
+final class ListStudiesRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListStudiesRequest';
 
@@ -95659,7 +95821,7 @@ final class ListStudiesRequest extends ProtoMessage {
 
 /// Response message for
 /// `VizierService.ListStudies`.
-final class ListStudiesResponse extends ProtoMessage {
+final class ListStudiesResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListStudiesResponse';
 
@@ -95700,7 +95862,7 @@ final class ListStudiesResponse extends ProtoMessage {
 
 /// Request message for
 /// `VizierService.DeleteStudy`.
-final class DeleteStudyRequest extends ProtoMessage {
+final class DeleteStudyRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteStudyRequest';
 
@@ -95728,7 +95890,7 @@ final class DeleteStudyRequest extends ProtoMessage {
 
 /// Request message for
 /// `VizierService.LookupStudy`.
-final class LookupStudyRequest extends ProtoMessage {
+final class LookupStudyRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.LookupStudyRequest';
 
@@ -95769,7 +95931,7 @@ final class LookupStudyRequest extends ProtoMessage {
 
 /// Request message for
 /// `VizierService.SuggestTrials`.
-final class SuggestTrialsRequest extends ProtoMessage {
+final class SuggestTrialsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SuggestTrialsRequest';
 
@@ -95864,7 +96026,7 @@ final class SuggestTrialsRequest extends ProtoMessage {
 
 /// Response message for
 /// `VizierService.SuggestTrials`.
-final class SuggestTrialsResponse extends ProtoMessage {
+final class SuggestTrialsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SuggestTrialsResponse';
 
@@ -95916,7 +96078,7 @@ final class SuggestTrialsResponse extends ProtoMessage {
 }
 
 /// Details of operations that perform Trials suggestion.
-final class SuggestTrialsMetadata extends ProtoMessage {
+final class SuggestTrialsMetadata extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.SuggestTrialsMetadata';
 
@@ -95960,7 +96122,7 @@ final class SuggestTrialsMetadata extends ProtoMessage {
 
 /// Request message for
 /// `VizierService.CreateTrial`.
-final class CreateTrialRequest extends ProtoMessage {
+final class CreateTrialRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CreateTrialRequest';
 
@@ -95995,7 +96157,7 @@ final class CreateTrialRequest extends ProtoMessage {
 
 /// Request message for
 /// `VizierService.GetTrial`.
-final class GetTrialRequest extends ProtoMessage {
+final class GetTrialRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GetTrialRequest';
 
@@ -96024,7 +96186,7 @@ final class GetTrialRequest extends ProtoMessage {
 
 /// Request message for
 /// `VizierService.ListTrials`.
-final class ListTrialsRequest extends ProtoMessage {
+final class ListTrialsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListTrialsRequest';
 
@@ -96073,7 +96235,7 @@ final class ListTrialsRequest extends ProtoMessage {
 
 /// Response message for
 /// `VizierService.ListTrials`.
-final class ListTrialsResponse extends ProtoMessage {
+final class ListTrialsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListTrialsResponse';
 
@@ -96114,7 +96276,7 @@ final class ListTrialsResponse extends ProtoMessage {
 
 /// Request message for
 /// `VizierService.AddTrialMeasurement`.
-final class AddTrialMeasurementRequest extends ProtoMessage {
+final class AddTrialMeasurementRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.AddTrialMeasurementRequest';
 
@@ -96153,7 +96315,7 @@ final class AddTrialMeasurementRequest extends ProtoMessage {
 
 /// Request message for
 /// `VizierService.CompleteTrial`.
-final class CompleteTrialRequest extends ProtoMessage {
+final class CompleteTrialRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CompleteTrialRequest';
 
@@ -96215,7 +96377,7 @@ final class CompleteTrialRequest extends ProtoMessage {
 
 /// Request message for
 /// `VizierService.DeleteTrial`.
-final class DeleteTrialRequest extends ProtoMessage {
+final class DeleteTrialRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.DeleteTrialRequest';
 
@@ -96244,7 +96406,7 @@ final class DeleteTrialRequest extends ProtoMessage {
 
 /// Request message for
 /// `VizierService.CheckTrialEarlyStoppingState`.
-final class CheckTrialEarlyStoppingStateRequest extends ProtoMessage {
+final class CheckTrialEarlyStoppingStateRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CheckTrialEarlyStoppingStateRequest';
 
@@ -96276,7 +96438,7 @@ final class CheckTrialEarlyStoppingStateRequest extends ProtoMessage {
 
 /// Response message for
 /// `VizierService.CheckTrialEarlyStoppingState`.
-final class CheckTrialEarlyStoppingStateResponse extends ProtoMessage {
+final class CheckTrialEarlyStoppingStateResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CheckTrialEarlyStoppingStateResponse';
 
@@ -96309,7 +96471,8 @@ final class CheckTrialEarlyStoppingStateResponse extends ProtoMessage {
 /// This message will be placed in the metadata field of a
 /// google.longrunning.Operation associated with a CheckTrialEarlyStoppingState
 /// request.
-final class CheckTrialEarlyStoppingStateMetatdata extends ProtoMessage {
+final class CheckTrialEarlyStoppingStateMetatdata
+    extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.CheckTrialEarlyStoppingStateMetatdata';
 
@@ -96362,7 +96525,7 @@ final class CheckTrialEarlyStoppingStateMetatdata extends ProtoMessage {
 
 /// Request message for
 /// `VizierService.StopTrial`.
-final class StopTrialRequest extends ProtoMessage {
+final class StopTrialRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.StopTrialRequest';
 
@@ -96391,7 +96554,7 @@ final class StopTrialRequest extends ProtoMessage {
 
 /// Request message for
 /// `VizierService.ListOptimalTrials`.
-final class ListOptimalTrialsRequest extends ProtoMessage {
+final class ListOptimalTrialsRequest extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListOptimalTrialsRequest';
 
@@ -96418,7 +96581,7 @@ final class ListOptimalTrialsRequest extends ProtoMessage {
 
 /// Response message for
 /// `VizierService.ListOptimalTrials`.
-final class ListOptimalTrialsResponse extends ProtoMessage {
+final class ListOptimalTrialsResponse extends protobuf.ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.ListOptimalTrialsResponse';
 
@@ -96448,7 +96611,7 @@ final class ListOptimalTrialsResponse extends ProtoMessage {
 }
 
 /// Represents a hardware accelerator type.
-final class AcceleratorType extends ProtoEnum {
+final class AcceleratorType extends protobuf.ProtoEnum {
   /// Unspecified accelerator type, which means no accelerator.
   static const acceleratorTypeUnspecified = AcceleratorType(
     'ACCELERATOR_TYPE_UNSPECIFIED',
@@ -96518,7 +96681,7 @@ final class AcceleratorType extends ProtoEnum {
 }
 
 /// Harm categories that will block the content.
-final class HarmCategory extends ProtoEnum {
+final class HarmCategory extends protobuf.ProtoEnum {
   /// The harm category is unspecified.
   static const harmCategoryUnspecified = HarmCategory(
     'HARM_CATEGORY_UNSPECIFIED',
@@ -96562,7 +96725,7 @@ final class HarmCategory extends ProtoEnum {
 }
 
 /// Content Part modality
-final class Modality extends ProtoEnum {
+final class Modality extends protobuf.ProtoEnum {
   /// Unspecified modality.
   static const modalityUnspecified = Modality('MODALITY_UNSPECIFIED');
 
@@ -96590,7 +96753,7 @@ final class Modality extends ProtoEnum {
 }
 
 /// Stage field indicating the current progress of a deployment.
-final class DeploymentStage extends ProtoEnum {
+final class DeploymentStage extends protobuf.ProtoEnum {
   /// Default value. This value is unused.
   static const deploymentStageUnspecified = DeploymentStage(
     'DEPLOYMENT_STAGE_UNSPECIFIED',
@@ -96635,7 +96798,7 @@ final class DeploymentStage extends ProtoEnum {
 }
 
 /// Pairwise prediction autorater preference.
-final class PairwiseChoice extends ProtoEnum {
+final class PairwiseChoice extends protobuf.ProtoEnum {
   /// Unspecified prediction choice.
   static const pairwiseChoiceUnspecified = PairwiseChoice(
     'PAIRWISE_CHOICE_UNSPECIFIED',
@@ -96659,7 +96822,7 @@ final class PairwiseChoice extends ProtoEnum {
 }
 
 /// Enum of location an HTTP element can be.
-final class HttpElementLocation extends ProtoEnum {
+final class HttpElementLocation extends protobuf.ProtoEnum {
   static const httpInUnspecified = HttpElementLocation('HTTP_IN_UNSPECIFIED');
 
   /// Element is in the HTTP request query.
@@ -96687,7 +96850,7 @@ final class HttpElementLocation extends ProtoEnum {
 }
 
 /// Type of Auth.
-final class AuthType extends ProtoEnum {
+final class AuthType extends protobuf.ProtoEnum {
   static const authTypeUnspecified = AuthType('AUTH_TYPE_UNSPECIFIED');
 
   /// No Auth.
@@ -96719,7 +96882,7 @@ final class AuthType extends ProtoEnum {
 }
 
 /// Format of the data in the Feature View.
-final class FeatureViewDataFormat extends ProtoEnum {
+final class FeatureViewDataFormat extends protobuf.ProtoEnum {
   /// Not set. Will be treated as the KeyValue format.
   static const featureViewDataFormatUnspecified = FeatureViewDataFormat(
     'FEATURE_VIEW_DATA_FORMAT_UNSPECIFIED',
@@ -96741,7 +96904,7 @@ final class FeatureViewDataFormat extends ProtoEnum {
 }
 
 /// Describes the state of a job.
-final class JobState extends ProtoEnum {
+final class JobState extends protobuf.ProtoEnum {
   /// The job state is unspecified.
   static const jobStateUnspecified = JobState('JOB_STATE_UNSPECIFIED');
 
@@ -96791,7 +96954,7 @@ final class JobState extends ProtoEnum {
 }
 
 /// The Model Monitoring Objective types.
-final class ModelDeploymentMonitoringObjectiveType extends ProtoEnum {
+final class ModelDeploymentMonitoringObjectiveType extends protobuf.ProtoEnum {
   /// Default value, should not be set.
   static const modelDeploymentMonitoringObjectiveTypeUnspecified =
       ModelDeploymentMonitoringObjectiveType(
@@ -96832,7 +96995,7 @@ final class ModelDeploymentMonitoringObjectiveType extends ProtoEnum {
 }
 
 /// View enumeration of PublisherModel.
-final class PublisherModelView extends ProtoEnum {
+final class PublisherModelView extends protobuf.ProtoEnum {
   /// The default / unset value. The API will default to the BASIC view.
   static const publisherModelViewUnspecified = PublisherModelView(
     'PUBLISHER_MODEL_VIEW_UNSPECIFIED',
@@ -96863,7 +97026,7 @@ final class PublisherModelView extends ProtoEnum {
 }
 
 /// Represents a notebook runtime type.
-final class NotebookRuntimeType extends ProtoEnum {
+final class NotebookRuntimeType extends protobuf.ProtoEnum {
   /// Unspecified notebook runtime type, NotebookRuntimeType will default to
   /// USER_DEFINED.
   static const notebookRuntimeTypeUnspecified = NotebookRuntimeType(
@@ -96886,7 +97049,7 @@ final class NotebookRuntimeType extends ProtoEnum {
 }
 
 /// Views for Get/List NotebookExecutionJob
-final class NotebookExecutionJobView extends ProtoEnum {
+final class NotebookExecutionJobView extends protobuf.ProtoEnum {
   /// When unspecified, the API defaults to the BASIC view.
   static const notebookExecutionJobViewUnspecified = NotebookExecutionJobView(
     'NOTEBOOK_EXECUTION_JOB_VIEW_UNSPECIFIED',
@@ -96913,7 +97076,7 @@ final class NotebookExecutionJobView extends ProtoEnum {
 
 /// Type contains the list of OpenAPI data types as defined by
 /// https://swagger.io/docs/specification/data-models/data-types/
-final class Type extends ProtoEnum {
+final class Type extends protobuf.ProtoEnum {
   /// Not specified, should not be used.
   static const typeUnspecified = Type('TYPE_UNSPECIFIED');
 
@@ -96949,7 +97112,7 @@ final class Type extends ProtoEnum {
 /// pipeline is set to PIPELINE_FAILURE_POLICY_FAIL_FAST, it will stop scheduling
 /// any new tasks when a task has failed. Any scheduled tasks will continue to
 /// completion.
-final class PipelineFailurePolicy extends ProtoEnum {
+final class PipelineFailurePolicy extends protobuf.ProtoEnum {
   /// Default value, and follows fail slow behavior.
   static const pipelineFailurePolicyUnspecified = PipelineFailurePolicy(
     'PIPELINE_FAILURE_POLICY_UNSPECIFIED',
@@ -96977,7 +97140,7 @@ final class PipelineFailurePolicy extends ProtoEnum {
 }
 
 /// Describes the state of a pipeline.
-final class PipelineState extends ProtoEnum {
+final class PipelineState extends protobuf.ProtoEnum {
   /// The pipeline state is unspecified.
   static const pipelineStateUnspecified = PipelineState(
     'PIPELINE_STATE_UNSPECIFIED',
@@ -97025,7 +97188,7 @@ final class PipelineState extends ProtoEnum {
 }
 
 /// The state of the PSC service automation.
-final class PscautomationState extends ProtoEnum {
+final class PscautomationState extends protobuf.ProtoEnum {
   /// Should not be used.
   static const pscAutomationStateUnspecified = PscautomationState(
     'PSC_AUTOMATION_STATE_UNSPECIFIED',

--- a/generated/google_cloud_api/lib/api.dart
+++ b/generated/google_cloud_api/lib/api.dart
@@ -19,9 +19,8 @@
 /// Lets you define and config your API service.
 library;
 
-import 'package:google_cloud_gax/gax.dart';
-import 'package:google_cloud_gax/src/encoding.dart';
 import 'package:google_cloud_protobuf/protobuf.dart';
+import 'package:google_cloud_protobuf/src/encoding.dart';
 
 /// `Authentication` defines the authentication configuration for API methods
 /// provided by an API service.

--- a/generated/google_cloud_api/pubspec.yaml
+++ b/generated/google_cloud_api/pubspec.yaml
@@ -26,7 +26,6 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_gax: ^0.1.0
   google_cloud_protobuf: ^0.1.0
 
 dev_dependencies:

--- a/generated/google_cloud_common/lib/common.dart
+++ b/generated/google_cloud_common/lib/common.dart
@@ -19,9 +19,8 @@
 /// Additional metadata for operations.
 library;
 
-import 'package:google_cloud_gax/gax.dart';
-import 'package:google_cloud_gax/src/encoding.dart';
 import 'package:google_cloud_protobuf/protobuf.dart';
+import 'package:google_cloud_protobuf/src/encoding.dart';
 
 /// Represents the metadata of the long-running operation.
 final class OperationMetadata extends ProtoMessage {

--- a/generated/google_cloud_common/pubspec.yaml
+++ b/generated/google_cloud_common/pubspec.yaml
@@ -26,7 +26,6 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_gax: ^0.1.0
   google_cloud_protobuf: ^0.1.0
 
 dev_dependencies:

--- a/generated/google_cloud_functions_v2/lib/cloudfunctions.dart
+++ b/generated/google_cloud_functions_v2/lib/cloudfunctions.dart
@@ -20,11 +20,11 @@
 library;
 
 import 'package:google_cloud_gax/gax.dart';
-import 'package:google_cloud_gax/src/encoding.dart';
 import 'package:google_cloud_iam_v1/iam.dart';
 import 'package:google_cloud_location/location.dart';
 import 'package:google_cloud_longrunning/longrunning.dart';
 import 'package:google_cloud_protobuf/protobuf.dart';
+import 'package:google_cloud_protobuf/src/encoding.dart';
 import 'package:google_cloud_rpc/rpc.dart';
 import 'package:google_cloud_type/type.dart';
 import 'package:googleapis_auth/auth_io.dart' as auth;

--- a/generated/google_cloud_iam_v1/lib/iam.dart
+++ b/generated/google_cloud_iam_v1/lib/iam.dart
@@ -20,8 +20,8 @@
 library;
 
 import 'package:google_cloud_gax/gax.dart';
-import 'package:google_cloud_gax/src/encoding.dart';
 import 'package:google_cloud_protobuf/protobuf.dart';
+import 'package:google_cloud_protobuf/src/encoding.dart';
 import 'package:google_cloud_type/type.dart';
 import 'package:googleapis_auth/auth_io.dart' as auth;
 import 'package:http/http.dart' as http;

--- a/generated/google_cloud_language_v2/lib/language.dart
+++ b/generated/google_cloud_language_v2/lib/language.dart
@@ -22,7 +22,8 @@
 library;
 
 import 'package:google_cloud_gax/gax.dart';
-import 'package:google_cloud_gax/src/encoding.dart';
+import 'package:google_cloud_protobuf/protobuf.dart';
+import 'package:google_cloud_protobuf/src/encoding.dart';
 import 'package:googleapis_auth/auth_io.dart' as auth;
 import 'package:http/http.dart' as http;
 

--- a/generated/google_cloud_language_v2/pubspec.yaml
+++ b/generated/google_cloud_language_v2/pubspec.yaml
@@ -27,6 +27,7 @@ resolution: workspace
 
 dependencies:
   google_cloud_gax: ^0.1.0
+  google_cloud_protobuf: ^0.1.0
   googleapis_auth: ^2.0.0
   http: ^1.3.0
 

--- a/generated/google_cloud_location/lib/location.dart
+++ b/generated/google_cloud_location/lib/location.dart
@@ -22,8 +22,8 @@
 library;
 
 import 'package:google_cloud_gax/gax.dart';
-import 'package:google_cloud_gax/src/encoding.dart';
 import 'package:google_cloud_protobuf/protobuf.dart';
+import 'package:google_cloud_protobuf/src/encoding.dart';
 import 'package:googleapis_auth/auth_io.dart' as auth;
 import 'package:http/http.dart' as http;
 

--- a/generated/google_cloud_longrunning/lib/longrunning.dart
+++ b/generated/google_cloud_longrunning/lib/longrunning.dart
@@ -29,8 +29,8 @@
 library;
 
 import 'package:google_cloud_gax/gax.dart';
-import 'package:google_cloud_gax/src/encoding.dart';
 import 'package:google_cloud_protobuf/protobuf.dart';
+import 'package:google_cloud_protobuf/src/encoding.dart';
 import 'package:google_cloud_rpc/rpc.dart';
 import 'package:googleapis_auth/auth_io.dart' as auth;
 import 'package:http/http.dart' as http;

--- a/generated/google_cloud_protobuf/lib/protobuf.dart
+++ b/generated/google_cloud_protobuf/lib/protobuf.dart
@@ -19,9 +19,10 @@
 /// Core Protobuf types used by most services.
 library;
 
-import 'package:google_cloud_gax/gax.dart';
-import 'package:google_cloud_gax/src/encoding.dart';
+import 'dart:convert';
+import 'dart:typed_data';
 
+part 'src/encoding.p.dart';
 part 'src/protobuf.p.dart';
 
 /// Api is a light-weight descriptor for an API Interface.

--- a/generated/google_cloud_protobuf/lib/protobuf.dart
+++ b/generated/google_cloud_protobuf/lib/protobuf.dart
@@ -19,10 +19,9 @@
 /// Core Protobuf types used by most services.
 library;
 
-import 'dart:convert';
-import 'dart:typed_data';
+import 'package:google_cloud_protobuf/protobuf.dart';
+import 'package:google_cloud_protobuf/src/encoding.dart';
 
-part 'src/encoding.p.dart';
 part 'src/protobuf.p.dart';
 
 /// Api is a light-weight descriptor for an API Interface.

--- a/generated/google_cloud_protobuf/lib/src/encoding.dart
+++ b/generated/google_cloud_protobuf/lib/src/encoding.dart
@@ -12,11 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+library;
+
+import 'dart:convert';
+import 'dart:typed_data';
+export 'dart:typed_data' show Uint8List;
+
+import 'package:google_cloud_protobuf/protobuf.dart';
+
 /// Utility methods for JSON encoding and decoding from [ProtoMessage] objects.
 ///
 /// See https://protobuf.dev/programming-guides/json/ for docs on the JSON
 /// encoding of many of these types.
-part of '../protobuf.dart';
 
 /// Decode an `int64` value.
 int? decodeInt64(Object? value) =>

--- a/generated/google_cloud_protobuf/lib/src/encoding.p.dart
+++ b/generated/google_cloud_protobuf/lib/src/encoding.p.dart
@@ -16,11 +16,7 @@
 ///
 /// See https://protobuf.dev/programming-guides/json/ for docs on the JSON
 /// encoding of many of these types.
-library;
-
-import 'dart:convert';
-
-import '../gax.dart';
+part of '../protobuf.dart';
 
 /// Decode an `int64` value.
 int? decodeInt64(Object? value) =>

--- a/generated/google_cloud_protobuf/lib/src/protobuf.p.dart
+++ b/generated/google_cloud_protobuf/lib/src/protobuf.p.dart
@@ -14,6 +14,38 @@
 
 part of '../protobuf.dart';
 
+abstract class JsonEncodable {
+  Object? toJson();
+}
+
+/// The abstract common superclass of all messages.
+abstract class ProtoMessage implements JsonEncodable {
+  /// The fully qualified name of this message, i.e., `google.protobuf.Duration`
+  /// or `google.rpc.ErrorInfo`.
+  final String qualifiedName;
+
+  ProtoMessage(this.qualifiedName);
+}
+
+/// The abstract common superclass of all enum values.
+abstract class ProtoEnum implements JsonEncodable {
+  final String value;
+
+  const ProtoEnum(this.value);
+
+  @override
+  String toJson() => value;
+
+  @override
+  bool operator ==(Object other) =>
+      other is ProtoEnum &&
+      other.runtimeType == runtimeType &&
+      value == other.value;
+
+  @override
+  int get hashCode => value.hashCode;
+}
+
 /// `Any` contains an arbitrary serialized message along with a URL that
 /// describes the type of the serialized message.
 class Any extends ProtoMessage {

--- a/generated/google_cloud_protobuf/lib/src/protobuf.p.dart
+++ b/generated/google_cloud_protobuf/lib/src/protobuf.p.dart
@@ -14,6 +14,10 @@
 
 part of '../protobuf.dart';
 
+/// An abstract class that can return a JSON representation of itself.
+///
+/// Classes that implement [JsonEncodable] will often have a `fromJson()`
+/// constructor.
 abstract class JsonEncodable {
   Object? toJson();
 }

--- a/generated/google_cloud_protobuf/pubspec.yaml
+++ b/generated/google_cloud_protobuf/pubspec.yaml
@@ -25,9 +25,6 @@ environment:
 
 resolution: workspace
 
-dependencies:
-  google_cloud_gax: ^0.1.0
-
 dev_dependencies:
   test: any
   lints: any

--- a/generated/google_cloud_protobuf/test/encoding_test.dart
+++ b/generated/google_cloud_protobuf/test/encoding_test.dart
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:typed_data';
-
 import 'package:google_cloud_protobuf/protobuf.dart';
+import 'package:google_cloud_protobuf/src/encoding.dart';
 import 'package:test/test.dart';
 
 final class TestEnum extends ProtoEnum {

--- a/generated/google_cloud_protobuf/test/encoding_test.dart
+++ b/generated/google_cloud_protobuf/test/encoding_test.dart
@@ -14,9 +14,43 @@
 
 import 'dart:typed_data';
 
-import 'package:google_cloud_gax/src/encoding.dart';
-import 'package:google_cloud_rpc/rpc.dart';
+import 'package:google_cloud_protobuf/protobuf.dart';
 import 'package:test/test.dart';
+
+final class TestEnum extends ProtoEnum {
+  static const one = TestEnum('ONE');
+  static const two = TestEnum('TWO');
+
+  const TestEnum(super.value);
+
+  factory TestEnum.fromJson(String json) => TestEnum(json);
+
+  @override
+  String toString() => 'TestEnum.$value';
+}
+
+final class TestMessage extends ProtoMessage {
+  static const String fullyQualifiedName = 'testMessage';
+
+  final String? message;
+
+  TestMessage({this.message}) : super(fullyQualifiedName);
+
+  factory TestMessage.fromJson(Map<String, dynamic> json) {
+    return TestMessage(message: json['message']);
+  }
+
+  @override
+  Object toJson() {
+    return {if (message != null) 'message': message};
+  }
+
+  @override
+  String toString() {
+    final contents = [if (message != null) 'message=$message'].join(',');
+    return 'TestMessage($contents)';
+  }
+}
 
 void main() {
   test('int64', () {
@@ -45,22 +79,27 @@ void main() {
   });
 
   test('enum', () {
-    final actual = decodeEnum(const Code('NOT_FOUND').toJson(), Code.fromJson);
-    expect(actual!.value, 'NOT_FOUND');
+    final actual = decodeEnum(
+      const TestEnum('ONE').toJson(),
+      TestEnum.fromJson,
+    );
+    expect(actual, TestEnum.one);
   });
 
   test('message', () {
     final actual = decode(
-      Status(code: 200, message: 'OK').toJson() as Map<String, Object?>,
-      Status.fromJson,
+      TestMessage(message: 'Hello World').toJson() as Map<String, Object?>,
+      TestMessage.fromJson,
     );
-    expect(actual!.code, 200);
-    expect(actual.message, 'OK');
+    expect(
+      actual,
+      isA<TestMessage>().having((o) => o.message, 'message', 'Hello World'),
+    );
   });
 
   test('list of enums', () {
-    expect(decodeListEnum(encodeList([Code.notFound]), Code.fromJson), [
-      Code.notFound,
+    expect(decodeListEnum(encodeList([TestEnum.one]), TestEnum.fromJson), [
+      TestEnum.one,
     ]);
   });
 
@@ -82,24 +121,31 @@ void main() {
 
   test('list of messages', () {
     final actual = decodeListMessage(
-      encodeList([Status(code: 200)]),
-      Status.fromJson,
+      encodeList([TestMessage(message: 'Hello World')]),
+      TestMessage.fromJson,
     );
-    expect(actual![0], isA<Status>());
-    expect(actual[0].code, 200);
+    expect(actual!, hasLength(1));
+    expect(
+      actual[0],
+      isA<TestMessage>().having((o) => o.message, 'message', 'Hello World'),
+    );
   });
 
   test('map of enums', () {
-    final actual = decodeMapEnum<String, Code>(
+    final actual = decodeMapEnum<String, TestEnum>(
       encodeMap({
-        'one': Code.aborted,
-        'two': Code.alreadyExists,
-        'three': Code.notFound,
+        'one': TestEnum.one,
+        'two': TestEnum.two,
+        'three': TestEnum.one,
       }),
-      Code.fromJson,
+      TestEnum.fromJson,
     );
+
     expect(actual, isMap);
-    expect(actual!['one'], Code.aborted);
+    expect(actual, hasLength(3));
+    expect(actual, containsPair('one', TestEnum.one));
+    expect(actual, containsPair('two', TestEnum.two));
+    expect(actual, containsPair('three', TestEnum.one));
   });
 
   test('map of bytes', () {
@@ -114,12 +160,29 @@ void main() {
   });
 
   test('map of messages', () {
-    final actual = decodeMapMessage<String, Status>(
-      encodeMap({'one': Status(code: 200), 'two': Status(code: 301)}),
-      Status.fromJson,
+    final actual = decodeMapMessage<String, TestMessage>(
+      encodeMap({
+        'one': TestMessage(message: 'Hello'),
+        'two': TestMessage(message: 'World'),
+      }),
+      TestMessage.fromJson,
     );
     expect(actual, isMap);
-    expect(actual!['one']!.code, 200);
+    expect(actual, hasLength(2));
+    expect(
+      actual,
+      containsPair(
+        'one',
+        isA<TestMessage>().having((o) => o.message, 'message', 'Hello'),
+      ),
+    );
+    expect(
+      actual,
+      containsPair(
+        'two',
+        isA<TestMessage>().having((o) => o.message, 'message', 'World'),
+      ),
+    );
   });
 
   group('bytes', () {

--- a/generated/google_cloud_rpc/lib/rpc.dart
+++ b/generated/google_cloud_rpc/lib/rpc.dart
@@ -19,8 +19,8 @@
 /// Defines RPC types.
 library;
 
-import 'package:google_cloud_gax/gax.dart';
 import 'package:google_cloud_protobuf/protobuf.dart';
+import 'package:google_cloud_protobuf/src/encoding.dart';
 
 part 'src/rpc.p.dart';
 

--- a/generated/google_cloud_rpc/lib/rpc.dart
+++ b/generated/google_cloud_rpc/lib/rpc.dart
@@ -20,7 +20,6 @@
 library;
 
 import 'package:google_cloud_gax/gax.dart';
-import 'package:google_cloud_gax/src/encoding.dart';
 import 'package:google_cloud_protobuf/protobuf.dart';
 
 part 'src/rpc.p.dart';

--- a/generated/google_cloud_rpc/pubspec.yaml
+++ b/generated/google_cloud_rpc/pubspec.yaml
@@ -26,7 +26,6 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_gax: ^0.1.0
   google_cloud_protobuf: ^0.1.0
 
 dev_dependencies:

--- a/generated/google_cloud_secretmanager_v1/lib/secretmanager.dart
+++ b/generated/google_cloud_secretmanager_v1/lib/secretmanager.dart
@@ -21,10 +21,10 @@
 library;
 
 import 'package:google_cloud_gax/gax.dart';
-import 'package:google_cloud_gax/src/encoding.dart';
 import 'package:google_cloud_iam_v1/iam.dart';
 import 'package:google_cloud_location/location.dart';
 import 'package:google_cloud_protobuf/protobuf.dart';
+import 'package:google_cloud_protobuf/src/encoding.dart';
 import 'package:googleapis_auth/auth_io.dart' as auth;
 import 'package:http/http.dart' as http;
 

--- a/generated/google_cloud_type/lib/type.dart
+++ b/generated/google_cloud_type/lib/type.dart
@@ -19,9 +19,8 @@
 /// Defines common types for Google APIs.
 library;
 
-import 'package:google_cloud_gax/gax.dart';
-import 'package:google_cloud_gax/src/encoding.dart';
 import 'package:google_cloud_protobuf/protobuf.dart';
+import 'package:google_cloud_protobuf/src/encoding.dart';
 
 /// Represents a color in the RGBA color space. This representation is designed
 /// for simplicity of conversion to/from color representations in various

--- a/generated/google_cloud_type/pubspec.yaml
+++ b/generated/google_cloud_type/pubspec.yaml
@@ -26,7 +26,6 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_gax: ^0.1.0
   google_cloud_protobuf: ^0.1.0
 
 dev_dependencies:

--- a/packages/google_cloud_gax/example/main.dart
+++ b/packages/google_cloud_gax/example/main.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'package:google_cloud_gax/gax.dart';
+import 'package:google_cloud_protobuf/protobuf.dart';
 import 'package:googleapis_auth/auth_io.dart';
 
 class AnalysisRequest implements JsonEncodable {

--- a/packages/google_cloud_gax/lib/gax.dart
+++ b/packages/google_cloud_gax/lib/gax.dart
@@ -14,7 +14,7 @@
 
 import 'dart:convert';
 
-import 'package:google_cloud_protobuf/';
+import 'package:google_cloud_protobuf/protobuf.dart';
 import 'package:google_cloud_rpc/rpc.dart';
 import 'package:http/http.dart' as http;
 

--- a/packages/google_cloud_gax/lib/gax.dart
+++ b/packages/google_cloud_gax/lib/gax.dart
@@ -14,6 +14,7 @@
 
 import 'dart:convert';
 
+import 'package:google_cloud_protobuf/';
 import 'package:google_cloud_rpc/rpc.dart';
 import 'package:http/http.dart' as http;
 
@@ -37,38 +38,6 @@ const String _typeJson = 'application/json';
 ///
 /// Classes that implement [JsonEncodable] will often have a `fromJson()`
 /// constructor.
-abstract class JsonEncodable {
-  Object? toJson();
-}
-
-/// The abstract common superclass of all messages.
-abstract class ProtoMessage implements JsonEncodable {
-  /// The fully qualified name of this message, i.e., `google.protobuf.Duration`
-  /// or `google.rpc.ErrorInfo`.
-  final String qualifiedName;
-
-  ProtoMessage(this.qualifiedName);
-}
-
-/// The abstract common superclass of all enum values.
-abstract class ProtoEnum implements JsonEncodable {
-  final String value;
-
-  const ProtoEnum(this.value);
-
-  @override
-  String toJson() => value;
-
-  @override
-  bool operator ==(Object other) =>
-      other is ProtoEnum &&
-      other.runtimeType == runtimeType &&
-      value == other.value;
-
-  @override
-  int get hashCode => value.hashCode;
-}
-
 /// Exception thrown when calling an API through [ServiceClient] fails.
 final class ServiceException implements Exception {
   /// A message describing the cause of the exception.

--- a/packages/google_cloud_gax/lib/gax.dart
+++ b/packages/google_cloud_gax/lib/gax.dart
@@ -34,10 +34,6 @@ final String _clientName = 'gl-dart/$clientDartVersion gax/$gaxVersion';
 const String _contentTypeKey = 'content-type';
 const String _typeJson = 'application/json';
 
-/// An abstract class that can return a JSON representation of itself.
-///
-/// Classes that implement [JsonEncodable] will often have a `fromJson()`
-/// constructor.
 /// Exception thrown when calling an API through [ServiceClient] fails.
 final class ServiceException implements Exception {
   /// A message describing the cause of the exception.

--- a/packages/google_cloud_gax/pubspec.yaml
+++ b/packages/google_cloud_gax/pubspec.yaml
@@ -27,6 +27,7 @@ environment:
 resolution: workspace
 
 dependencies:
+  google_cloud_protobuf: ^0.1.0
   google_cloud_rpc: ^0.1.0
   http: ^1.3.0
 

--- a/packages/google_cloud_gax/test/client_test.dart
+++ b/packages/google_cloud_gax/test/client_test.dart
@@ -15,6 +15,7 @@
 import 'dart:convert';
 
 import 'package:google_cloud_gax/gax.dart';
+import 'package:google_cloud_protobuf/protobuf.dart';
 import 'package:google_cloud_rpc/rpc.dart';
 import 'package:http/http.dart';
 import 'package:http/testing.dart';


### PR DESCRIPTION
Moved:
1. `JsonEncodable`, `ProtoMessage`, `ProtoEnum` to `google_cloud_protobuf/src/protobuf.p.dart`
2. `google_cloud_gax/src/encoding.dart` (and test [tests were updated]) to google_cloud_protobuf/src/encoding.dart`

Added a dependency on `package:google_cloud_protobuf` to `package:google_cloud_gax` to acomodate the move of `JsonEncodable`.

Depends on the code generation in https://github.com/googleapis/librarian/pull/2660