### PR TITLE
chore(storage): Prepare to release 0.6.2

### DIFF
--- a/pkgs/google_cloud_storage/CHANGELOG.md
+++ b/pkgs/google_cloud_storage/CHANGELOG.md
@@ -17,7 +17,7 @@
   * `patchObjectAcl`
   * `updateObjectAcl`.
 * Add `Storage.makeObjectPublic`.
-* Add `StorageObject.makeObjectPublic`.
+* Add StorageObject.makePublic.
 
 ## 0.6.1
 

--- a/pkgs/google_cloud_storage/CHANGELOG.md
+++ b/pkgs/google_cloud_storage/CHANGELOG.md
@@ -17,7 +17,7 @@
   * `patchObjectAcl`
   * `updateObjectAcl`
 * Add `Storage.makeObjectPublic`.
-* Add StorageObject.makePublic.
+* Add `StorageObject.makePublic`.
 
 ## 0.6.1
 

--- a/pkgs/google_cloud_storage/CHANGELOG.md
+++ b/pkgs/google_cloud_storage/CHANGELOG.md
@@ -1,11 +1,23 @@
-## 0.6.2-wip
+## 0.6.2
 
 * Add retries to `uploadObjectFromSink`.
-* Add `deleteBucketAcl`, `getBucketAcl`, `insertBucketAcl`,
-  `listBucketAcl`, `patchBucketAcl`, and `updateBucketAcl`.
-* Add `deleteObjectAcl`, `getObjectAcl`, `listObjectAcl`, `patchObjectAcl`,
-  and `updateObjectAcl`.
-* Add `makeObjectPublic`.
+* Add `Storage.moveObject`.
+* Add `StorageObject.move`.
+* Add new `Storage` methods for bucket ACLs:
+  * `deleteBucketAcl`
+  * `getBucketAcl`
+  * `insertBucketAcl`
+  * `listBucketAcl`
+  * `patchBucketAcl`
+  * `updateBucketAcl`.
+* Add new `Storage` methods for object ACLs:
+  * `deleteObjectAcl`
+  * `getObjectAcl`
+  * `listObjectAcl`
+  * `patchObjectAcl`
+  * `updateObjectAcl`.
+* Add `Storage.makeObjectPublic`.
+* Add `StorageObject.makeObjectPublic`.
 
 ## 0.6.1
 

--- a/pkgs/google_cloud_storage/CHANGELOG.md
+++ b/pkgs/google_cloud_storage/CHANGELOG.md
@@ -9,13 +9,13 @@
   * `insertBucketAcl`
   * `listBucketAcl`
   * `patchBucketAcl`
-  * `updateBucketAcl`.
+  * `updateBucketAcl`
 * Add new `Storage` methods for object ACLs:
   * `deleteObjectAcl`
   * `getObjectAcl`
   * `listObjectAcl`
   * `patchObjectAcl`
-  * `updateObjectAcl`.
+  * `updateObjectAcl`
 * Add `Storage.makeObjectPublic`.
 * Add `StorageObject.makeObjectPublic`.
 

--- a/pkgs/google_cloud_storage/pubspec.yaml
+++ b/pkgs/google_cloud_storage/pubspec.yaml
@@ -16,7 +16,7 @@ name: google_cloud_storage
 description: >-
   A client for Google Cloud Storage, a managed service for storing, archiving,
   and serving unstructured data of any size.
-version: 0.6.2-wip
+version: 0.6.2
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/pkgs/google_cloud_storage
 
 environment:
@@ -30,7 +30,7 @@ dependencies:
   convert: ^3.1.2
   crypto: ^3.0.7
   ffi: ^2.2.0
-  google_cloud: '>=0.3.0 <0.5.0'
+  google_cloud: '>=0.3.0 <0.6.0'
   google_cloud_protobuf: ^0.5.0
   google_cloud_rpc: ^0.5.0
   googleapis_auth: ^2.0.0


### PR DESCRIPTION
* Remove `-wip` from CHANGELOG.md/pubspec.yaml
* Clean up CHANGELOG.md
* Open up version range of supported google_cloud