### PR TITLE
fix: ConfigurationException in `fromApiKey`

### DIFF
--- a/.github/workflows/dart_checks.yaml
+++ b/.github/workflows/dart_checks.yaml
@@ -93,6 +93,6 @@ jobs:
       - name: Regenerate existing clients
         # The current head version of sidekick can be generated with:
         # GOPROXY=direct go list -m -u -f '{{.Version}}' github.com/googleapis/librarian@main
-        run: go run github.com/googleapis/librarian/cmd/sidekick@v0.5.1-0.20251027173757-4968d63d3f90 refreshall -project-root .
+        run: go run github.com/googleapis/librarian/cmd/sidekick@v0.5.1-0.20251028230334-0950c1e33936 refreshall -project-root .
       - name: Generated Diff
         run: git diff --exit-code

--- a/.sidekick.toml
+++ b/.sidekick.toml
@@ -40,11 +40,11 @@ issue-tracker-url = "https://github.com/googleapis/google-cloud-dart/issues"
 # Generated packages
 'package:google_cloud_api'         = '^0.1.2'
 'package:google_cloud_iam_v1'      = '^0.1.2'
-'package:google_cloud_protobuf'    = '^0.1.2'
+'package:google_cloud_protobuf'    = '^0.1.0'
 'package:google_cloud_location'    = '^0.1.2'
 'package:google_cloud_longrunning' = '^0.1.2'
-'package:google_cloud_rpc'         = '^0.1.2'
-'package:google_cloud_type'        = '^0.1.2'
+'package:google_cloud_rpc'         = '^0.1.0'
+'package:google_cloud_type'        = '^0.1.0'
 
 # A mapping from protobuf packages to Dart imports.
 'proto:google.api'            = 'package:google_cloud_api/api.dart'

--- a/.sidekick.toml
+++ b/.sidekick.toml
@@ -27,24 +27,24 @@ protobuf-subdir         = "src"
 
 [codec]
 # The default version for Dart packages.
-version = "0.1.1"
+version = "0.1.2"
 
 api-keys-environment-variables = "GOOGLE_API_KEY"
 issue-tracker-url = "https://github.com/googleapis/google-cloud-dart/issues"
 
 # Default package dependency versions.
 'package:googleapis_auth'  = '^2.0.0'
-'package:google_cloud_gax' = '^0.1.0'
+'package:google_cloud_gax' = '^0.1.2'
 'package:http'             = '^1.3.0'
 
 # Generated packages
-'package:google_cloud_api'         = '^0.1.1'
-'package:google_cloud_iam_v1'      = '^0.1.1'
-'package:google_cloud_protobuf'    = '^0.1.1'
-'package:google_cloud_location'    = '^0.1.1'
-'package:google_cloud_longrunning' = '^0.1.1'
-'package:google_cloud_rpc'         = '^0.1.1'
-'package:google_cloud_type'        = '^0.1.1'
+'package:google_cloud_api'         = '^0.1.2'
+'package:google_cloud_iam_v1'      = '^0.1.2'
+'package:google_cloud_protobuf'    = '^0.1.2'
+'package:google_cloud_location'    = '^0.1.2'
+'package:google_cloud_longrunning' = '^0.1.2'
+'package:google_cloud_rpc'         = '^0.1.2'
+'package:google_cloud_type'        = '^0.1.2'
 
 # A mapping from protobuf packages to Dart imports.
 'proto:google.api'            = 'package:google_cloud_api/api.dart'

