### PR TITLE
feat(logging): `package:logging` integration

### DIFF
--- a/pkgs/google_cloud_logging/CHANGELOG.md
+++ b/pkgs/google_cloud_logging/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.1
+## 0.5.1-wip
 
 - Add integrations for `package:logging`.
 

--- a/pkgs/google_cloud_logging/CHANGELOG.md
+++ b/pkgs/google_cloud_logging/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.1
+
+- Add integrations for `package:logging`.
+
 ## 0.5.0
 
 - Added `CloudLogger`

--- a/pkgs/google_cloud_logging/README.md
+++ b/pkgs/google_cloud_logging/README.md
@@ -69,7 +69,7 @@ void main() {
 This allows you to generate structured logs for Google Cloud without changing
 the logging in the rest of your application and libraries.
 
-<?code-excerpt "example/logging.dart (cloud-logger)"?>
+<?code-excerpt "example/logging.dart"?>
 ```dart
 import 'package:google_cloud_logging/google_cloud_logging.dart';
 import 'package:logging/logging.dart';

--- a/pkgs/google_cloud_logging/README.md
+++ b/pkgs/google_cloud_logging/README.md
@@ -61,13 +61,11 @@ void main() {
 }
 ```
 
-### Using CloudLogging with `package:logging`
+### Integrating with `package:logging`
 
-`CloudLogger` can be installed as a handler for 
-[`package:logging`](https://pub.dev/packages/logging).
+`CloudLogger` can be used as a global handler for the standard [`package:logging`](https://pub.dev/packages/logging) package.
 
-This allows you to generate structured logs for Google Cloud without changing
-the logging in the rest of your application and libraries.
+This allows you to output structured logs for Google Cloud automatically without changing any existing logging code in your application or its dependencies.
 
 <?code-excerpt "example/logging.dart"?>
 ```dart

--- a/pkgs/google_cloud_logging/README.md
+++ b/pkgs/google_cloud_logging/README.md
@@ -61,4 +61,26 @@ void main() {
 }
 ```
 
+### Using CloudLogging with `package:logging`
+
+`CloudLogger` can be installed as a handler for 
+[`package:logging`](https://pub.dev/packages/logging).
+
+This allows you to generate structured logs for Google Cloud without changing
+the logging in the rest of your application and libraries.
+
+<?code-excerpt "example/logging.dart (cloud-logger)"?>
+```dart
+import 'package:google_cloud_logging/google_cloud_logging.dart';
+import 'package:logging/logging.dart';
+
+void main() {
+  const cloudLogger = CloudLogger.structuredLogger();
+  Logger.root.onRecord.listen(cloudLogger.handleLog);
+  Logger.root.level = Level.ALL;
+
+  Logger('MyClassName').fine('Starting file copy.');
+}
+```
+
 [issues]: https://github.com/googleapis/google-cloud-dart/issues

--- a/pkgs/google_cloud_logging/example/logging.dart
+++ b/pkgs/google_cloud_logging/example/logging.dart
@@ -1,0 +1,10 @@
+import 'package:google_cloud_logging/google_cloud_logging.dart';
+import 'package:logging/logging.dart';
+
+void main() {
+  const cloudLogger = CloudLogger.structuredLogger();
+  Logger.root.onRecord.listen(cloudLogger.handleLog);
+  Logger.root.level = Level.ALL;
+
+  Logger('MyClassName').fine('Starting file copy.');
+}

--- a/pkgs/google_cloud_logging/lib/src/logger.dart
+++ b/pkgs/google_cloud_logging/lib/src/logger.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'package:google_cloud_logging_type/logging_type.dart' as logging_type;
+import 'package:logging/logging.dart';
 
 import 'structured_logging.dart' show createStructuredLog, formatStackTrace;
 
@@ -29,6 +30,25 @@ abstract base class CloudLogger {
   /// Creates a logger that outputs log messages in Cloud Logging structured
   /// format.
   const factory CloudLogger.structuredLogger() = _StructuredLogger;
+
+  void handleLog(LogRecord record) {
+    final method = switch (record.level) {
+      Level.FINE || Level.FINER || Level.FINEST => debug,
+      Level.INFO => info,
+      Level.WARNING => warning,
+      Level.SEVERE => error,
+      Level.SHOUT => emergency,
+      _ => error,
+    };
+    final object = record.object;
+    final errorObject = record.error;
+
+    method(
+      object ?? record.message,
+      payload: errorObject == null ? null : {'error': errorObject},
+      stackTrace: record.stackTrace,
+    );
+  }
 
   /// Logs a message at the given [severity].
   ///

--- a/pkgs/google_cloud_logging/lib/src/logger.dart
+++ b/pkgs/google_cloud_logging/lib/src/logger.dart
@@ -51,8 +51,10 @@ abstract base class CloudLogger {
   /// ```
   void handleLog(LogRecord record) {
     final method = switch (record.level) {
+      // Where both levels have the same name, they are mapped together.
+      // Arguably, `Level.CONFIG` (700) should map to `info` (200) and
+      // `Level.INFO` (800) should map to `notice` (300).
       <= Level.FINE => debug,
-      <= Level.CONFIG => notice,
       <= Level.INFO => info,
       <= Level.WARNING => warning,
       <= Level.SEVERE => error,

--- a/pkgs/google_cloud_logging/lib/src/logger.dart
+++ b/pkgs/google_cloud_logging/lib/src/logger.dart
@@ -31,6 +31,24 @@ abstract base class CloudLogger {
   /// format.
   const factory CloudLogger.structuredLogger() = _StructuredLogger;
 
+  /// A handler for streams of [LogRecord] provided by a `package:logging`
+  /// [Logger].
+  ///
+  /// You can configure `package:logging` to use `CloudLogger` globally with
+  /// this code:
+  ///
+  /// ```dart
+  /// import 'package:google_cloud_logging/google_cloud_logging.dart';
+  /// import 'package:logging/logging.dart';
+  ///
+  /// void main() {
+  ///   const cloudLogger = CloudLogger.structuredLogger();
+  ///   Logger.root.onRecord.listen(cloudLogger.handleLog);
+  ///   Logger.root.level = Level.ALL;
+  ///
+  ///   // Use `package:logging` as normal.
+  /// }
+  /// ```
   void handleLog(LogRecord record) {
     final method = switch (record.level) {
       Level.FINE || Level.FINER || Level.FINEST => debug,

--- a/pkgs/google_cloud_logging/lib/src/logger.dart
+++ b/pkgs/google_cloud_logging/lib/src/logger.dart
@@ -34,8 +34,8 @@ abstract base class CloudLogger {
   /// A handler for streams of [LogRecord] provided by a `package:logging`
   /// [Logger].
   ///
-  /// You can configure `package:logging` to use `CloudLogger` globally with
-  /// this code:
+  /// You can configure `package:logging` to redirect all logs globally with
+  /// this setup:
   ///
   /// ```dart
   /// import 'package:google_cloud_logging/google_cloud_logging.dart';
@@ -51,12 +51,11 @@ abstract base class CloudLogger {
   /// ```
   void handleLog(LogRecord record) {
     final method = switch (record.level) {
-      Level.FINE || Level.FINER || Level.FINEST => debug,
-      Level.INFO => info,
-      Level.WARNING => warning,
-      Level.SEVERE => error,
-      Level.SHOUT => emergency,
-      _ => error,
+      <= Level.FINE => debug,
+      <= Level.INFO => info,
+      <= Level.WARNING => warning,
+      <= Level.SEVERE => error,
+      _ => emergency,
     };
     final object = record.object;
     final errorObject = record.error;

--- a/pkgs/google_cloud_logging/lib/src/logger.dart
+++ b/pkgs/google_cloud_logging/lib/src/logger.dart
@@ -52,17 +52,19 @@ abstract base class CloudLogger {
   void handleLog(LogRecord record) {
     final method = switch (record.level) {
       <= Level.FINE => debug,
+      <= Level.CONFIG => notice,
       <= Level.INFO => info,
       <= Level.WARNING => warning,
       <= Level.SEVERE => error,
       _ => emergency,
     };
-    final object = record.object;
-    final errorObject = record.error;
-
+    final payload = {
+      'error': ?record.error,
+      if (record.loggerName.isNotEmpty) 'logger': record.loggerName,
+    };
     method(
-      object ?? record.message,
-      payload: errorObject == null ? null : {'error': errorObject},
+      record.object ?? record.message,
+      payload: payload.isNotEmpty ? payload : null,
       stackTrace: record.stackTrace,
     );
   }

--- a/pkgs/google_cloud_logging/pubspec.yaml
+++ b/pkgs/google_cloud_logging/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_cloud_logging
 description: >-
   Structured logging for Google Cloud environments with trace correlation
   and automatic formatting.
-version: 0.5.0
+version: 0.5.1-wip
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/pkgs/google_cloud_logging
 
 resolution: workspace

--- a/pkgs/google_cloud_logging/pubspec.yaml
+++ b/pkgs/google_cloud_logging/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   google_cloud_logging_type: ^0.5.2
   google_cloud_logging_v2: ^0.5.2
   google_cloud_protobuf: ^0.5.2
+  logging: ^1.3.0
   meta: ^1.18.2
   stack_trace: ^1.11.0
 

--- a/pkgs/google_cloud_logging/test/logging_test.dart
+++ b/pkgs/google_cloud_logging/test/logging_test.dart
@@ -24,40 +24,40 @@ void main() {
   group('CloudLogger.printLogger()', () {
     test('string message', () async {
       const cloudLogger = CloudLogger.printLogger();
-      final log = Logger('CloudLogger');
+      final log = Logger('MyClass');
 
       await expectLater(() async {
         log.onRecord.listen(cloudLogger.handleLog);
         log.info('hello');
         await Future<void>.delayed(const Duration(milliseconds: 10));
-      }, prints('INFO: hello\n'));
+      }, prints('INFO: hello\nPayload: {logger: MyClass}\n'));
     });
 
     test('object message', () async {
       const cloudLogger = CloudLogger.printLogger();
-      final log = Logger('CloudLogger');
+      final log = Logger('MyClass');
 
       await expectLater(() async {
         log.onRecord.listen(cloudLogger.handleLog);
         log.info([1, 2, 3]);
         await Future<void>.delayed(const Duration(milliseconds: 10));
-      }, prints('INFO: [1, 2, 3]\n'));
+      }, prints('INFO: [1, 2, 3]\nPayload: {logger: MyClass}\n'));
     });
 
     test('with error', () async {
       const cloudLogger = CloudLogger.printLogger();
-      final log = Logger('CloudLogger');
+      final log = Logger('MyClass');
 
       await expectLater(() async {
         log.onRecord.listen(cloudLogger.handleLog);
         log.info('hello', [1, 2, 3]);
         await Future<void>.delayed(const Duration(milliseconds: 10));
-      }, prints('INFO: hello\nPayload: {error: [1, 2, 3]}\n'));
+      }, prints('INFO: hello\nPayload: {error: [1, 2, 3], logger: MyClass}\n'));
     });
 
     test('with stacktrace', testOn: '!browser', () async {
       const cloudLogger = CloudLogger.printLogger();
-      final log = Logger('CloudLogger');
+      final log = Logger('MyClass');
       final caught = catchingFunction();
 
       await expectLater(
@@ -67,16 +67,31 @@ void main() {
           await Future<void>.delayed(const Duration(milliseconds: 10));
         },
         prints(
-          allOf(startsWith('INFO: hello\n'), contains('test/test_utils.dart')),
+          allOf(
+            startsWith('INFO: hello\n'),
+            contains('test/test_utils.dart'),
+            endsWith('Payload: {logger: MyClass}\n'),
+          ),
         ),
       );
+    });
+
+    test('empty logger name', () async {
+      const cloudLogger = CloudLogger.printLogger();
+      final log = Logger('');
+
+      await expectLater(() async {
+        log.onRecord.listen(cloudLogger.handleLog);
+        log.info('hello');
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }, prints('INFO: hello\n'));
     });
   });
 
   group('CloudLogger.structuredLogger()', () {
     test('string message', () async {
       const cloudLogger = CloudLogger.structuredLogger();
-      final log = Logger('CloudLogger');
+      final log = Logger('MyClass');
 
       await expectLater(
         () async {
@@ -88,7 +103,7 @@ void main() {
           isA<String>().having(
             (s) => jsonDecode(s) as Map<String, Object?>,
             'parsed json',
-            {'message': 'hello', 'severity': 'INFO'},
+            {'message': 'hello', 'severity': 'INFO', 'logger': 'MyClass'},
           ),
         ),
       );
@@ -96,7 +111,7 @@ void main() {
 
     test('object message', () async {
       const cloudLogger = CloudLogger.structuredLogger();
-      final log = Logger('CloudLogger');
+      final log = Logger('MyClass');
 
       await expectLater(
         () async {
@@ -111,6 +126,7 @@ void main() {
             {
               'message': [1, 2, 3],
               'severity': 'INFO',
+              'logger': 'MyClass',
             },
           ),
         ),
@@ -119,7 +135,7 @@ void main() {
 
     test('with error', () async {
       const cloudLogger = CloudLogger.structuredLogger();
-      final log = Logger('CloudLogger');
+      final log = Logger('MyClass');
 
       await expectLater(
         () async {
@@ -135,6 +151,7 @@ void main() {
               'message': 'hello',
               'severity': 'INFO',
               'error': [1, 2, 3],
+              'logger': 'MyClass',
             },
           ),
         ),
@@ -143,7 +160,7 @@ void main() {
 
     test('with stacktrace', testOn: '!browser', () async {
       const cloudLogger = CloudLogger.structuredLogger();
-      final log = Logger('CloudLogger');
+      final log = Logger('MyClass');
       final caught = catchingFunction();
 
       await expectLater(
@@ -159,6 +176,7 @@ void main() {
             {
               'message': 'hello',
               'severity': 'INFO',
+              'logger': 'MyClass',
               'stack_trace': contains('logging_test.dart'),
               'logging.googleapis.com/sourceLocation': {
                 'file': endsWith('test_utils.dart'),
@@ -170,6 +188,26 @@ void main() {
                 ),
               },
             },
+          ),
+        ),
+      );
+    });
+
+    test('empty logger name', () async {
+      const cloudLogger = CloudLogger.structuredLogger();
+      final log = Logger('');
+
+      await expectLater(
+        () async {
+          log.onRecord.listen(cloudLogger.handleLog);
+          log.info('hello');
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+        },
+        prints(
+          isA<String>().having(
+            (s) => jsonDecode(s) as Map<String, Object?>,
+            'parsed json',
+            {'message': 'hello', 'severity': 'INFO'},
           ),
         ),
       );

--- a/pkgs/google_cloud_logging/test/logging_test.dart
+++ b/pkgs/google_cloud_logging/test/logging_test.dart
@@ -1,0 +1,178 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+
+import 'package:google_cloud_logging/google_cloud_logging.dart';
+import 'package:logging/logging.dart';
+import 'package:test/test.dart';
+
+import 'test_utils.dart';
+
+void main() {
+  group('CloudLogger.printLogger()', () {
+    test('string message', () async {
+      const cloudLogger = CloudLogger.printLogger();
+      final log = Logger('CloudLogger');
+
+      await expectLater(() async {
+        log.onRecord.listen(cloudLogger.handleLog);
+        log.info('hello');
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }, prints('INFO: hello\n'));
+    });
+
+    test('object message', () async {
+      const cloudLogger = CloudLogger.printLogger();
+      final log = Logger('CloudLogger');
+
+      await expectLater(() async {
+        log.onRecord.listen(cloudLogger.handleLog);
+        log.info([1, 2, 3]);
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }, prints('INFO: [1, 2, 3]\n'));
+    });
+
+    test('with error', () async {
+      const cloudLogger = CloudLogger.printLogger();
+      final log = Logger('CloudLogger');
+
+      await expectLater(() async {
+        log.onRecord.listen(cloudLogger.handleLog);
+        log.info('hello', [1, 2, 3]);
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }, prints('INFO: hello\nPayload: {error: [1, 2, 3]}\n'));
+    });
+
+    test('with stacktrace', testOn: '!browser', () async {
+      const cloudLogger = CloudLogger.printLogger();
+      final log = Logger('CloudLogger');
+      final caught = catchingFunction();
+
+      await expectLater(
+        () async {
+          log.onRecord.listen(cloudLogger.handleLog);
+          log.info('hello', null, caught.stackTrace);
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+        },
+        prints(
+          allOf(startsWith('INFO: hello\n'), contains('test/test_utils.dart')),
+        ),
+      );
+    });
+  });
+
+  group('CloudLogger.structuredLogger()', () {
+    test('string message', () async {
+      const cloudLogger = CloudLogger.structuredLogger();
+      final log = Logger('CloudLogger');
+
+      await expectLater(
+        () async {
+          log.onRecord.listen(cloudLogger.handleLog);
+          log.info('hello');
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+        },
+        prints(
+          isA<String>().having(
+            (s) => jsonDecode(s) as Map<String, Object?>,
+            'parsed json',
+            {'message': 'hello', 'severity': 'INFO'},
+          ),
+        ),
+      );
+    });
+
+    test('object message', () async {
+      const cloudLogger = CloudLogger.structuredLogger();
+      final log = Logger('CloudLogger');
+
+      await expectLater(
+        () async {
+          log.onRecord.listen(cloudLogger.handleLog);
+          log.info([1, 2, 3]);
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+        },
+        prints(
+          isA<String>().having(
+            (s) => jsonDecode(s) as Map<String, Object?>,
+            'parsed json',
+            {
+              'message': [1, 2, 3],
+              'severity': 'INFO',
+            },
+          ),
+        ),
+      );
+    });
+
+    test('with error', () async {
+      const cloudLogger = CloudLogger.structuredLogger();
+      final log = Logger('CloudLogger');
+
+      await expectLater(
+        () async {
+          log.onRecord.listen(cloudLogger.handleLog);
+          log.info('hello', [1, 2, 3]);
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+        },
+        prints(
+          isA<String>().having(
+            (s) => jsonDecode(s) as Map<String, Object?>,
+            'parsed json',
+            {
+              'message': 'hello',
+              'severity': 'INFO',
+              'error': [1, 2, 3],
+            },
+          ),
+        ),
+      );
+    });
+
+    test('with stacktrace', testOn: '!browser', () async {
+      const cloudLogger = CloudLogger.structuredLogger();
+      final log = Logger('CloudLogger');
+      final caught = catchingFunction();
+
+      await expectLater(
+        () async {
+          log.onRecord.listen(cloudLogger.handleLog);
+          log.info('hello', null, caught.stackTrace);
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+        },
+        prints(
+          isA<String>().having(
+            (s) => jsonDecode(s) as Map<String, Object?>,
+            'parsed json',
+            {
+              'message': 'hello',
+              'severity': 'INFO',
+              'stack_trace': contains('logging_test.dart'),
+              'logging.googleapis.com/sourceLocation': {
+                'file': endsWith('test_utils.dart'),
+                'function': endsWith('throwingFunction'),
+                'line': isA<String>().having(
+                  int.parse,
+                  'parsed line',
+                  greaterThan(1),
+                ),
+              },
+            },
+          ),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Allows this:

```dart
import 'package:google_cloud_logging/google_cloud_logging.dart';
import 'package:logging/logging.dart';

void main() {
  const cloudLogger = CloudLogger.structuredLogger();
  Logger.root.onRecord.listen(cloudLogger.handleLog);
  Logger.root.level = Level.ALL;

  Logger('MyClassName').fine('Starting file copy.');
}
```