### PR TITLE
chore(storage): remove settable boundary string

### DIFF
--- a/pkgs/google_cloud_storage/lib/src/file_upload.dart
+++ b/pkgs/google_cloud_storage/lib/src/file_upload.dart
@@ -33,17 +33,7 @@ final _random = Random.secure();
 /// See https://datatracker.ietf.org/doc/html/rfc2046
 const _boundaryChars = 'abcdefghijklmnopqrstuvwxyz0123456789';
 
-/// The boundary string to use when seperating parts of a multipart request.
-///
-/// If `null` then the boundary string will be generated randomly. Setting this
-/// to a fixed value is useful for testing because it results in a deterministic
-/// request body.
-@visibleForTesting
-String? fixedBoundaryString;
-
 String _boundaryString() {
-  if (fixedBoundaryString case final boundary?) return boundary;
-
   // A boundary string has a maximum length of 70 characters.
   // See https://datatracker.ietf.org/doc/html/rfc2046#section-5.1
   var prefix = 'http-boundary-';

--- a/pkgs/google_cloud_storage/lib/src/file_upload.dart
+++ b/pkgs/google_cloud_storage/lib/src/file_upload.dart
@@ -19,7 +19,6 @@ import 'dart:typed_data';
 import 'package:crypto/crypto.dart' as crypto;
 import 'package:google_cloud_rpc/exceptions.dart';
 import 'package:http/http.dart' as http;
-import 'package:meta/meta.dart';
 
 import 'crc32c.dart';
 import 'object_metadata.dart';

--- a/pkgs/google_cloud_storage/test/delete_object_test.dart
+++ b/pkgs/google_cloud_storage/test/delete_object_test.dart
@@ -15,7 +15,6 @@
 import 'dart:convert';
 
 import 'package:google_cloud_storage/google_cloud_storage.dart';
-import 'package:google_cloud_storage/src/file_upload.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:test/test.dart';
@@ -28,7 +27,6 @@ void main() async {
   group('delete object', () {
     group('google-cloud', tags: ['google-cloud'], () {
       setUp(() {
-        fixedBoundaryString = 'boundary';
         storage = Storage();
       });
 

--- a/pkgs/google_cloud_storage/test/download_object_test.dart
+++ b/pkgs/google_cloud_storage/test/download_object_test.dart
@@ -20,8 +20,6 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:google_cloud_storage/google_cloud_storage.dart';
-import 'package:google_cloud_storage/src/file_upload.dart'
-    show fixedBoundaryString;
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:test/test.dart';
@@ -34,7 +32,6 @@ void main() async {
   group('download object', () {
     group('google-cloud', tags: ['google-cloud'], () {
       setUp(() async {
-        fixedBoundaryString = 'boundary';
         storage = Storage();
       });
 

--- a/pkgs/google_cloud_storage/test/list_objects_test.dart
+++ b/pkgs/google_cloud_storage/test/list_objects_test.dart
@@ -19,7 +19,6 @@ library;
 import 'dart:convert';
 
 import 'package:google_cloud_storage/google_cloud_storage.dart';
-import 'package:google_cloud_storage/src/file_upload.dart';
 import 'package:test/test.dart';
 
 import 'test_utils.dart';
@@ -29,7 +28,6 @@ void main() async {
 
   group('list objects', () {
     setUp(() {
-      fixedBoundaryString = 'boundary';
       storage = Storage();
     });
 

--- a/pkgs/google_cloud_storage/test/object_metadata_api_test.dart
+++ b/pkgs/google_cloud_storage/test/object_metadata_api_test.dart
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import 'package:google_cloud_storage/google_cloud_storage.dart';
-import 'package:google_cloud_storage/src/file_upload.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:test/test.dart';
@@ -26,7 +25,6 @@ void main() async {
   group('object metadata', () {
     group('google-cloud', tags: ['google-cloud'], () {
       setUp(() async {
-        fixedBoundaryString = 'boundary';
         storage = Storage();
       });
 

--- a/pkgs/google_cloud_storage/test/patch_object_test.dart
+++ b/pkgs/google_cloud_storage/test/patch_object_test.dart
@@ -16,7 +16,6 @@ import 'dart:convert';
 
 import 'package:google_cloud_protobuf/protobuf.dart' hide Duration;
 import 'package:google_cloud_storage/google_cloud_storage.dart';
-import 'package:google_cloud_storage/src/file_upload.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:test/test.dart';
@@ -29,7 +28,6 @@ void main() async {
   group('patch object', () {
     group('google-cloud', tags: ['google-cloud'], () {
       setUp(() async {
-        fixedBoundaryString = 'boundary';
         storage = Storage();
       });
 

--- a/pkgs/google_cloud_storage/test/storage_object_test.dart
+++ b/pkgs/google_cloud_storage/test/storage_object_test.dart
@@ -19,8 +19,6 @@ library;
 import 'dart:convert';
 
 import 'package:google_cloud_storage/google_cloud_storage.dart';
-import 'package:google_cloud_storage/src/file_upload.dart'
-    show fixedBoundaryString;
 import 'package:test/test.dart';
 
 import 'test_utils.dart';
@@ -30,7 +28,6 @@ void main() async {
 
   group('storage object', () {
     setUp(() {
-      fixedBoundaryString = 'boundary';
       storage = Storage();
     });
 

--- a/pkgs/google_cloud_storage/test/upload_object_from_string_test.dart
+++ b/pkgs/google_cloud_storage/test/upload_object_from_string_test.dart
@@ -19,8 +19,6 @@ library;
 import 'dart:convert';
 
 import 'package:google_cloud_storage/google_cloud_storage.dart';
-import 'package:google_cloud_storage/src/file_upload.dart'
-    show fixedBoundaryString;
 import 'package:test/test.dart';
 
 import 'test_utils.dart';
@@ -30,7 +28,6 @@ void main() async {
 
   group('upload object from string', () {
     setUp(() {
-      fixedBoundaryString = 'boundary';
       storage = Storage();
     });
 

--- a/pkgs/google_cloud_storage/test/upload_object_test.dart
+++ b/pkgs/google_cloud_storage/test/upload_object_test.dart
@@ -16,8 +16,6 @@ import 'dart:convert';
 
 import 'package:google_cloud_protobuf/protobuf.dart' as protobuf;
 import 'package:google_cloud_storage/google_cloud_storage.dart';
-import 'package:google_cloud_storage/src/file_upload.dart'
-    show fixedBoundaryString;
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:test/test.dart';
@@ -30,7 +28,6 @@ void main() async {
   group('upload object', () {
     group('google-cloud', tags: ['google-cloud'], () {
       setUp(() {
-        fixedBoundaryString = 'boundary';
         storage = Storage();
       });
 


### PR DESCRIPTION
The ability to set a fixed boundary string was previously required because the HTTP recording/replying system required deterministic payloads.