--- a/generated/google_cloud_ai_generativelanguage_v1beta/lib/generativelanguage.dart
+++ b/generated/google_cloud_ai_generativelanguage_v1beta/lib/generativelanguage.dart
@@ -60,8 +60,9 @@ final class CacheService {
   /// - `GOOGLE_API_KEY`
   /// - `GEMINI_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory CacheService.fromApiKey([String? apiKey]) {
@@ -221,8 +222,9 @@ final class DiscussService {
   /// - `GOOGLE_API_KEY`
   /// - `GEMINI_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory DiscussService.fromApiKey([String? apiKey]) {
@@ -337,8 +339,9 @@ final class FileService {
   /// - `GOOGLE_API_KEY`
   /// - `GEMINI_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory FileService.fromApiKey([String? apiKey]) {
@@ -485,8 +488,9 @@ final class GenerativeService {
   /// - `GOOGLE_API_KEY`
   /// - `GEMINI_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory GenerativeService.fromApiKey([String? apiKey]) {
@@ -668,8 +672,9 @@ final class ModelService {
   /// - `GOOGLE_API_KEY`
   /// - `GEMINI_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory ModelService.fromApiKey([String? apiKey]) {
@@ -871,8 +876,9 @@ final class PermissionService {
   /// - `GOOGLE_API_KEY`
   /// - `GEMINI_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory PermissionService.fromApiKey([String? apiKey]) {
@@ -1038,8 +1044,9 @@ final class PredictionService {
   /// - `GOOGLE_API_KEY`
   /// - `GEMINI_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory PredictionService.fromApiKey([String? apiKey]) {
@@ -1163,8 +1170,9 @@ final class RetrieverService {
   /// - `GOOGLE_API_KEY`
   /// - `GEMINI_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory RetrieverService.fromApiKey([String? apiKey]) {
@@ -1511,8 +1519,9 @@ final class TextService {
   /// - `GOOGLE_API_KEY`
   /// - `GEMINI_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory TextService.fromApiKey([String? apiKey]) {

--- a/generated/google_cloud_ai_generativelanguage_v1beta/pubspec.yaml
+++ b/generated/google_cloud_ai_generativelanguage_v1beta/pubspec.yaml
@@ -28,9 +28,9 @@ resolution: workspace
 dependencies:
   google_cloud_gax: ^0.1.2
   google_cloud_longrunning: ^0.1.2
-  google_cloud_protobuf: ^0.1.2
-  google_cloud_rpc: ^0.1.2
-  google_cloud_type: ^0.1.2
+  google_cloud_protobuf: ^0.1.0
+  google_cloud_rpc: ^0.1.0
+  google_cloud_type: ^0.1.0
   http: ^1.3.0
 
 dev_dependencies:

--- a/generated/google_cloud_ai_generativelanguage_v1beta/pubspec.yaml
+++ b/generated/google_cloud_ai_generativelanguage_v1beta/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: google_cloud_ai_generativelanguage_v1beta
 description: The Google Cloud client library for the Generative Language API.
-version: 0.1.1
+version: 0.1.2
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_ai_generativelanguage_v1beta
 issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 
@@ -26,11 +26,11 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_gax: ^0.1.0
-  google_cloud_longrunning: ^0.1.1
-  google_cloud_protobuf: ^0.1.1
-  google_cloud_rpc: ^0.1.1
-  google_cloud_type: ^0.1.1
+  google_cloud_gax: ^0.1.2
+  google_cloud_longrunning: ^0.1.2
+  google_cloud_protobuf: ^0.1.2
+  google_cloud_rpc: ^0.1.2
+  google_cloud_type: ^0.1.2
   http: ^1.3.0
 
 dev_dependencies:

--- a/generated/google_cloud_aiplatform_v1beta1/lib/aiplatform.dart
+++ b/generated/google_cloud_aiplatform_v1beta1/lib/aiplatform.dart
@@ -54,8 +54,9 @@ final class DatasetService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory DatasetService.fromApiKey([String? apiKey]) {
@@ -696,8 +697,9 @@ final class DeploymentResourcePoolService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory DeploymentResourcePoolService.fromApiKey([String? apiKey]) {
@@ -1028,8 +1030,9 @@ final class EndpointService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory EndpointService.fromApiKey([String? apiKey]) {
@@ -1457,8 +1460,9 @@ final class EvaluationService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory EvaluationService.fromApiKey([String? apiKey]) {
@@ -1682,8 +1686,9 @@ final class ExampleStoreService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory ExampleStoreService.fromApiKey([String? apiKey]) {
@@ -2031,8 +2036,9 @@ final class ExtensionExecutionService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory ExtensionExecutionService.fromApiKey([String? apiKey]) {
@@ -2241,8 +2247,9 @@ final class ExtensionRegistryService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory ExtensionRegistryService.fromApiKey([String? apiKey]) {
@@ -2521,8 +2528,9 @@ final class FeatureOnlineStoreAdminService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory FeatureOnlineStoreAdminService.fromApiKey([String? apiKey]) {
@@ -2979,8 +2987,9 @@ final class FeatureOnlineStoreService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory FeatureOnlineStoreService.fromApiKey([String? apiKey]) {
@@ -3215,8 +3224,9 @@ final class FeatureRegistryService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory FeatureRegistryService.fromApiKey([String? apiKey]) {
@@ -3839,8 +3849,9 @@ final class FeaturestoreOnlineServingService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory FeaturestoreOnlineServingService.fromApiKey([String? apiKey]) {
@@ -4080,8 +4091,9 @@ final class FeaturestoreService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory FeaturestoreService.fromApiKey([String? apiKey]) {
@@ -4805,8 +4817,9 @@ final class GenAiCacheService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory GenAiCacheService.fromApiKey([String? apiKey]) {
@@ -5056,8 +5069,9 @@ final class GenAiTuningService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory GenAiTuningService.fromApiKey([String? apiKey]) {
@@ -5328,8 +5342,9 @@ final class IndexEndpointService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory IndexEndpointService.fromApiKey([String? apiKey]) {
@@ -5692,8 +5707,9 @@ final class IndexService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory IndexService.fromApiKey([String? apiKey]) {
@@ -6025,8 +6041,9 @@ final class JobService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory JobService.fromApiKey([String? apiKey]) {
@@ -6870,8 +6887,9 @@ final class LlmUtilityService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory LlmUtilityService.fromApiKey([String? apiKey]) {
@@ -7066,8 +7084,9 @@ final class MatchService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory MatchService.fromApiKey([String? apiKey]) {
@@ -7281,8 +7300,9 @@ final class MemoryBankService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory MemoryBankService.fromApiKey([String? apiKey]) {
@@ -7604,8 +7624,9 @@ final class MetadataService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory MetadataService.fromApiKey([String? apiKey]) {
@@ -8375,8 +8396,9 @@ final class MigrationService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory MigrationService.fromApiKey([String? apiKey]) {
@@ -8608,8 +8630,9 @@ final class ModelGardenService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory ModelGardenService.fromApiKey([String? apiKey]) {
@@ -8957,8 +8980,9 @@ final class ModelMonitoringService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory ModelMonitoringService.fromApiKey([String? apiKey]) {
@@ -9363,8 +9387,9 @@ final class ModelService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory ModelService.fromApiKey([String? apiKey]) {
@@ -9937,8 +9962,9 @@ final class NotebookService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory NotebookService.fromApiKey([String? apiKey]) {
@@ -10505,8 +10531,9 @@ final class PersistentResourceService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory PersistentResourceService.fromApiKey([String? apiKey]) {
@@ -10831,8 +10858,9 @@ final class PipelineService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory PipelineService.fromApiKey([String? apiKey]) {
@@ -11273,8 +11301,9 @@ final class PredictionService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory PredictionService.fromApiKey([String? apiKey]) {
@@ -11626,8 +11655,9 @@ final class ReasoningEngineExecutionService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory ReasoningEngineExecutionService.fromApiKey([String? apiKey]) {
@@ -11835,8 +11865,9 @@ final class ReasoningEngineService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory ReasoningEngineService.fromApiKey([String? apiKey]) {
@@ -12128,8 +12159,9 @@ final class ScheduleService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory ScheduleService.fromApiKey([String? apiKey]) {
@@ -12425,8 +12457,9 @@ final class SessionService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory SessionService.fromApiKey([String? apiKey]) {
@@ -12732,8 +12765,9 @@ final class SpecialistPoolService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory SpecialistPoolService.fromApiKey([String? apiKey]) {
@@ -13024,8 +13058,9 @@ final class TensorboardService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory TensorboardService.fromApiKey([String? apiKey]) {
@@ -13763,8 +13798,9 @@ final class VertexRagDataService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory VertexRagDataService.fromApiKey([String? apiKey]) {
@@ -14173,8 +14209,9 @@ final class VertexRagService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory VertexRagService.fromApiKey([String? apiKey]) {
@@ -14404,8 +14441,9 @@ final class VizierService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory VizierService.fromApiKey([String? apiKey]) {

--- a/generated/google_cloud_aiplatform_v1beta1/pubspec.yaml
+++ b/generated/google_cloud_aiplatform_v1beta1/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: google_cloud_aiplatform_v1beta1
 description: The Google Cloud client library for the Vertex AI API.
-version: 0.1.1
+version: 0.1.2
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_aiplatform_v1beta1
 issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 
@@ -26,14 +26,14 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_api: ^0.1.1
-  google_cloud_gax: ^0.1.0
-  google_cloud_iam_v1: ^0.1.1
-  google_cloud_location: ^0.1.1
-  google_cloud_longrunning: ^0.1.1
-  google_cloud_protobuf: ^0.1.1
-  google_cloud_rpc: ^0.1.1
-  google_cloud_type: ^0.1.1
+  google_cloud_api: ^0.1.2
+  google_cloud_gax: ^0.1.2
+  google_cloud_iam_v1: ^0.1.2
+  google_cloud_location: ^0.1.2
+  google_cloud_longrunning: ^0.1.2
+  google_cloud_protobuf: ^0.1.2
+  google_cloud_rpc: ^0.1.2
+  google_cloud_type: ^0.1.2
   http: ^1.3.0
 
 dev_dependencies:

--- a/generated/google_cloud_aiplatform_v1beta1/pubspec.yaml
+++ b/generated/google_cloud_aiplatform_v1beta1/pubspec.yaml
@@ -31,9 +31,9 @@ dependencies:
   google_cloud_iam_v1: ^0.1.2
   google_cloud_location: ^0.1.2
   google_cloud_longrunning: ^0.1.2
-  google_cloud_protobuf: ^0.1.2
-  google_cloud_rpc: ^0.1.2
-  google_cloud_type: ^0.1.2
+  google_cloud_protobuf: ^0.1.0
+  google_cloud_rpc: ^0.1.0
+  google_cloud_type: ^0.1.0
   http: ^1.3.0
 
 dev_dependencies:

--- a/generated/google_cloud_api/pubspec.yaml
+++ b/generated/google_cloud_api/pubspec.yaml
@@ -26,7 +26,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_protobuf: ^0.1.2
+  google_cloud_protobuf: ^0.1.0
 
 dev_dependencies:
   lints: any

--- a/generated/google_cloud_api/pubspec.yaml
+++ b/generated/google_cloud_api/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: google_cloud_api
 description: The Google Cloud client library for the Service Config API.
-version: 0.1.1
+version: 0.1.2
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_api
 issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 
@@ -26,7 +26,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_protobuf: ^0.1.1
+  google_cloud_protobuf: ^0.1.2
 
 dev_dependencies:
   lints: any

--- a/generated/google_cloud_common/pubspec.yaml
+++ b/generated/google_cloud_common/pubspec.yaml
@@ -26,7 +26,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_protobuf: ^0.1.2
+  google_cloud_protobuf: ^0.1.0
 
 dev_dependencies:
   lints: any

--- a/generated/google_cloud_common/pubspec.yaml
+++ b/generated/google_cloud_common/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: google_cloud_common
 description: The Google Cloud client library for the Common Operation Metadata type.
-version: 0.1.1
+version: 0.1.2
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_common
 issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 
@@ -26,7 +26,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_protobuf: ^0.1.1
+  google_cloud_protobuf: ^0.1.2
 
 dev_dependencies:
   lints: any

--- a/generated/google_cloud_functions_v2/lib/cloudfunctions.dart
+++ b/generated/google_cloud_functions_v2/lib/cloudfunctions.dart
@@ -57,8 +57,9 @@ final class FunctionService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory FunctionService.fromApiKey([String? apiKey]) {

--- a/generated/google_cloud_functions_v2/pubspec.yaml
+++ b/generated/google_cloud_functions_v2/pubspec.yaml
@@ -30,9 +30,9 @@ dependencies:
   google_cloud_iam_v1: ^0.1.2
   google_cloud_location: ^0.1.2
   google_cloud_longrunning: ^0.1.2
-  google_cloud_protobuf: ^0.1.2
-  google_cloud_rpc: ^0.1.2
-  google_cloud_type: ^0.1.2
+  google_cloud_protobuf: ^0.1.0
+  google_cloud_rpc: ^0.1.0
+  google_cloud_type: ^0.1.0
   http: ^1.3.0
 
 dev_dependencies:

--- a/generated/google_cloud_functions_v2/pubspec.yaml
+++ b/generated/google_cloud_functions_v2/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: google_cloud_functions_v2
 description: The Google Cloud client library for the Cloud Functions API.
-version: 0.1.1
+version: 0.1.2
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_functions_v2
 issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 
@@ -26,13 +26,13 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_gax: ^0.1.0
-  google_cloud_iam_v1: ^0.1.1
-  google_cloud_location: ^0.1.1
-  google_cloud_longrunning: ^0.1.1
-  google_cloud_protobuf: ^0.1.1
-  google_cloud_rpc: ^0.1.1
-  google_cloud_type: ^0.1.1
+  google_cloud_gax: ^0.1.2
+  google_cloud_iam_v1: ^0.1.2
+  google_cloud_location: ^0.1.2
+  google_cloud_longrunning: ^0.1.2
+  google_cloud_protobuf: ^0.1.2
+  google_cloud_rpc: ^0.1.2
+  google_cloud_type: ^0.1.2
   http: ^1.3.0
 
 dev_dependencies:

--- a/generated/google_cloud_iam_v1/lib/iam.dart
+++ b/generated/google_cloud_iam_v1/lib/iam.dart
@@ -72,8 +72,9 @@ final class IAMPolicy {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory IAMPolicy.fromApiKey([String? apiKey]) {

--- a/generated/google_cloud_iam_v1/pubspec.yaml
+++ b/generated/google_cloud_iam_v1/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: google_cloud_iam_v1
 description: The Google Cloud client library for the IAM Meta API.
-version: 0.1.1
+version: 0.1.2
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_iam_v1
 issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 
@@ -26,9 +26,9 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_gax: ^0.1.0
-  google_cloud_protobuf: ^0.1.1
-  google_cloud_type: ^0.1.1
+  google_cloud_gax: ^0.1.2
+  google_cloud_protobuf: ^0.1.2
+  google_cloud_type: ^0.1.2
   http: ^1.3.0
 
 dev_dependencies:

--- a/generated/google_cloud_iam_v1/pubspec.yaml
+++ b/generated/google_cloud_iam_v1/pubspec.yaml
@@ -27,8 +27,8 @@ resolution: workspace
 
 dependencies:
   google_cloud_gax: ^0.1.2
-  google_cloud_protobuf: ^0.1.2
-  google_cloud_type: ^0.1.2
+  google_cloud_protobuf: ^0.1.0
+  google_cloud_type: ^0.1.0
   http: ^1.3.0
 
 dev_dependencies:

--- a/generated/google_cloud_language_v2/lib/language.dart
+++ b/generated/google_cloud_language_v2/lib/language.dart
@@ -50,8 +50,9 @@ final class LanguageService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory LanguageService.fromApiKey([String? apiKey]) {

--- a/generated/google_cloud_language_v2/pubspec.yaml
+++ b/generated/google_cloud_language_v2/pubspec.yaml
@@ -27,7 +27,7 @@ resolution: workspace
 
 dependencies:
   google_cloud_gax: ^0.1.2
-  google_cloud_protobuf: ^0.1.2
+  google_cloud_protobuf: ^0.1.0
   http: ^1.3.0
 
 dev_dependencies:

--- a/generated/google_cloud_language_v2/pubspec.yaml
+++ b/generated/google_cloud_language_v2/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: google_cloud_language_v2
 description: The Google Cloud client library for the Cloud Natural Language API.
-version: 0.1.1
+version: 0.1.2
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_language_v2
 issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 
@@ -26,8 +26,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_gax: ^0.1.0
-  google_cloud_protobuf: ^0.1.1
+  google_cloud_gax: ^0.1.2
+  google_cloud_protobuf: ^0.1.2
   http: ^1.3.0
 
 dev_dependencies:

--- a/generated/google_cloud_location/lib/location.dart
+++ b/generated/google_cloud_location/lib/location.dart
@@ -51,8 +51,9 @@ final class Locations {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory Locations.fromApiKey([String? apiKey]) {

--- a/generated/google_cloud_location/pubspec.yaml
+++ b/generated/google_cloud_location/pubspec.yaml
@@ -27,7 +27,7 @@ resolution: workspace
 
 dependencies:
   google_cloud_gax: ^0.1.2
-  google_cloud_protobuf: ^0.1.2
+  google_cloud_protobuf: ^0.1.0
   http: ^1.3.0
 
 dev_dependencies:

--- a/generated/google_cloud_location/pubspec.yaml
+++ b/generated/google_cloud_location/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: google_cloud_location
 description: The Google Cloud client library for the Cloud Metadata API.
-version: 0.1.1
+version: 0.1.2
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_location
 issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 
@@ -26,8 +26,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_gax: ^0.1.0
-  google_cloud_protobuf: ^0.1.1
+  google_cloud_gax: ^0.1.2
+  google_cloud_protobuf: ^0.1.2
   http: ^1.3.0
 
 dev_dependencies:

--- a/generated/google_cloud_longrunning/lib/longrunning.dart
+++ b/generated/google_cloud_longrunning/lib/longrunning.dart
@@ -67,8 +67,9 @@ final class Operations {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory Operations.fromApiKey([String? apiKey]) {

--- a/generated/google_cloud_longrunning/pubspec.yaml
+++ b/generated/google_cloud_longrunning/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: google_cloud_longrunning
 description: The Google Cloud client library for the Long Running Operations API.
-version: 0.1.1
+version: 0.1.2
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_longrunning
 issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 
@@ -26,9 +26,9 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_gax: ^0.1.0
-  google_cloud_protobuf: ^0.1.1
-  google_cloud_rpc: ^0.1.1
+  google_cloud_gax: ^0.1.2
+  google_cloud_protobuf: ^0.1.2
+  google_cloud_rpc: ^0.1.2
   http: ^1.3.0
 
 dev_dependencies:

--- a/generated/google_cloud_longrunning/pubspec.yaml
+++ b/generated/google_cloud_longrunning/pubspec.yaml
@@ -27,8 +27,8 @@ resolution: workspace
 
 dependencies:
   google_cloud_gax: ^0.1.2
-  google_cloud_protobuf: ^0.1.2
-  google_cloud_rpc: ^0.1.2
+  google_cloud_protobuf: ^0.1.0
+  google_cloud_rpc: ^0.1.0
   http: ^1.3.0
 
 dev_dependencies:

--- a/generated/google_cloud_protobuf/.sidekick.toml
+++ b/generated/google_cloud_protobuf/.sidekick.toml
@@ -34,6 +34,7 @@ include-list = """\
 """
 
 [codec]
+version = "0.1.0"
 copyright-year   = '2025'
 part-file        = "src/protobuf.p.dart"
 dev-dependencies = "test"

--- a/generated/google_cloud_protobuf/pubspec.yaml
+++ b/generated/google_cloud_protobuf/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: google_cloud_protobuf
 description: The Google Cloud client library for the Core Protobuf Types.
-version: 0.1.1
+version: 0.1.2
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_protobuf
 issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 

--- a/generated/google_cloud_protobuf/pubspec.yaml
+++ b/generated/google_cloud_protobuf/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: google_cloud_protobuf
 description: The Google Cloud client library for the Core Protobuf Types.
-version: 0.1.2
+version: 0.1.0
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_protobuf
 issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 

--- a/generated/google_cloud_rpc/.sidekick.toml
+++ b/generated/google_cloud_rpc/.sidekick.toml
@@ -17,6 +17,7 @@ specification-source = 'google/rpc'
 service-config = 'google/rpc/rpc_publish.yaml'
 
 [codec]
+version = "0.1.0"
 copyright-year = '2025'
 part-file = "src/rpc.p.dart"
 dev-dependencies = "test"

--- a/generated/google_cloud_rpc/pubspec.yaml
+++ b/generated/google_cloud_rpc/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: google_cloud_rpc
 description: The Google Cloud client library for the Google RPC Types.
-version: 0.1.1
+version: 0.1.2
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_rpc
 issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 
@@ -26,7 +26,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_protobuf: ^0.1.1
+  google_cloud_protobuf: ^0.1.2
 
 dev_dependencies:
   test: any

--- a/generated/google_cloud_rpc/pubspec.yaml
+++ b/generated/google_cloud_rpc/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: google_cloud_rpc
 description: The Google Cloud client library for the Google RPC Types.
-version: 0.1.2
+version: 0.1.0
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_rpc
 issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 
@@ -26,7 +26,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_protobuf: ^0.1.2
+  google_cloud_protobuf: ^0.1.0
 
 dev_dependencies:
   test: any

--- a/generated/google_cloud_secretmanager_v1/lib/secretmanager.dart
+++ b/generated/google_cloud_secretmanager_v1/lib/secretmanager.dart
@@ -56,8 +56,9 @@ final class SecretManagerService {
   ///
   /// - `GOOGLE_API_KEY`
   ///
-  /// Throws [ArgumentError] if called without arguments and none of the above
-  /// environment variables are set.
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
   ///
   /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
   factory SecretManagerService.fromApiKey([String? apiKey]) {

--- a/generated/google_cloud_secretmanager_v1/pubspec.yaml
+++ b/generated/google_cloud_secretmanager_v1/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: google_cloud_secretmanager_v1
 description: The Google Cloud client library for the Secret Manager API.
-version: 0.1.1
+version: 0.1.2
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_secretmanager_v1
 issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 
@@ -26,10 +26,10 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_gax: ^0.1.0
-  google_cloud_iam_v1: ^0.1.1
-  google_cloud_location: ^0.1.1
-  google_cloud_protobuf: ^0.1.1
+  google_cloud_gax: ^0.1.2
+  google_cloud_iam_v1: ^0.1.2
+  google_cloud_location: ^0.1.2
+  google_cloud_protobuf: ^0.1.2
   http: ^1.3.0
 
 dev_dependencies:

--- a/generated/google_cloud_secretmanager_v1/pubspec.yaml
+++ b/generated/google_cloud_secretmanager_v1/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   google_cloud_gax: ^0.1.2
   google_cloud_iam_v1: ^0.1.2
   google_cloud_location: ^0.1.2
-  google_cloud_protobuf: ^0.1.2
+  google_cloud_protobuf: ^0.1.0
   http: ^1.3.0
 
 dev_dependencies:

--- a/generated/google_cloud_type/.sidekick.toml
+++ b/generated/google_cloud_type/.sidekick.toml
@@ -17,5 +17,6 @@ specification-source = 'google/type'
 service-config = 'google/type/type.yaml'
 
 [codec]
+version = "0.1.0"
 copyright-year = '2025'
 repository-url = "https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_type"

--- a/generated/google_cloud_type/pubspec.yaml
+++ b/generated/google_cloud_type/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: google_cloud_type
 description: The Google Cloud client library for the Common Types.
-version: 0.1.1
+version: 0.1.2
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_type
 issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 
@@ -26,7 +26,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_protobuf: ^0.1.1
+  google_cloud_protobuf: ^0.1.2
 
 dev_dependencies:
   lints: any

--- a/generated/google_cloud_type/pubspec.yaml
+++ b/generated/google_cloud_type/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: google_cloud_type
 description: The Google Cloud client library for the Common Types.
-version: 0.1.2
+version: 0.1.0
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_type
 issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 
@@ -26,7 +26,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_protobuf: ^0.1.2
+  google_cloud_protobuf: ^0.1.0
 
 dev_dependencies:
   lints: any

--- a/packages/google_cloud_gax/CHANGELOG.md
+++ b/packages/google_cloud_gax/CHANGELOG.md
@@ -1,5 +1,8 @@
-## 0.1.1
+## 0.1.2
 
+* **BREAKING**: Throw `ConfigurationException` instead of `ArgumentError` when
+  `fromApiKey` is called without arguments and none of the relevant
+  environment variables are not set.
 * Enable support on the web
   [[fixes: #55]](https://github.com/googleapis/google-cloud-dart/issues/55)
 

--- a/packages/google_cloud_gax/lib/gax.dart
+++ b/packages/google_cloud_gax/lib/gax.dart
@@ -34,6 +34,16 @@ final String _clientName = 'gl-dart/$clientDartVersion gax/$gaxVersion';
 const String _contentTypeKey = 'content-type';
 const String _typeJson = 'application/json';
 
+/// Exception thrown when a method is called without correct configuration.
+final class ConfigurationException implements Exception {
+  final String _message;
+
+  ConfigurationException(this._message);
+
+  @override
+  String toString() => 'ConfigurationException: $_message';
+}
+
 /// Exception thrown when calling an API through [ServiceClient] fails.
 final class ServiceException implements Exception {
   /// A message describing the cause of the exception.

--- a/packages/google_cloud_gax/lib/gax.dart
+++ b/packages/google_cloud_gax/lib/gax.dart
@@ -36,12 +36,13 @@ const String _typeJson = 'application/json';
 
 /// Exception thrown when a method is called without correct configuration.
 final class ConfigurationException implements Exception {
-  final String _message;
+  /// A message describing the cause of the exception.
+  final String message;
 
-  ConfigurationException(this._message);
+  ConfigurationException(this.message);
 
   @override
-  String toString() => 'ConfigurationException: $_message';
+  String toString() => 'ConfigurationException: $message';
 }
 
 /// Exception thrown when calling an API through [ServiceClient] fails.

--- a/packages/google_cloud_gax/lib/src/vm.dart
+++ b/packages/google_cloud_gax/lib/src/vm.dart
@@ -20,6 +20,8 @@ import 'dart:io';
 import 'package:googleapis_auth/googleapis_auth.dart' as auth;
 import 'package:http/http.dart' as http;
 
+import '../gax.dart';
+
 /// The Dart version to use in "x-goog-api-client" headers.
 ///
 /// The format is either `major.minor.patch` or the special value `0`, which
@@ -37,12 +39,12 @@ final clientDartVersion = Platform.version
 ///
 /// On the web, `apiKey` must be provided and `envKeys` is ignored.
 ///
-/// Throws [ArgumentError] `apiKey` is `null` and no API key is found in the
-/// given environment variables.
+/// Throws [ConfigurationException] `apiKey` is `null` and no API key is found
+/// in the given environment variables.
 http.Client httpClientFromApiKey(String? apiKey, List<String> envKeys) {
   apiKey ??= envKeys.map((n) => Platform.environment[n]).nonNulls.firstOrNull;
   if (apiKey == null) {
-    throw ArgumentError(
+    throw ConfigurationException(
       'apiKey or one of these environment variables must be set to an API key: '
       '${envKeys.join(', ')}',
     );

--- a/packages/google_cloud_gax/lib/src/web.dart
+++ b/packages/google_cloud_gax/lib/src/web.dart
@@ -18,6 +18,8 @@ library;
 import 'package:googleapis_auth/googleapis_auth.dart' as auth;
 import 'package:http/http.dart' as http;
 
+import '../gax.dart';
+
 /// The Dart version to use in "x-goog-api-client" headers.
 ///
 /// The format is either `major.minor.patch` or the special value `0`, which
@@ -32,11 +34,11 @@ const String clientDartVersion = '0';
 ///
 /// On the web, `apiKey` must be provided and `envKeys` is ignored.
 ///
-/// Throws [ArgumentError] `apiKey` is `null` and no API key is found in the
-/// given environment variables.
+/// Throws [ConfigurationException] `apiKey` is `null` and no API key is found
+/// in the given environment variables.
 http.Client httpClientFromApiKey(String? apiKey, List<String> envKeys) {
   if (apiKey == null) {
-    throw ArgumentError('apiKey must be set to an API key');
+    throw ConfigurationException('apiKey must be set to an API key');
   }
   return auth.clientViaApiKey(apiKey);
 }

--- a/packages/google_cloud_gax/pubspec.yaml
+++ b/packages/google_cloud_gax/pubspec.yaml
@@ -18,7 +18,7 @@ description: Common code for the Google Cloud client library packages.
 # * CHANGELOG.yaml
 # * pubspec.yaml
 # * lib/src/versions.dart
-version: 0.1.0
+version: 0.1.2
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/packages/google_cloud_gax
 
 environment:


### PR DESCRIPTION
Change `fromApiKey` to throw `ConfigurationException` rather than `ArgumentError`

Depends on https://github.com/googleapis/librarian/pull/2697

Fixes https://github.com/googleapis/google-cloud-dart/issues/53

Non-generated changes:
- `**/.sidekick.yaml`
- all the changes in` google_cloud_gax`