### PR TITLE
feat(storage): add bucket ACL methods

### DIFF
--- a/pkgs/google_cloud_storage/CHANGELOG.md
+++ b/pkgs/google_cloud_storage/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.6.2-wip
 
 * Add retries to `uploadObjectFromSink`.
+* Add `deleteBucketAcl`, `getBucketAcl`, `insertBucketAcl`,
+  `listBucketAcl`, `patchBucketAcl`, and `updateBucketAcl`.
 * Add `deleteObjectAcl`, `getObjectAcl`, `listObjectAcl`, `patchObjectAcl`,
   and `updateObjectAcl`.
 * Add `makeObjectPublic`.

--- a/pkgs/google_cloud_storage/lib/src/client.dart
+++ b/pkgs/google_cloud_storage/lib/src/client.dart
@@ -314,6 +314,118 @@ final class Storage {
     await serviceClient.delete(url);
   }, isIdempotent: ifMetagenerationMatch != null);
 
+  /// Deletes an ACL entry on the specified [Google Cloud Storage bucket].
+  ///
+  /// This operation is not idempotent.
+  ///
+  /// If the bucket has uniform bucket-level access enabled, this operation
+  /// will fail with [BadRequestException].
+  ///
+  /// Throws [NotFoundException] if the bucket or ACL does not exist.
+  ///
+  /// {@macro acl_entity_docs}
+  ///
+  /// See [API reference docs](https://cloud.google.com/storage/docs/json_api/v1/bucketAccessControls/delete).
+  ///
+  /// [Google Cloud Storage bucket]: https://docs.cloud.google.com/storage/docs/buckets
+  Future<void> deleteBucketAcl(
+    String bucket,
+    String entity, {
+    RetryRunner retry = defaultRetry,
+  }) => retry.run(() async {
+    final serviceClient = await _serviceClient;
+    final url = _requestUrl(['storage', 'v1', 'b', bucket, 'acl', entity], {});
+    await serviceClient.delete(url);
+  }, isIdempotent: false);
+
+  /// Returns the ACL entry for the specified entity on the specified
+  /// [Google Cloud Storage bucket].
+  ///
+  /// This operation is read-only and always idempotent.
+  ///
+  /// {@macro acl_entity_docs}
+  ///
+  /// Throws [NotFoundException] if the bucket or ACL entry does not exist.
+  ///
+  /// See [API reference docs](https://cloud.google.com/storage/docs/json_api/v1/bucketAccessControls/get).
+  ///
+  /// [Google Cloud Storage bucket]: https://docs.cloud.google.com/storage/docs/buckets
+  Future<BucketAccessControl> getBucketAcl(
+    String bucket,
+    String entity, {
+    RetryRunner retry = defaultRetry,
+  }) => retry.run(() async {
+    final serviceClient = await _serviceClient;
+    final url = _requestUrl(['storage', 'v1', 'b', bucket, 'acl', entity], {});
+    final j = await serviceClient.get(url);
+    return bucketAccessControlFromJson(j as Map<String, Object?>)!;
+  }, isIdempotent: true);
+
+  /// Creates a new ACL entry on the specified [Google Cloud Storage bucket].
+  ///
+  /// This operation is not idempotent.
+  ///
+  /// If the bucket has uniform bucket-level access enabled, this operation
+  /// will fail with [BadRequestException].
+  ///
+  /// Throws [NotFoundException] if the bucket does not exist.
+  ///
+  /// {@macro acl_entity_docs}
+  ///
+  /// {@template bucket_acl_role_docs}
+  /// [role] specifies the access permission for the entity. There are three
+  /// roles that can be assigned to an entity:
+  /// 1. `READER`s can get the bucket, though no acl property will be returned,
+  ///    and list the bucket's objects.
+  /// 2. `WRITER`s are `READER`s, and they can insert objects into the bucket
+  ///    and delete the bucket's objects.
+  /// 3. `OWNER`s are `WRITER`s, and they can get the acl property of a bucket,
+  ///    update a bucket, and call all [BucketAccessControl]-related methods on
+  ///    the bucket.
+  /// {@endtemplate}
+  ///
+  /// See [API reference docs](https://cloud.google.com/storage/docs/json_api/v1/bucketAccessControls/insert).
+  ///
+  /// [Google Cloud Storage bucket]: https://docs.cloud.google.com/storage/docs/buckets
+  Future<BucketAccessControl> insertBucketAcl(
+    String bucket,
+    String entity,
+    String role, {
+    RetryRunner retry = defaultRetry,
+  }) => retry.run(() async {
+    final serviceClient = await _serviceClient;
+    final url = _requestUrl(['storage', 'v1', 'b', bucket, 'acl'], {});
+    final j = await serviceClient.post(
+      url,
+      body: _JsonEncodableWrapper({'entity': entity, 'role': role}),
+    );
+    return bucketAccessControlFromJson(j as Map<String, Object?>)!;
+  }, isIdempotent: false);
+
+  /// A list of Access Control List (ACL) entries on the specified
+  /// [Google Cloud Storage bucket].
+  ///
+  /// This operation is read-only and always idempotent.
+  ///
+  /// Throws [NotFoundException] if the bucket does not exist.
+  ///
+  /// See [API reference docs](https://cloud.google.com/storage/docs/json_api/v1/bucketAccessControls/list).
+  ///
+  /// [Google Cloud Storage bucket]: https://docs.cloud.google.com/storage/docs/buckets
+  Future<List<BucketAccessControl>> listBucketAcl(
+    String bucket, {
+    RetryRunner retry = defaultRetry,
+  }) => retry.run(() async {
+    final serviceClient = await _serviceClient;
+    final url = _requestUrl(['storage', 'v1', 'b', bucket, 'acl'], {});
+    final j = await serviceClient.get(url);
+    final items = j['items'] as List<Object?>? ?? const [];
+    return [
+      for (final item in items)
+        bucketAccessControlFromJson(item as Map<String, Object?>)!,
+    ];
+  }, isIdempotent: true);
+
   /// A stream of buckets in the project in lexicographical order by name.
   ///
   /// [prefix] filters the returned buckets to those whose names begin with the
@@ -436,6 +548,70 @@ final class Storage {
     );
     return bucketMetadataFromJson(j as Map<String, Object?>);
   }, isIdempotent: ifMetagenerationMatch != null);
