### PR TITLE
chore(cloud): prepare to release 0.5.0

### DIFF
--- a/pkgs/google_cloud/CHANGELOG.md
+++ b/pkgs/google_cloud/CHANGELOG.md
@@ -24,6 +24,9 @@
 
 ### `general.dart`
 
+- **BREAKING:** No longer exports logging features. Use
+  [`package:google_cloud_logging`](https://pub.dev/packages/google_cloud_logging)
+  instead.
 - **DEPRECATED:** Use `google_cloud.dart` instead.
 
 ### `http_serving.dart`

--- a/pkgs/google_cloud/CHANGELOG.md
+++ b/pkgs/google_cloud/CHANGELOG.md
@@ -4,11 +4,16 @@
 
 ### `general.dart`
 
-- DEPRECATED. Use `google_cloud.dart` instead.
+- **DEPRECATED:** Use `google_cloud.dart` instead.
+- **BREAKING:** All logging-related features are now in the new
+  [`package:google_cloud_logging`](https://pub.dev/packages/google_cloud_logging)
+  package.
 
 ### `http_serving.dart`
 
-- REMOVED everything. These features are now in the new [`package:google_cloud_shelf`](https://pub.dev/packages/google_cloud_shelf) package.
+- **BREAKING:** These features are now in the new
+  [`package:google_cloud_shelf`](https://pub.dev/packages/google_cloud_shelf)
+  package.
 
 ## 0.4.1
 

--- a/pkgs/google_cloud/CHANGELOG.md
+++ b/pkgs/google_cloud/CHANGELOG.md
@@ -1,7 +1,4 @@
-<!--
-TODO: This is going to be a breaking change release, but we need to bump deps
--->
-## 0.4.2-wip
+## 0.5.0
 
 ### `google_cloud.dart`: now is the primary exporter of the core APIs.
 

--- a/pkgs/google_cloud/CHANGELOG.md
+++ b/pkgs/google_cloud/CHANGELOG.md
@@ -1,17 +1,35 @@
 ## 0.5.0
 
-### `google_cloud.dart`: now is the primary exporter of the core APIs.
+### `google_cloud.dart`
+
+- **BREAKING:** No longer exports logging or HTTP serving features.
+  These are now exported by the new packages:
+
+  - [`package:google_cloud_logging`](https://pub.dev/packages/google_cloud_logging)
+  - [`package:google_cloud_shelf`](https://pub.dev/packages/google_cloud_shelf)
+
+### `constants.dart`
+
+- **BREAKING:** Removed logging and serving related constants:
+
+  - `portEnvironmentVariable`
+  - `defaultListenPort`
+  - `cloudTraceContextHeader`
+  - `logTraceKey`
+  - `logSpanIdKey`
+  - `logTraceSampledKey`
+
+  These constants are available in the new
+  [`package:google_cloud_shelf`](https://pub.dev/packages/google_cloud_shelf).
 
 ### `general.dart`
 
 - **DEPRECATED:** Use `google_cloud.dart` instead.
-- **BREAKING:** All logging-related features are now in the new
-  [`package:google_cloud_logging`](https://pub.dev/packages/google_cloud_logging)
-  package.
 
 ### `http_serving.dart`
 
-- **BREAKING:** These features are now in the new
+- **BREAKING:** Library file has been removed entirely. All HTTP serving
+  features are now in the new
   [`package:google_cloud_shelf`](https://pub.dev/packages/google_cloud_shelf)
   package.
 

--- a/pkgs/google_cloud/pubspec.yaml
+++ b/pkgs/google_cloud/pubspec.yaml
@@ -12,7 +12,6 @@ dependencies:
   collection: ^1.19.0
   http: ^1.1.0
   meta: ^1.17.0
-  shelf: ^1.4.0
   stack_trace: ^1.11.0
 
 dev_dependencies:

--- a/pkgs/google_cloud/pubspec.yaml
+++ b/pkgs/google_cloud/pubspec.yaml
@@ -1,7 +1,7 @@
 name: google_cloud
 description: >-
   Utilities for running Dart code correctly on the Google Cloud Platform.
-version: 0.4.2-wip
+version: 0.5.0
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/pkgs/google_cloud
 
 resolution: workspace


### PR DESCRIPTION
- Sets release version to `0.5.0`.
- Removes the obsolete dependency on `package:shelf`.
- Some wordsmithing on the `0.5.0` `CHANGELOG.md` entry.