### PR TITLE
chore(storage): older meta, ready release

### DIFF
--- a/pkgs/google_cloud_storage/CHANGELOG.md
+++ b/pkgs/google_cloud_storage/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.6.1-wip
+## 0.6.1
 
 * Add `Storage.insertObjectAcl`.
 

--- a/pkgs/google_cloud_storage/pubspec.yaml
+++ b/pkgs/google_cloud_storage/pubspec.yaml
@@ -16,7 +16,7 @@ name: google_cloud_storage
 description: >-
   A client for Google Cloud Storage, a managed service for storing, archiving,
   and serving unstructured data of any size.
-version: 0.6.1-wip
+version: 0.6.1
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/pkgs/google_cloud_storage
 
 environment:
@@ -35,7 +35,7 @@ dependencies:
   google_cloud_rpc: ^0.5.0
   googleapis_auth: ^2.0.0
   http: ^1.6.0
-  meta: ^1.18.1
+  meta: ^1.17.0
 
 dev_dependencies:
   benchmark_harness: ^2.3.1


### PR DESCRIPTION
- Downgrade `package:meta` to `^1.17.0` (see https://github.com/firebase/firebase-functions-dart/issues/133)
- Prepare to release `0.6.1`