+
+  /// Patches an Access Control List (ACL) entry on the specified
+  /// [Google Cloud Storage bucket].
+  ///
+  /// This operation is not idempotent.
+  ///
+  /// If the bucket has uniform bucket-level access enabled, this operation
+  /// will fail with [BadRequestException].
+  ///
+  /// Throws [NotFoundException] if the bucket or ACL does not exist.
+  ///
+  /// {@macro acl_entity_docs}
+  ///
+  /// {@macro bucket_acl_role_docs}
+  ///
+  /// See [API reference docs](https://cloud.google.com/storage/docs/json_api/v1/bucketAccessControls/patch).
+  ///
+  /// [Google Cloud Storage bucket]: https://docs.cloud.google.com/storage/docs/buckets
+  Future<BucketAccessControl> patchBucketAcl(
+    String bucket,
+    String entity,
+    String role, {
+    RetryRunner retry = defaultRetry,
+  }) => retry.run(() async {
+    final serviceClient = await _serviceClient;
+    final url = _requestUrl(['storage', 'v1', 'b', bucket, 'acl', entity], {});
+    final j = await serviceClient.patch(
+      url,
+      body: _JsonEncodableWrapper({'entity': entity, 'role': role}),
+    );
+    return bucketAccessControlFromJson(j as Map<String, Object?>)!;
+  }, isIdempotent: false);
+
+  /// Updates an Access Control List (ACL) entry on the specified
+  /// [Google Cloud Storage bucket].
+  ///
+  /// This operation is not idempotent.
+  ///
+  /// If the bucket has uniform bucket-level access enabled, this operation
+  /// will fail with [BadRequestException].
+  ///
+  /// Throws [NotFoundException] if the bucket or ACL does not exist.
+  ///
+  /// {@macro acl_entity_docs}
+  ///
+  /// {@macro bucket_acl_role_docs}
+  ///
+  /// See [API reference docs](https://cloud.google.com/storage/docs/json_api/v1/bucketAccessControls/update).
+  ///
+  /// [Google Cloud Storage bucket]: https://docs.cloud.google.com/storage/docs/buckets
+  Future<BucketAccessControl> updateBucketAcl(
+    String bucket,
+    String entity,
+    String role, {
+    RetryRunner retry = defaultRetry,
+  }) => retry.run(() async {
+    final serviceClient = await _serviceClient;
+    final url = _requestUrl(['storage', 'v1', 'b', bucket, 'acl', entity], {});
+    final j = await serviceClient.put(
+      url,
+      body: _JsonEncodableWrapper({'entity': entity, 'role': role}),
+    );
+    return bucketAccessControlFromJson(j as Map<String, Object?>)!;
+  }, isIdempotent: false);
 
   // Object-related methods, keep alphabetized.
 

--- a/pkgs/google_cloud_storage/test/delete_bucket_acl_test.dart
+++ b/pkgs/google_cloud_storage/test/delete_bucket_acl_test.dart
@@ -1,0 +1,131 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:google_cloud_storage/google_cloud_storage.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+import 'package:test_utils/cloud.dart' as cloud;
+
+import 'test_utils.dart';
+
+void deleteBucketAclTest(Storage Function() createStorage) {
+  late Storage storage;
+
+  setUp(() {
+    storage = createStorage();
+  });
+
+  tearDown(() => storage.close());
+
+  test('success', () async {
+    final bucketName = await createBucketWithTearDown(
+      storage,
+      'del_bkt_acl_ok',
+      metadata: BucketMetadata(
+        iamConfiguration: BucketIamConfiguration(
+          uniformBucketLevelAccess: UniformBucketLevelAccess(enabled: false),
+        ),
+      ),
+    );
+
+    const entity = 'user-${cloud.googleTestUser}';
+    await storage.insertBucketAcl(bucketName, entity, 'READER');
+
+    await storage.deleteBucketAcl(bucketName, entity);
+
+    final metadata = await storage.bucketMetadata(
+      bucketName,
+      projection: 'full',
+    );
+
+    final testUserRoles = [
+      for (var i in metadata.acl ?? <BucketAccessControl>[])
+        if (i.entity == entity) (i.entity, i.role),
+    ];
+    expect(testUserRoles, isEmpty);
+  });
+
+  test('no bucket', () async {
+    expect(
+      () => storage.deleteBucketAcl('del_bkt_acl_no_bucket', 'allUsers'),
+      throwsA(isA<NotFoundException>()),
+    );
+  });
+
+  test('no acl', () async {
+    final bucketName = await createBucketWithTearDown(
+      storage,
+      'del_bkt_acl_no_acl',
+      metadata: BucketMetadata(
+        iamConfiguration: BucketIamConfiguration(
+          uniformBucketLevelAccess: UniformBucketLevelAccess(enabled: false),
+        ),
+      ),
+    );
+
+    const entity = 'user-${cloud.googleTestUser}';
+    expect(
+      () => storage.deleteBucketAcl(bucketName, entity),
+      throwsA(isA<NotFoundException>()),
+    );
+  });
+}
+
+void main() async {
+  group('delete bucket acl', () {
+    group('google-cloud', tags: ['google-cloud', 'no-ulba'], () {
+      deleteBucketAclTest(Storage.new);
+    });
+
+    group('storage-testbench', tags: ['storage-testbench'], () {
+      late Storage storage;
+      late RetryTestHttpClient client;
+
+      setUp(() {
+        client = RetryTestHttpClient(http.Client());
+        storage = Storage(
+          projectId: 'test-project',
+          apiEndpoint: 'localhost:9000',
+          useAuthWithCustomEndpoint: false,
+          client: client,
+        );
+      });
+
+      tearDown(() => storage.close());
+
+      deleteBucketAclTest(() => storage);
+    });
+
+    test('non-idempotent transport failure', () async {
+      var count = 0;
+      final mockClient = MockClient((request) async {
+        count++;
+        if (count == 1) {
+          throw http.ClientException('Some transport failure');
+        } else {
+          throw StateError('Unexpected call count: $count');
+        }
+      });
+
+      final storage = Storage(client: mockClient, projectId: 'fake project');
+
+      await expectLater(
+        storage.deleteBucketAcl('bucket', 'entity'),
+        throwsA(isA<http.ClientException>()),
+      );
+      expect(count, 1);
+    });
+  });
+}

--- a/pkgs/google_cloud_storage/test/delete_bucket_acl_test.dart
+++ b/pkgs/google_cloud_storage/test/delete_bucket_acl_test.dart
@@ -40,7 +40,11 @@ void deleteBucketAclTest(Storage Function() createStorage) {
       ),
     );
 
