### PR TITLE
chore: split developer guide 

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -3,8 +3,10 @@
 ## Layout
 
 - `examples/`: various examples of Google Cloud client usage
-- `generated/`: the generated Google Cloud API packages
-- `pkgs/`: hand-written API and support packages
+- `generated/`: the generated Google Cloud API packages (see
+  [`generated/README.md`](generated/README.md) for generation instructions)
+- `pkgs/`: hand-written API and support packages (see
+  [`pkgs/README.md`](pkgs/README.md) for package-specific instructions)
 - `tests/`: unit and integration tests for the generated cloud APIs
 
 The dependency graph for the current set of packages:
@@ -59,27 +61,6 @@ To run these tests locally (they are automatically run for PRs using
 *   **Missing Scopes:** If a test fails with `insufficient_scope`, check the error message for the required scope URL and re-authenticate with that scope.
 *   **Disabled APIs:** If a test fails with a `ForbiddenException` stating an API has not been used, follow the URL in the error message to enable the API in the Google Cloud Console.
 
-### Running against Storage Testbench
-
-Some integration tests in `package:google_cloud_storage` use the
-[Storage Testbench][]. These tests are tagged with
-`@Tags(['storage-testbench'])` and are not run by default, i.e., `dart test`
-will not run them.
-
-To run these tests locally (they are automatically run for PRs using a
-[GitHub workflow](.github/workflows/dart_checks.yaml)):
-
-1.  **Start Storage Testbench:**
-    ```bash
-    $ docker run -d --rm -p 9000:9000 -p 8888:8888 \
-        gcr.io/cloud-devrel-public-resources/storage-testbench:latest
-    ```
-
-2.  **Run the tests:**
-    ```bash
-    $ dart test . -P storage-testbench
-    ```
-
 ## Pull Requests
 
 * PRs should follow [Conventional Commits][]
@@ -88,68 +69,5 @@ To run these tests locally (they are automatically run for PRs using a
   example, for a documentation changes to `package:google_cloud_storage`,
   `docs(storage): clarify retry logic`.
 
-## Developing
-
-### Librarian
-
-[Librarian](https://github.com/googleapis/librarian/blob/main/README.md)
-is the tool used to generate Dart packages from API descriptions.
-
-#### Regenerating the Dart packages
-
-From the root of the project:
-
-```bash
-go run github.com/googleapis/librarian/cmd/librarian@main generate -all
-```
-
-> [!NOTE]
-> You will have to [update Librarian](#updating-librarian) if you want to merge these changes.
-
-#### Regenerating from a locally modified Librarian
-
-Clone https://github.com/googleapis/librarian as a sibling directory to this
-repo, make any desired changes to Librarian, then - from the root of the
-project - run:
-
-```bash
-# Build the binary
-go -C ../librarian build -o ../librarian/librarian ./cmd/librarian
-# Run library regeneration
-../librarian/librarian generate -all
-```
-> [!NOTE]
-> Use `-f` to ignore the librarian version check since the local version is likely not the same
-> as the one in [librarian.yaml](librarian.yaml).
-
-#### Updating Librarian
-
-[Workflow automation](.github/workflows/dart_checks.yaml) ensures that all
-generated code matches what the generator would actually produce.
-
-To prevent Librarian changes from causing workflow automation failures in this
-repository, the version of Librarian used by this automation is pinned.
-
-After making changes to Librarian you must 
-[regenerate the Dart packages](#regenerating-the-dart-packages) and update
-the version of Librarian used in the automation:
-1. Find the head version of Librarian by running this command:
-   
-   `GOPROXY=direct go list -m -u -f '{{.Version}}' github.com/googleapis/librarian@main`
-2. Modify the Librarian invocation in [.github/workflows/dart_checks.yaml](.github/workflows/dart_checks.yaml)
-
-#### Updating API sources
-
-Configuration for API source descriptions is found in the `[sources]`
-section of the root [`librarian.yaml`](librarian.yaml).
-
-You can update these sources to their latest versions by running
-(from the root of the project):
-
-```bash
-go run github.com/googleapis/librarian/cmd/librarian@main update conformance googleapis protobuf showcase
-```
-
 [Google Cloud Console]: https://console.cloud.google.com/
 [Conventional Commits]: https://www.conventionalcommits.org/
-[Storage Testbench]: https://github.com/googleapis/storage-testbench

--- a/generated/README.md
+++ b/generated/README.md
@@ -1,6 +1,7 @@
 # Generated packages
 
-This directory contains the generated Google Cloud API packages.
+This directory contains Google Cloud API packages that are automatically
+generated from API descriptions.
 
 ## Developing
 

--- a/generated/README.md
+++ b/generated/README.md
@@ -1,0 +1,65 @@
+# Generated packages
+
+This directory contains the generated Google Cloud API packages.
+
+## Developing
+
+### Librarian
+
+[Librarian](https://github.com/googleapis/librarian/blob/main/README.md)
+is the tool used to generate Dart packages from API descriptions.
+
+#### Regenerating the Dart packages
+
+From the root of the project:
+
+```bash
+go run github.com/googleapis/librarian/cmd/librarian@main generate -all
+```
+
+> [!NOTE]
+> You will have to [update Librarian](#updating-librarian) if you want to merge these changes.
+
+#### Regenerating from a locally modified Librarian
+
+Clone https://github.com/googleapis/librarian as a sibling directory to this
+repo, make any desired changes to Librarian, then - from the root of the
+project - run:
+
+```bash
+# Build the binary
+go -C ../librarian build -o ../librarian/librarian ./cmd/librarian
+# Run library regeneration
+../librarian/librarian generate -all
+```
+> [!NOTE]
+> Use `-f` to ignore the librarian version check since the local version is likely not the same
+> as the one in [../librarian.yaml](../librarian.yaml).
+
+#### Updating Librarian
+
+[Workflow automation](../.github/workflows/dart_checks.yaml) ensures that all
+generated code matches what the generator would actually produce.
+
+To prevent Librarian changes from causing workflow automation failures in this
+repository, the version of Librarian used by this automation is pinned.
+
+After making changes to Librarian you must 
+[regenerate the Dart packages](#regenerating-the-dart-packages) and update
+the version of Librarian used in the automation:
+1. Find the head version of Librarian by running this command:
+   
+   `GOPROXY=direct go list -m -u -f '{{.Version}}' github.com/googleapis/librarian@main`
+2. Modify the Librarian invocation in [../.github/workflows/dart_checks.yaml](../.github/workflows/dart_checks.yaml)
+
+#### Updating API sources
+
+Configuration for API source descriptions is found in the `[sources]`
+section of the root [`../librarian.yaml`](../librarian.yaml).
+
+You can update these sources to their latest versions by running
+(from the root of the project):
+
+```bash
+go run github.com/googleapis/librarian/cmd/librarian@main update conformance googleapis protobuf showcase
+```

--- a/pkgs/README.md
+++ b/pkgs/README.md
@@ -1,28 +1,3 @@
 # Hand-written packages
 
 This directory contains hand-written API and support packages.
-
-## Testing
-
-### Running against Storage Testbench
-
-Some integration tests in `package:google_cloud_storage` use the
-[Storage Testbench][]. These tests are tagged with
-`@Tags(['storage-testbench'])` and are not run by default, i.e., `dart test`
-will not run them.
-
-To run these tests locally (they are automatically run for PRs using a
-[GitHub workflow](../.github/workflows/dart_checks.yaml)):
-
-1.  **Start Storage Testbench:**
-    ```bash
-    $ docker run -d --rm -p 9000:9000 -p 8888:8888 \
-        gcr.io/cloud-devrel-public-resources/storage-testbench:latest
-    ```
-
-2.  **Run the tests:**
-    ```bash
-    $ dart test . -P storage-testbench
-    ```
-
-[Storage Testbench]: https://github.com/googleapis/storage-testbench

--- a/pkgs/README.md
+++ b/pkgs/README.md
@@ -1,0 +1,28 @@
+# Hand-written packages
+
+This directory contains hand-written API and support packages.
+
+## Testing
+
+### Running against Storage Testbench
+
+Some integration tests in `package:google_cloud_storage` use the
+[Storage Testbench][]. These tests are tagged with
+`@Tags(['storage-testbench'])` and are not run by default, i.e., `dart test`
+will not run them.
+
+To run these tests locally (they are automatically run for PRs using a
+[GitHub workflow](../.github/workflows/dart_checks.yaml)):
+
+1.  **Start Storage Testbench:**
+    ```bash
+    $ docker run -d --rm -p 9000:9000 -p 8888:8888 \
+        gcr.io/cloud-devrel-public-resources/storage-testbench:latest
+    ```
+
+2.  **Run the tests:**
+    ```bash
+    $ dart test . -P storage-testbench
+    ```
+
+[Storage Testbench]: https://github.com/googleapis/storage-testbench

--- a/pkgs/google_cloud_storage/DEVELOPER_GUIDE.md
+++ b/pkgs/google_cloud_storage/DEVELOPER_GUIDE.md
@@ -8,7 +8,7 @@ Some integration tests in `package:google_cloud_storage` use the
 will not run them.
 
 To run these tests locally (they are automatically run for PRs using a
-[GitHub workflow](../.github/workflows/dart_checks.yaml)):
+[GitHub workflow](../../.github/workflows/dart_checks.yaml)):
 
 1.  **Start Storage Testbench:**
     ```bash

--- a/pkgs/google_cloud_storage/DEVELOPER_GUIDE.md
+++ b/pkgs/google_cloud_storage/DEVELOPER_GUIDE.md
@@ -1,0 +1,24 @@
+## Testing
+
+### Running against Storage Testbench
+
+Some integration tests in `package:google_cloud_storage` use the
+[Storage Testbench][]. These tests are tagged with
+`@Tags(['storage-testbench'])` and are not run by default, i.e., `dart test`
+will not run them.
+
+To run these tests locally (they are automatically run for PRs using a
+[GitHub workflow](../.github/workflows/dart_checks.yaml)):
+
+1.  **Start Storage Testbench:**
+    ```bash
+    $ docker run -d --rm -p 9000:9000 -p 8888:8888 \
+        gcr.io/cloud-devrel-public-resources/storage-testbench:latest
+    ```
+
+2.  **Run the tests:**
+    ```bash
+    $ dart test pkgs/google_cloud_storage -P storage-testbench
+    ```
+
+[Storage Testbench]: https://github.com/googleapis/storage-testbench

--- a/pkgs/google_cloud_storage/DEVELOPER_GUIDE.md
+++ b/pkgs/google_cloud_storage/DEVELOPER_GUIDE.md
@@ -17,6 +17,8 @@ To run these tests locally (they are automatically run for PRs using a
     ```
 
 2.  **Run the tests:**
+
+    From the root of the project:
     ```bash
     $ dart test pkgs/google_cloud_storage -P storage-testbench
     ```


### PR DESCRIPTION
Splits the developer site into three parts:
1. information related to the whole repository
2. information related to hand-written packages
3. information specific to `package:google_cloud_storage`

Also adds some information and how the package is setup to the root DEVELOPER_GUIDE.md