-    const entity = 'user-${cloud.googleTestUser}';
+    // The `iam.allowedPolicyMemberDomains` constraint on the test project does
+    // not allow `cloud.googleTestUser` to be an owner, so we use project
+    // viewers instead.
+    final initialMetadata = await storage.bucketMetadata(bucketName);
+    final entity = 'project-viewers-${initialMetadata.projectNumber}';
     await storage.insertBucketAcl(bucketName, entity, 'READER');
 
     await storage.deleteBucketAcl(bucketName, entity);
@@ -86,9 +90,7 @@ void deleteBucketAclTest(Storage Function() createStorage) {
 void main() async {
   group('delete bucket acl', () {
     group('google-cloud', tags: ['google-cloud', 'no-ulba'], () {
-      // TODO: run when the test project disables the
-      // `iam.allowedPolicyMemberDomains` constraint.
-      // deleteBucketAclTest(Storage.new);
+      deleteBucketAclTest(Storage.new);
     });
 
     group('storage-testbench', tags: ['storage-testbench'], () {

--- a/pkgs/google_cloud_storage/test/delete_bucket_acl_test.dart
+++ b/pkgs/google_cloud_storage/test/delete_bucket_acl_test.dart
@@ -86,7 +86,9 @@ void deleteBucketAclTest(Storage Function() createStorage) {
 void main() async {
   group('delete bucket acl', () {
     group('google-cloud', tags: ['google-cloud', 'no-ulba'], () {
-      deleteBucketAclTest(Storage.new);
+      // TODO: run when the test project disables the
+      // `iam.allowedPolicyMemberDomains` constraint.
+      // deleteBucketAclTest(Storage.new);
     });
 
     group('storage-testbench', tags: ['storage-testbench'], () {

--- a/pkgs/google_cloud_storage/test/get_bucket_acl_test.dart
+++ b/pkgs/google_cloud_storage/test/get_bucket_acl_test.dart
@@ -40,7 +40,11 @@ void getBucketAclTest(Storage Function() createStorage) {
       ),
     );
 
-    const entity = 'user-${cloud.googleTestUser}';
+    // The `iam.allowedPolicyMemberDomains` constraint on the test project does
+    // not allow `cloud.googleTestUser` to be an owner, so we use project
+    // viewers instead.
+    final initialMetadata = await storage.bucketMetadata(bucketName);
+    final entity = 'project-viewers-${initialMetadata.projectNumber}';
     await storage.insertBucketAcl(bucketName, entity, 'READER');
 
     final acl = await storage.getBucketAcl(bucketName, entity);
@@ -77,9 +81,7 @@ void getBucketAclTest(Storage Function() createStorage) {
 void main() async {
   group('get bucket acl', () {
     group('google-cloud', tags: ['google-cloud', 'no-ulba'], () {
-      // TODO: run when the test project disables the
-      // `iam.allowedPolicyMemberDomains` constraint.
-      // getBucketAclTest(Storage.new);
+      getBucketAclTest(Storage.new);
     });
 
     group('storage-testbench', tags: ['storage-testbench'], () {

--- a/pkgs/google_cloud_storage/test/get_bucket_acl_test.dart
+++ b/pkgs/google_cloud_storage/test/get_bucket_acl_test.dart
@@ -77,7 +77,7 @@ void getBucketAclTest(Storage Function() createStorage) {
 void main() async {
   group('get bucket acl', () {
     group('google-cloud', tags: ['google-cloud', 'no-ulba'], () {
-      // TODO: run when the test project disables the 
+      // TODO: run when the test project disables the
       // `iam.allowedPolicyMemberDomains` constraint.
       // getBucketAclTest(Storage.new);
     });

--- a/pkgs/google_cloud_storage/test/get_bucket_acl_test.dart
+++ b/pkgs/google_cloud_storage/test/get_bucket_acl_test.dart
@@ -1,0 +1,127 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:google_cloud_storage/google_cloud_storage.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+import 'package:test_utils/cloud.dart' as cloud;
+
+import 'test_utils.dart';
+
+void getBucketAclTest(Storage Function() createStorage) {
+  late Storage storage;
+
+  setUp(() {
+    storage = createStorage();
+  });
+
+  tearDown(() => storage.close());
+
+  test('success', () async {
+    final bucketName = await createBucketWithTearDown(
+      storage,
+      'get_bkt_acl_ok',
+      metadata: BucketMetadata(
+        iamConfiguration: BucketIamConfiguration(
+          uniformBucketLevelAccess: UniformBucketLevelAccess(enabled: false),
+        ),
+      ),
+    );
+
+    const entity = 'user-${cloud.googleTestUser}';
+    await storage.insertBucketAcl(bucketName, entity, 'READER');
+
+    final acl = await storage.getBucketAcl(bucketName, entity);
+    expect(acl.entity, entity);
+    expect(acl.role, 'READER');
+  });
+
+  test('no bucket', () async {
+    expect(
+      () => storage.getBucketAcl('get_bkt_acl_no_bucket', 'allUsers'),
+      throwsA(isA<NotFoundException>()),
+    );
+  });
+
+  test('no acl', () async {
+    final bucketName = await createBucketWithTearDown(
+      storage,
+      'get_bkt_acl_no_acl',
+      metadata: BucketMetadata(
+        iamConfiguration: BucketIamConfiguration(
+          uniformBucketLevelAccess: UniformBucketLevelAccess(enabled: false),
+        ),
+      ),
+    );
+
+    const entity = 'user-${cloud.googleTestUser}';
+    expect(
+      () => storage.getBucketAcl(bucketName, entity),
+      throwsA(isA<NotFoundException>()),
+    );
+  });
+}
+
+void main() async {
+  group('get bucket acl', () {
+    group('google-cloud', tags: ['google-cloud', 'no-ulba'], () {
+      getBucketAclTest(Storage.new);
+    });
+
+    group('storage-testbench', tags: ['storage-testbench'], () {
+      late Storage storage;
+      late RetryTestHttpClient client;
+
+      setUp(() {
+        client = RetryTestHttpClient(http.Client());
+        storage = Storage(
+          projectId: 'test-project',
+          apiEndpoint: 'localhost:9000',
+          useAuthWithCustomEndpoint: false,
+          client: client,
+        );
+      });
+
+      tearDown(() => storage.close());
+
+      getBucketAclTest(() => storage);
+    });
+
+    test('idempotent transport failure', () async {
+      var count = 0;
+      final mockClient = MockClient((request) async {
+        count++;
+        if (count == 1) {
+          throw http.ClientException('Some transport failure');
+        } else if (count == 2) {
+          return http.Response(
+            '{"kind": "storage#bucketAccessControl", '
+            '"entity": "user-test", "role": "READER"}',
+            200,
+          );
+        } else {
+          throw StateError('Unexpected call count: $count');
+        }
+      });
+
+      final storage = Storage(client: mockClient, projectId: 'fake project');
+
+      final acl = await storage.getBucketAcl('bucket', 'user-test');
+      expect(acl.entity, 'user-test');
+      expect(acl.role, 'READER');
+      expect(count, 2);
+    });
+  });
+}

--- a/pkgs/google_cloud_storage/test/get_bucket_acl_test.dart
+++ b/pkgs/google_cloud_storage/test/get_bucket_acl_test.dart
@@ -77,7 +77,9 @@ void getBucketAclTest(Storage Function() createStorage) {
 void main() async {
   group('get bucket acl', () {
     group('google-cloud', tags: ['google-cloud', 'no-ulba'], () {
-      getBucketAclTest(Storage.new);
+      // TODO: run when the test project disables the 
+      // `iam.allowedPolicyMemberDomains` constraint.
+      // getBucketAclTest(Storage.new);
     });
 
     group('storage-testbench', tags: ['storage-testbench'], () {

--- a/pkgs/google_cloud_storage/test/insert_bucket_acl_test.dart
+++ b/pkgs/google_cloud_storage/test/insert_bucket_acl_test.dart
@@ -1,0 +1,209 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:google_cloud_storage/google_cloud_storage.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+import 'package:test_utils/cloud.dart' as cloud;
+
+import 'test_utils.dart';
+
+void insertBucketAclTest(Storage Function() createStorage) {
+  late Storage storage;
+
+  setUp(() {
+    storage = createStorage();
+  });
+
+  tearDown(() => storage.close());
+
+  test('success', () async {
+    final bucketName = await createBucketWithTearDown(
+      storage,
+      'ins_bkt_acl_ok',
+      metadata: BucketMetadata(
+        iamConfiguration: BucketIamConfiguration(
+          uniformBucketLevelAccess: UniformBucketLevelAccess(enabled: false),
+        ),
+      ),
+    );
+
+    final acl = await storage.insertBucketAcl(
+      bucketName,
+      'user-${cloud.googleTestUser}',
+      'READER',
+    );
+
+    expect(acl.entity, 'user-${cloud.googleTestUser}');
+    expect(acl.role, 'READER');
+
+    final metadata = await storage.bucketMetadata(
+      bucketName,
+      projection: 'full',
+    );
+    final testUserRoles = [
+      for (var i in metadata.acl ?? <BucketAccessControl>[])
+        if (i.entity == 'user-${cloud.googleTestUser}') (i.entity, i.role),
+    ];
+    expect(testUserRoles, [('user-${cloud.googleTestUser}', 'READER')]);
+  });
+
+  test('reader then owner', () async {
+    final bucketName = await createBucketWithTearDown(
+      storage,
+      'ins_bkt_acl_ok',
+      metadata: BucketMetadata(
+        iamConfiguration: BucketIamConfiguration(
+          uniformBucketLevelAccess: UniformBucketLevelAccess(enabled: false),
+        ),
+      ),
+    );
+
+    await storage.insertBucketAcl(
+      bucketName,
+      'user-${cloud.googleTestUser}',
+      'READER',
+    );
+    await storage.insertBucketAcl(
+      bucketName,
+      'user-${cloud.googleTestUser}',
+      'OWNER',
+    );
+
+    final metadata = await storage.bucketMetadata(
+      bucketName,
+      projection: 'full',
+    );
+
+    final testUserRoles = [
+      for (var i in metadata.acl ?? <BucketAccessControl>[])
+        if (i.entity == 'user-${cloud.googleTestUser}') (i.entity, i.role),
+    ];
+    expect(testUserRoles, [('user-${cloud.googleTestUser}', 'OWNER')]);
+  });
+
+  test('owner then reader', () async {
+    final bucketName = await createBucketWithTearDown(
+      storage,
+      'ins_bkt_acl_ok',
+      metadata: BucketMetadata(
+        iamConfiguration: BucketIamConfiguration(
+          uniformBucketLevelAccess: UniformBucketLevelAccess(enabled: false),
+        ),
+      ),
+    );
+
+    await storage.insertBucketAcl(
+      bucketName,
+      'user-${cloud.googleTestUser}',
+      'OWNER',
+    );
+    await storage.insertBucketAcl(
+      bucketName,
+      'user-${cloud.googleTestUser}',
+      'READER',
+    );
+
+    final metadata = await storage.bucketMetadata(
+      bucketName,
+      projection: 'full',
+    );
+
+    final testUserRoles = [
+      for (var i in metadata.acl ?? <BucketAccessControl>[])
+        if (i.entity == 'user-${cloud.googleTestUser}') (i.entity, i.role),
+    ];
+    expect(testUserRoles, [('user-${cloud.googleTestUser}', 'READER')]);
+  });
+
+  test('not found', () async {
+    expect(
+      () => storage.insertBucketAcl(
+        'ins_bkt_acl_not_found_${DateTime.now().millisecondsSinceEpoch}',
+        'allUsers',
+        'READER',
+      ),
+      throwsA(isA<NotFoundException>()),
+    );
+  });
+
+  test('ubla enabled failure', () async {
+    final bucketName = await createBucketWithTearDown(
+      storage,
+      'ins_bkt_acl_ubla',
+      metadata: BucketMetadata(
+        iamConfiguration: BucketIamConfiguration(
+          uniformBucketLevelAccess: UniformBucketLevelAccess(enabled: true),
+        ),
+      ),
+    );
+
+    expect(
+      () => storage.insertBucketAcl(
+        bucketName,
+        'user-${cloud.googleTestUser}',
+        'READER',
+      ),
+      throwsA(isA<BadRequestException>()),
+    );
+  });
+}
+
+void main() async {
+  group('insert bucket acl', () {
+    group('google-cloud', tags: ['google-cloud', 'no-ulba'], () {
+      insertBucketAclTest(Storage.new);
+    });
+
+    group('storage-testbench', tags: ['storage-testbench'], () {
+      late Storage storage;
+      late RetryTestHttpClient client;
+
+      setUp(() {
+        client = RetryTestHttpClient(http.Client());
+        storage = Storage(
+          projectId: 'test-project',
+          apiEndpoint: 'localhost:9000',
+          useAuthWithCustomEndpoint: false,
+          client: client,
+        );
+      });
+
+      tearDown(() => storage.close());
+
+      insertBucketAclTest(() => storage);
+    });
+
+    test('non-idempotent transport failure', () async {
+      var count = 0;
+      final mockClient = MockClient((request) async {
+        count++;
+        if (count == 1) {
+          throw http.ClientException('Some transport failure');
+        } else {
+          throw StateError('Unexpected call count: $count');
+        }
+      });
+
+      final storage = Storage(client: mockClient, projectId: 'fake project');
+
+      await expectLater(
+        storage.insertBucketAcl('bucket', 'entity', 'role'),
+        throwsA(isA<http.ClientException>()),
+      );
+      expect(count, 1);
+    });
+  });
+}

--- a/pkgs/google_cloud_storage/test/insert_bucket_acl_test.dart
+++ b/pkgs/google_cloud_storage/test/insert_bucket_acl_test.dart
@@ -138,33 +138,38 @@ void insertBucketAclTest(Storage Function() createStorage) {
       throwsA(isA<NotFoundException>()),
     );
   });
-
-  test('ubla enabled failure', () async {
-    final bucketName = await createBucketWithTearDown(
-      storage,
-      'ins_bkt_acl_ubla',
-      metadata: BucketMetadata(
-        iamConfiguration: BucketIamConfiguration(
-          uniformBucketLevelAccess: UniformBucketLevelAccess(enabled: true),
-        ),
-      ),
-    );
-
-    expect(
-      () => storage.insertBucketAcl(
-        bucketName,
-        'user-${cloud.googleTestUser}',
-        'READER',
-      ),
-      throwsA(isA<BadRequestException>()),
-    );
-  });
 }
 
 void main() async {
   group('insert bucket acl', () {
     group('google-cloud', tags: ['google-cloud', 'no-ulba'], () {
-      insertBucketAclTest(Storage.new);
+      // TODO: run when the test project disables the
+      // `iam.allowedPolicyMemberDomains` constraint.
+      // insertBucketAclTest(Storage.new);
+
+      test('ubla enabled failure', () async {
+        // UBLA is not supposed in Storage Testbench
+        final storage = Storage();
+        addTearDown(storage.close);
+        final bucketName = await createBucketWithTearDown(
+          storage,
+          'ins_bkt_acl_ubla',
+          metadata: BucketMetadata(
+            iamConfiguration: BucketIamConfiguration(
+              uniformBucketLevelAccess: UniformBucketLevelAccess(enabled: true),
+            ),
+          ),
+        );
+
+        expect(
+          () => storage.insertBucketAcl(
+            bucketName,
+            'user-${cloud.googleTestUser}',
+            'READER',
+          ),
+          throwsA(isA<BadRequestException>()),
+        );
+      });
     });
 
     group('storage-testbench', tags: ['storage-testbench'], () {

--- a/pkgs/google_cloud_storage/test/insert_bucket_acl_test.dart
+++ b/pkgs/google_cloud_storage/test/insert_bucket_acl_test.dart
@@ -40,13 +40,15 @@ void insertBucketAclTest(Storage Function() createStorage) {
       ),
     );
 
-    final acl = await storage.insertBucketAcl(
-      bucketName,
-      'user-${cloud.googleTestUser}',
-      'READER',
-    );
+    // The `iam.allowedPolicyMemberDomains` constraint on the test project does
+    // not allow `cloud.googleTestUser` to be an owner, so we use project
+    // viewers instead.
+    final initialMetadata = await storage.bucketMetadata(bucketName);
+    final entity = 'project-viewers-${initialMetadata.projectNumber}';
 
-    expect(acl.entity, 'user-${cloud.googleTestUser}');
+    final acl = await storage.insertBucketAcl(bucketName, entity, 'READER');
+
+    expect(acl.entity, entity);
     expect(acl.role, 'READER');
 
     final metadata = await storage.bucketMetadata(
@@ -55,9 +57,9 @@ void insertBucketAclTest(Storage Function() createStorage) {
     );
     final testUserRoles = [
       for (var i in metadata.acl ?? <BucketAccessControl>[])
-        if (i.entity == 'user-${cloud.googleTestUser}') (i.entity, i.role),
+        if (i.entity == entity) (i.entity, i.role),
     ];
-    expect(testUserRoles, [('user-${cloud.googleTestUser}', 'READER')]);
+    expect(testUserRoles, [(entity, 'READER')]);
   });
 
   test('reader then owner', () async {
@@ -71,16 +73,11 @@ void insertBucketAclTest(Storage Function() createStorage) {
       ),
     );
 
-    await storage.insertBucketAcl(
-      bucketName,
-      'user-${cloud.googleTestUser}',
-      'READER',
-    );
-    await storage.insertBucketAcl(
-      bucketName,
-      'user-${cloud.googleTestUser}',
-      'OWNER',
-    );
+    final initialMetadata = await storage.bucketMetadata(bucketName);
+    final entity = 'project-viewers-${initialMetadata.projectNumber}';
+
+    await storage.insertBucketAcl(bucketName, entity, 'READER');
+    await storage.insertBucketAcl(bucketName, entity, 'OWNER');
 
     final metadata = await storage.bucketMetadata(
       bucketName,
@@ -89,9 +86,9 @@ void insertBucketAclTest(Storage Function() createStorage) {
 
     final testUserRoles = [
       for (var i in metadata.acl ?? <BucketAccessControl>[])
-        if (i.entity == 'user-${cloud.googleTestUser}') (i.entity, i.role),
+        if (i.entity == entity) (i.entity, i.role),
     ];
-    expect(testUserRoles, [('user-${cloud.googleTestUser}', 'OWNER')]);
+    expect(testUserRoles, [(entity, 'OWNER')]);
   });
 
   test('owner then reader', () async {
@@ -105,16 +102,11 @@ void insertBucketAclTest(Storage Function() createStorage) {
       ),
     );
 
-    await storage.insertBucketAcl(
-      bucketName,
-      'user-${cloud.googleTestUser}',
-      'OWNER',
-    );
-    await storage.insertBucketAcl(
-      bucketName,
-      'user-${cloud.googleTestUser}',
-      'READER',
-    );
+    final initialMetadata = await storage.bucketMetadata(bucketName);
+    final entity = 'project-viewers-${initialMetadata.projectNumber}';
+
+    await storage.insertBucketAcl(bucketName, entity, 'OWNER');
+    await storage.insertBucketAcl(bucketName, entity, 'READER');
 
     final metadata = await storage.bucketMetadata(
       bucketName,
@@ -123,9 +115,9 @@ void insertBucketAclTest(Storage Function() createStorage) {
 
     final testUserRoles = [
       for (var i in metadata.acl ?? <BucketAccessControl>[])
-        if (i.entity == 'user-${cloud.googleTestUser}') (i.entity, i.role),
+        if (i.entity == entity) (i.entity, i.role),
     ];
-    expect(testUserRoles, [('user-${cloud.googleTestUser}', 'READER')]);
+    expect(testUserRoles, [(entity, 'READER')]);
   });
 
   test('not found', () async {
@@ -143,9 +135,7 @@ void insertBucketAclTest(Storage Function() createStorage) {
 void main() async {
   group('insert bucket acl', () {
     group('google-cloud', tags: ['google-cloud', 'no-ulba'], () {
-      // TODO: run when the test project disables the
-      // `iam.allowedPolicyMemberDomains` constraint.
-      // insertBucketAclTest(Storage.new);
+      insertBucketAclTest(Storage.new);
 
       test('ubla enabled failure', () async {
         // UBLA is not supposed in Storage Testbench

--- a/pkgs/google_cloud_storage/test/list_bucket_acl_test.dart
+++ b/pkgs/google_cloud_storage/test/list_bucket_acl_test.dart
@@ -16,7 +16,6 @@ import 'package:google_cloud_storage/google_cloud_storage.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:test/test.dart';
-import 'package:test_utils/cloud.dart' as cloud;
 
 import 'test_utils.dart';
 
@@ -40,7 +39,11 @@ void listBucketAclTest(Storage Function() createStorage) {
       ),
     );
 
-    const entity = 'user-${cloud.googleTestUser}';
+    // The `iam.allowedPolicyMemberDomains` constraint on the test project does
+    // not allow `cloud.googleTestUser` to be an owner, so we use project
+    // viewers instead.
+    final initialMetadata = await storage.bucketMetadata(bucketName);
+    final entity = 'project-viewers-${initialMetadata.projectNumber}';
     await storage.insertBucketAcl(bucketName, entity, 'READER');
 
     final aclList = await storage.listBucketAcl(bucketName);
@@ -63,9 +66,7 @@ void listBucketAclTest(Storage Function() createStorage) {
 void main() async {
   group('list bucket acl', () {
     group('google-cloud', tags: ['google-cloud', 'no-ulba'], () {
-      // TODO: run when the test project disables the
-      // `iam.allowedPolicyMemberDomains` constraint.
-      // listBucketAclTest(Storage.new);
+      listBucketAclTest(Storage.new);
     });
 
     group('storage-testbench', tags: ['storage-testbench'], () {

--- a/pkgs/google_cloud_storage/test/list_bucket_acl_test.dart
+++ b/pkgs/google_cloud_storage/test/list_bucket_acl_test.dart
@@ -1,0 +1,115 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:google_cloud_storage/google_cloud_storage.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+import 'package:test_utils/cloud.dart' as cloud;
+
+import 'test_utils.dart';
+
+void listBucketAclTest(Storage Function() createStorage) {
+  late Storage storage;
+
+  setUp(() {
+    storage = createStorage();
+  });
+
+  tearDown(() => storage.close());
+
+  test('success', () async {
+    final bucketName = await createBucketWithTearDown(
+      storage,
+      'list_bkt_acl_ok',
+      metadata: BucketMetadata(
+        iamConfiguration: BucketIamConfiguration(
+          uniformBucketLevelAccess: UniformBucketLevelAccess(enabled: false),
+        ),
+      ),
+    );
+
+    const entity = 'user-${cloud.googleTestUser}';
+    await storage.insertBucketAcl(bucketName, entity, 'READER');
+
+    final aclList = await storage.listBucketAcl(bucketName);
+    expect(aclList, isNotEmpty);
+
+    final testUserAcl = aclList.firstWhere((i) => i.entity == entity);
+    expect(testUserAcl.role, 'READER');
+  });
+
+  test('no bucket', () async {
+    expect(
+      () => storage.listBucketAcl(
+        'list_bkt_acl_no_bucket_${DateTime.now().millisecondsSinceEpoch}',
+      ),
+      throwsA(isA<NotFoundException>()),
+    );
+  });
+}
+
+void main() async {
+  group('list bucket acl', () {
+    group('google-cloud', tags: ['google-cloud', 'no-ulba'], () {
+      listBucketAclTest(Storage.new);
+    });
+
+    group('storage-testbench', tags: ['storage-testbench'], () {
+      late Storage storage;
+      late RetryTestHttpClient client;
+
+      setUp(() {
+        client = RetryTestHttpClient(http.Client());
+        storage = Storage(
+          projectId: 'test-project',
+          apiEndpoint: 'localhost:9000',
+          useAuthWithCustomEndpoint: false,
+          client: client,
+        );
+      });
+
+      tearDown(() => storage.close());
+
+      listBucketAclTest(() => storage);
+    });
+
+    test('idempotent transport failure', () async {
+      var count = 0;
+      final mockClient = MockClient((request) async {
+        count++;
+        if (count == 1) {
+          throw http.ClientException('Some transport failure');
+        } else if (count == 2) {
+          return http.Response(
+            '{"kind": "storage#bucketAccessControls", "items": '
+            '[{"kind": "storage#bucketAccessControl", "entity": '
+            '"user-test", "role": "READER"}]}',
+            200,
+          );
+        } else {
+          throw StateError('Unexpected call count: $count');
+        }
+      });
+
+      final storage = Storage(client: mockClient, projectId: 'fake project');
+
+      final aclList = await storage.listBucketAcl('bucket');
+      expect(aclList, hasLength(1));
+      expect(aclList.first.entity, 'user-test');
+      expect(aclList.first.role, 'READER');
+      expect(count, 2);
+    });
+  });
+}

--- a/pkgs/google_cloud_storage/test/list_bucket_acl_test.dart
+++ b/pkgs/google_cloud_storage/test/list_bucket_acl_test.dart
@@ -63,7 +63,9 @@ void listBucketAclTest(Storage Function() createStorage) {
 void main() async {
   group('list bucket acl', () {
     group('google-cloud', tags: ['google-cloud', 'no-ulba'], () {
-      listBucketAclTest(Storage.new);
+      // TODO: run when the test project disables the
+      // `iam.allowedPolicyMemberDomains` constraint.
+      // listBucketAclTest(Storage.new);
     });
 
     group('storage-testbench', tags: ['storage-testbench'], () {

--- a/pkgs/google_cloud_storage/test/list_object_acl_test.dart
+++ b/pkgs/google_cloud_storage/test/list_object_acl_test.dart
@@ -136,7 +136,9 @@ void listObjectAclTest(Storage Function() createStorage) {
 void main() async {
   group('list object acl', () {
     group('google-cloud', tags: ['google-cloud', 'no-ulba'], () {
-      listObjectAclTest(Storage.new);
+      // TODO: run when the test project disables the
+      // `iam.allowedPolicyMemberDomains` constraint.
+      // listObjectAclTest(Storage.new);
     });
 
     group('storage-testbench', tags: ['storage-testbench'], () {

--- a/pkgs/google_cloud_storage/test/list_object_acl_test.dart
+++ b/pkgs/google_cloud_storage/test/list_object_acl_test.dart
@@ -136,9 +136,7 @@ void listObjectAclTest(Storage Function() createStorage) {
 void main() async {
   group('list object acl', () {
     group('google-cloud', tags: ['google-cloud', 'no-ulba'], () {
-      // TODO: run when the test project disables the
-      // `iam.allowedPolicyMemberDomains` constraint.
-      // listObjectAclTest(Storage.new);
+      listObjectAclTest(Storage.new);
     });
 
     group('storage-testbench', tags: ['storage-testbench'], () {

--- a/pkgs/google_cloud_storage/test/patch_bucket_acl_test.dart
+++ b/pkgs/google_cloud_storage/test/patch_bucket_acl_test.dart
@@ -16,7 +16,6 @@ import 'package:google_cloud_storage/google_cloud_storage.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:test/test.dart';
-import 'package:test_utils/cloud.dart' as cloud;
 
 import 'test_utils.dart';
 
@@ -40,7 +39,11 @@ void patchBucketAclTest(Storage Function() createStorage) {
       ),
     );
 
-    const entity = 'user-${cloud.googleTestUser}';
+    // The `iam.allowedPolicyMemberDomains` constraint on the test project does
+    // not allow `cloud.googleTestUser` to be an owner, so we use project
+    // viewers instead.
+    final initialMetadata = await storage.bucketMetadata(bucketName);
+    final entity = 'project-viewers-${initialMetadata.projectNumber}';
     await storage.insertBucketAcl(bucketName, entity, 'READER');
 
     final acl = await storage.patchBucketAcl(bucketName, entity, 'OWNER');
@@ -70,9 +73,7 @@ void patchBucketAclTest(Storage Function() createStorage) {
 void main() async {
   group('patch bucket acl', () {
     group('google-cloud', tags: ['google-cloud', 'no-ulba'], () {
-      // TODO: run when the test project disables the
-      // `iam.allowedPolicyMemberDomains` constraint.
-      // patchBucketAclTest(Storage.new);
+      patchBucketAclTest(Storage.new);
     });
 
     group('storage-testbench', tags: ['storage-testbench'], () {

--- a/pkgs/google_cloud_storage/test/patch_bucket_acl_test.dart
+++ b/pkgs/google_cloud_storage/test/patch_bucket_acl_test.dart
@@ -70,7 +70,9 @@ void patchBucketAclTest(Storage Function() createStorage) {
 void main() async {
   group('patch bucket acl', () {
     group('google-cloud', tags: ['google-cloud', 'no-ulba'], () {
-      patchBucketAclTest(Storage.new);
+      // TODO: run when the test project disables the
+      // `iam.allowedPolicyMemberDomains` constraint.
+      // patchBucketAclTest(Storage.new);
     });
 
     group('storage-testbench', tags: ['storage-testbench'], () {

--- a/pkgs/google_cloud_storage/test/patch_bucket_acl_test.dart
+++ b/pkgs/google_cloud_storage/test/patch_bucket_acl_test.dart
@@ -1,0 +1,115 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:google_cloud_storage/google_cloud_storage.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+import 'package:test_utils/cloud.dart' as cloud;
+
+import 'test_utils.dart';
+
+void patchBucketAclTest(Storage Function() createStorage) {
+  late Storage storage;
+
+  setUp(() {
+    storage = createStorage();
+  });
+
+  tearDown(() => storage.close());
+
+  test('success', () async {
+    final bucketName = await createBucketWithTearDown(
+      storage,
+      'patch_bkt_acl_ok',
+      metadata: BucketMetadata(
+        iamConfiguration: BucketIamConfiguration(
+          uniformBucketLevelAccess: UniformBucketLevelAccess(enabled: false),
+        ),
+      ),
+    );
+
+    const entity = 'user-${cloud.googleTestUser}';
+    await storage.insertBucketAcl(bucketName, entity, 'READER');
+
+    final acl = await storage.patchBucketAcl(bucketName, entity, 'OWNER');
+    expect(acl.entity, entity);
+    expect(acl.role, 'OWNER');
+
+    final metadata = await storage.bucketMetadata(
+      bucketName,
+      projection: 'full',
+    );
+    final testUserAcl = metadata.acl!.firstWhere((i) => i.entity == entity);
+    expect(testUserAcl.role, 'OWNER');
+  });
+
+  test('no bucket', () async {
+    expect(
+      () => storage.patchBucketAcl(
+        'patch_bkt_acl_no_bucket_${DateTime.now().millisecondsSinceEpoch}',
+        'allUsers',
+        'READER',
+      ),
+      throwsA(isA<NotFoundException>()),
+    );
+  });
+}
+
+void main() async {
+  group('patch bucket acl', () {
+    group('google-cloud', tags: ['google-cloud', 'no-ulba'], () {
+      patchBucketAclTest(Storage.new);
+    });
+
+    group('storage-testbench', tags: ['storage-testbench'], () {
+      late Storage storage;
+      late RetryTestHttpClient client;
+
+      setUp(() {
+        client = RetryTestHttpClient(http.Client());
+        storage = Storage(
+          projectId: 'test-project',
+          apiEndpoint: 'localhost:9000',
+          useAuthWithCustomEndpoint: false,
+          client: client,
+        );
+      });
+
+      tearDown(() => storage.close());
+
+      patchBucketAclTest(() => storage);
+    });
+
+    test('non-idempotent transport failure', () async {
+      var count = 0;
+      final mockClient = MockClient((request) async {
+        count++;
+        if (count == 1) {
+          throw http.ClientException('Some transport failure');
+        } else {
+          throw StateError('Unexpected call count: $count');
+        }
+      });
+
+      final storage = Storage(client: mockClient, projectId: 'fake project');
+
+      await expectLater(
+        storage.patchBucketAcl('bucket', 'entity', 'role'),
+        throwsA(isA<http.ClientException>()),
+      );
+      expect(count, 1);
+    });
+  });
+}

--- a/pkgs/google_cloud_storage/test/update_bucket_acl_test.dart
+++ b/pkgs/google_cloud_storage/test/update_bucket_acl_test.dart
@@ -1,0 +1,115 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:google_cloud_storage/google_cloud_storage.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+import 'package:test_utils/cloud.dart' as cloud;
+
+import 'test_utils.dart';
+
+void updateBucketAclTest(Storage Function() createStorage) {
+  late Storage storage;
+
+  setUp(() {
+    storage = createStorage();
+  });
+
+  tearDown(() => storage.close());
+
+  test('success', () async {
+    final bucketName = await createBucketWithTearDown(
+      storage,
+      'upd_bkt_acl_ok',
+      metadata: BucketMetadata(
+        iamConfiguration: BucketIamConfiguration(
+          uniformBucketLevelAccess: UniformBucketLevelAccess(enabled: false),
+        ),
+      ),
+    );
+
+    const entity = 'user-${cloud.googleTestUser}';
+    await storage.insertBucketAcl(bucketName, entity, 'READER');
+
+    final acl = await storage.updateBucketAcl(bucketName, entity, 'OWNER');
+    expect(acl.entity, entity);
+    expect(acl.role, 'OWNER');
+
+    final metadata = await storage.bucketMetadata(
+      bucketName,
+      projection: 'full',
+    );
+    final testUserAcl = metadata.acl!.firstWhere((i) => i.entity == entity);
+    expect(testUserAcl.role, 'OWNER');
+  });
+
+  test('no bucket', () async {
+    expect(
+      () => storage.updateBucketAcl(
+        'upd_bkt_acl_no_bucket_${DateTime.now().millisecondsSinceEpoch}',
+        'allUsers',
+        'READER',
+      ),
+      throwsA(isA<NotFoundException>()),
+    );
+  });
+}
+
+void main() async {
+  group('update bucket acl', () {
+    group('google-cloud', tags: ['google-cloud', 'no-ulba'], () {
+      updateBucketAclTest(Storage.new);
+    });
+
+    group('storage-testbench', tags: ['storage-testbench'], () {
+      late Storage storage;
+      late RetryTestHttpClient client;
+
+      setUp(() {
+        client = RetryTestHttpClient(http.Client());
+        storage = Storage(
+          projectId: 'test-project',
+          apiEndpoint: 'localhost:9000',
+          useAuthWithCustomEndpoint: false,
+          client: client,
+        );
+      });
+
+      tearDown(() => storage.close());
+
+      updateBucketAclTest(() => storage);
+    });
+
+    test('non-idempotent transport failure', () async {
+      var count = 0;
+      final mockClient = MockClient((request) async {
+        count++;
+        if (count == 1) {
+          throw http.ClientException('Some transport failure');
+        } else {
+          throw StateError('Unexpected call count: $count');
+        }
+      });
+
+      final storage = Storage(client: mockClient, projectId: 'fake project');
+
+      await expectLater(
+        storage.updateBucketAcl('bucket', 'entity', 'role'),
+        throwsA(isA<http.ClientException>()),
+      );
+      expect(count, 1);
+    });
+  });
+}

--- a/pkgs/google_cloud_storage/test/update_bucket_acl_test.dart
+++ b/pkgs/google_cloud_storage/test/update_bucket_acl_test.dart
@@ -70,7 +70,9 @@ void updateBucketAclTest(Storage Function() createStorage) {
 void main() async {
   group('update bucket acl', () {
     group('google-cloud', tags: ['google-cloud', 'no-ulba'], () {
-      updateBucketAclTest(Storage.new);
+      // TODO: run when the test project disables the
+      // `iam.allowedPolicyMemberDomains` constraint.
+      // updateBucketAclTest(Storage.new);
     });
 
     group('storage-testbench', tags: ['storage-testbench'], () {

--- a/pkgs/google_cloud_storage/test/update_bucket_acl_test.dart
+++ b/pkgs/google_cloud_storage/test/update_bucket_acl_test.dart
@@ -16,7 +16,6 @@ import 'package:google_cloud_storage/google_cloud_storage.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:test/test.dart';
-import 'package:test_utils/cloud.dart' as cloud;
 
 import 'test_utils.dart';
 
@@ -40,7 +39,11 @@ void updateBucketAclTest(Storage Function() createStorage) {
       ),
     );
 
-    const entity = 'user-${cloud.googleTestUser}';
+    // The `iam.allowedPolicyMemberDomains` constraint on the test project does
+    // not allow `cloud.googleTestUser` to be an owner, so we use project
+    // viewers instead.
+    final initialMetadata = await storage.bucketMetadata(bucketName);
+    final entity = 'project-viewers-${initialMetadata.projectNumber}';
     await storage.insertBucketAcl(bucketName, entity, 'READER');
 
     final acl = await storage.updateBucketAcl(bucketName, entity, 'OWNER');
@@ -70,9 +73,7 @@ void updateBucketAclTest(Storage Function() createStorage) {
 void main() async {
   group('update bucket acl', () {
     group('google-cloud', tags: ['google-cloud', 'no-ulba'], () {
-      // TODO: run when the test project disables the
-      // `iam.allowedPolicyMemberDomains` constraint.
-      // updateBucketAclTest(Storage.new);
+      updateBucketAclTest(Storage.new);
     });
 
     group('storage-testbench', tags: ['storage-testbench'], () {


### PR DESCRIPTION
Adds the following methods to `Storage`:
- `deleteBucketAcl`
- `getBucketAcl`
- `insertBucketAcl`
- `listBucketAcl`
- `patchBucketAcl`
- `updateBucketAcl`

Very much cloned from https://github.com/googleapis/google-cloud-dart/pull/270
