### PR TITLE
test(shelf): added integration tests for `print`

### DIFF
--- a/.gcb/builds/grants/main.tf
+++ b/.gcb/builds/grants/main.tf
@@ -42,6 +42,20 @@ resource "google_project_iam_member" "sa-can-use-logging" {
   member  = "serviceAccount:${data.google_service_account.integration-test-runner.email}"
 }
 
+# The service account needs to generate ID tokens for invoking private Cloud Run services.
+resource "google_project_iam_member" "sa-can-create-tokens" {
+  project = data.google_project.project.id
+  role    = "roles/iam.serviceAccountTokenCreator"
+  member  = "serviceAccount:${data.google_service_account.integration-test-runner.email}"
+}
+
+# The service account needs to invoke Cloud Run services for the logging tests.
+resource "google_project_iam_member" "sa-can-invoke-run" {
+  project = data.google_project.project.id
+  role    = "roles/run.invoker"
+  member  = "serviceAccount:${data.google_service_account.integration-test-runner.email}"
+}
+
 output "runner" {
   value = data.google_service_account.integration-test-runner.id
 }

--- a/.gcb/builds/grants/main.tf
+++ b/.gcb/builds/grants/main.tf
@@ -42,20 +42,6 @@ resource "google_project_iam_member" "sa-can-use-logging" {
   member  = "serviceAccount:${data.google_service_account.integration-test-runner.email}"
 }
 
-# The service account needs to generate ID tokens for invoking private Cloud Run services.
-resource "google_project_iam_member" "sa-can-create-tokens" {
-  project = data.google_project.project.id
-  role    = "roles/iam.serviceAccountTokenCreator"
-  member  = "serviceAccount:${data.google_service_account.integration-test-runner.email}"
-}
-
-# The service account needs to invoke Cloud Run services for the logging tests.
-resource "google_project_iam_member" "sa-can-invoke-run" {
-  project = data.google_project.project.id
-  role    = "roles/run.invoker"
-  member  = "serviceAccount:${data.google_service_account.integration-test-runner.email}"
-}
-
 output "runner" {
   value = data.google_service_account.integration-test-runner.id
 }

--- a/.gcb/integration.yaml
+++ b/.gcb/integration.yaml
@@ -24,7 +24,7 @@ options:
 serviceAccount: 'projects/${PROJECT_ID}/serviceAccounts/integration-test-runner@${PROJECT_ID}.iam.gserviceaccount.com'
 steps:
   - id: Run integration tests
-    name: 'dart:stable'
+    name: 'google/cloud-sdk:latest'
     args: ['.gcb/scripts/integration.sh']
     secretEnv: ['GITHUB_TOKEN']
     env:

--- a/.gcb/scripts/integration.sh
+++ b/.gcb/scripts/integration.sh
@@ -26,5 +26,5 @@ apt-get update && apt-get install -y dart
 export PATH="$PATH:/usr/lib/dart/bin"
 
 dart pub get
-dart test pkgs/google_cloud_shelf/test/logging_test.dart -P google-cloud
+dart test . -P google-cloud
 

--- a/.gcb/scripts/integration.sh
+++ b/.gcb/scripts/integration.sh
@@ -26,5 +26,5 @@ apt-get update && apt-get install -y dart
 export PATH="$PATH:/usr/lib/dart/bin"
 
 dart pub get
-dart test . -P google-cloud
+dart test pkgs/google_cloud_shelf/test/logging_test.dart -P google-cloud
 

--- a/.gcb/scripts/integration.sh
+++ b/.gcb/scripts/integration.sh
@@ -16,5 +16,15 @@
 
 set -e
 
+# Install Dart SDK using the process detailed here:
+# https://dart.dev/get-dart#install
+apt-get update && apt-get install -y apt-transport-https curl gnupg
+curl -fsSL https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/dart.gpg
+echo 'deb [signed-by=/usr/share/keyrings/dart.gpg] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' > /etc/apt/sources.list.d/dart.list
+apt-get update && apt-get install -y dart
+
+export PATH="$PATH:/usr/lib/dart/bin"
+
 dart pub get
 dart test . -P google-cloud
+

--- a/pkgs/google_cloud_shelf/pubspec.yaml
+++ b/pkgs/google_cloud_shelf/pubspec.yaml
@@ -19,5 +19,9 @@ dependencies:
   stack_trace: ^1.12.1
 
 dev_dependencies:
+  google_cloud_logging_v2: any
+  googleapis_auth: ^2.3.1
   test: ^1.31.0
   test_process: ^2.0.3
+  test_utils: any
+

--- a/pkgs/google_cloud_shelf/pubspec.yaml
+++ b/pkgs/google_cloud_shelf/pubspec.yaml
@@ -12,6 +12,7 @@ environment:
   sdk: ^3.9.0
 
 dependencies:
+  google_cloud: any
   google_cloud_logging: ^0.5.0
   http: ^1.6.0
   meta: ^1.18.2

--- a/pkgs/google_cloud_shelf/pubspec.yaml
+++ b/pkgs/google_cloud_shelf/pubspec.yaml
@@ -12,7 +12,6 @@ environment:
   sdk: ^3.9.0
 
 dependencies:
-  google_cloud: any
   google_cloud_logging: ^0.5.0
   http: ^1.6.0
   meta: ^1.18.2
@@ -20,6 +19,7 @@ dependencies:
   stack_trace: ^1.12.1
 
 dev_dependencies:
+  google_cloud: any
   google_cloud_logging_v2: any
   googleapis_auth: ^2.3.1
   test: ^1.31.0

--- a/pkgs/google_cloud_shelf/test/logging_server.dart
+++ b/pkgs/google_cloud_shelf/test/logging_server.dart
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:io';
+import 'package:google_cloud/google_cloud.dart';
 import 'package:google_cloud_shelf/google_cloud_shelf.dart';
 import 'package:shelf/shelf.dart';
 
 void main() async {
-  final projectId = Platform.environment['GOOGLE_CLOUD_PROJECT'];
+  final projectId = await computeProjectId();
 
   final handler = const Pipeline()
       .addMiddleware(createLoggingMiddleware(projectId: projectId))

--- a/pkgs/google_cloud_shelf/test/logging_server.dart
+++ b/pkgs/google_cloud_shelf/test/logging_server.dart
@@ -1,0 +1,35 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:io';
+import 'package:google_cloud_shelf/google_cloud_shelf.dart';
+import 'package:shelf/shelf.dart';
+
+void main() async {
+  final projectId = Platform.environment['GOOGLE_CLOUD_PROJECT'];
+
+  final handler = const Pipeline()
+      .addMiddleware(createLoggingMiddleware(projectId: projectId))
+      .addHandler((Request request) {
+        if (request.url.path == 'print') {
+          final msg =
+              request.requestedUri.queryParameters['msg'] ?? 'default print';
+          print(msg);
+          return Response.ok('Printed: $msg');
+        }
+        return Response.ok('Hello from E2E Server!');
+      });
+
+  await serveHandler(handler);
+}

--- a/pkgs/google_cloud_shelf/test/logging_server.dart
+++ b/pkgs/google_cloud_shelf/test/logging_server.dart
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// A simple server to validate the logging middleware.
+library;
+
 import 'package:google_cloud/google_cloud.dart';
 import 'package:google_cloud_shelf/google_cloud_shelf.dart';
 import 'package:shelf/shelf.dart';
@@ -28,7 +31,7 @@ void main() async {
           print(msg);
           return Response.ok('Printed: $msg');
         }
-        return Response.ok('Hello from E2E Server!');
+        return Response.ok('Hello World!');
       });
 
   await serveHandler(handler);

--- a/pkgs/google_cloud_shelf/test/logging_test.dart
+++ b/pkgs/google_cloud_shelf/test/logging_test.dart
@@ -232,12 +232,19 @@ Details:
     test('print', () async {
       final uniqueId = 'Hello World: ${randomAlphaNumString(20)}';
 
+      final headers = <String, String>{};
+      final token = await runner.getIdToken();
+      if (token != null) {
+        headers['Authorization'] = 'Bearer $token';
+      }
+
       // Trigger a print.
       final response = await http.get(
         runner.serverUri.replace(
           path: '/print',
           queryParameters: {'msg': uniqueId},
         ),
+        headers: headers,
       );
       expect(response.statusCode, 200);
 

--- a/pkgs/google_cloud_shelf/test/logging_test.dart
+++ b/pkgs/google_cloud_shelf/test/logging_test.dart
@@ -20,9 +20,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:google_cloud_logging/google_cloud_logging.dart';
-import 'package:google_cloud_logging_v2/logging.dart';
 import 'package:google_cloud_shelf/google_cloud_shelf.dart';
-import 'package:googleapis_auth/auth_io.dart' as auth;
 import 'package:http/http.dart' as http;
 import 'package:shelf/shelf.dart';
 import 'package:test/test.dart';
@@ -242,55 +240,14 @@ Details:
       );
       expect(response.statusCode, 200);
 
-      // 2. Authenticate with GCP Cloud Logging API
-      final client = await auth.clientViaApplicationDefaultCredentials(
-        scopes: ['https://www.googleapis.com/auth/cloud-platform'],
-      );
-      final loggingService = LoggingServiceV2(client: client);
+      final entries = await waitForLogs('textPayload:"$uniqueId"', 10);
 
-      // 3. Query Cloud Logging for the print statement
-      final request = ListLogEntriesRequest(
-        resourceNames: ['projects/$projectId'],
-        filter: 'textPayload:"$uniqueId" OR jsonPayload.message:"$uniqueId"',
-        orderBy: 'timestamp desc',
-        pageSize: 10,
-      );
-
-      var found = false;
-      // Ingestion can take a few seconds, so we poll with retries
-      for (var attempt = 1; attempt <= 15; attempt++) {
-        await Future<void>.delayed(const Duration(seconds: 4));
-        try {
-          final listResult = await loggingService.listLogEntries(request);
-          print(listResult.entries);
-          if (listResult.entries.isNotEmpty) {
-            found = true;
-            final entry = listResult.entries.first;
-            print('Successfully found log entry on attempt $attempt:');
-            if (entry.jsonPayload != null) {
-              print(entry.jsonPayload!.toJson());
-              final payloadMap =
-                  entry.jsonPayload!.toJson() as Map<String, dynamic>;
-              expect(payloadMap['message'], contains(uniqueId));
-            } else if (entry.textPayload != null) {
-              print(entry.textPayload);
-              expect(entry.textPayload, contains(uniqueId));
-            }
-            break;
-          }
-        } catch (e) {
-          print('Attempt $attempt failed with error: $e');
-        }
-      }
-
-      loggingService.close();
-      expect(
-        found,
-        isTrue,
-        reason:
-            'Log entry with unique ID "$uniqueId" was '
-            'not found in Cloud Logging within timeout',
-      );
+      expect(entries, isNotEmpty);
+      final entry = entries.first;
+      expect(entry.textPayload, uniqueId);
+      expect(entry.severity, LogSeverity.info);
+      expect(entry.trace, startsWith('projects/$projectId/traces/'));
+      expect(entry.spanId, isNotEmpty);
     });
   });
 }

--- a/pkgs/google_cloud_shelf/test/logging_test.dart
+++ b/pkgs/google_cloud_shelf/test/logging_test.dart
@@ -232,19 +232,13 @@ Details:
     test('print', () async {
       final uniqueId = 'Hello World: ${randomAlphaNumString(20)}';
 
-      final headers = <String, String>{};
-      final token = await runner.getIdToken();
-      if (token != null) {
-        headers['Authorization'] = 'Bearer $token';
-      }
-
       // Trigger a print.
       final response = await http.get(
         runner.serverUri.replace(
           path: '/print',
           queryParameters: {'msg': uniqueId},
         ),
-        headers: headers,
+        headers: await runner.headers(),
       );
       expect(response.statusCode, 200);
 

--- a/pkgs/google_cloud_shelf/test/logging_test.dart
+++ b/pkgs/google_cloud_shelf/test/logging_test.dart
@@ -235,7 +235,10 @@ Details:
       final headers = <String, String>{};
       final token = await runner.getIdToken();
       if (token != null) {
+        print('Retrieved token (first 20 chars): ${token.substring(0, 20)}...');
         headers['Authorization'] = 'Bearer $token';
+      } else {
+        print('No token retrieved!');
       }
 
       // Trigger a print.

--- a/pkgs/google_cloud_shelf/test/logging_test.dart
+++ b/pkgs/google_cloud_shelf/test/logging_test.dart
@@ -20,9 +20,13 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:google_cloud_logging/google_cloud_logging.dart';
+import 'package:google_cloud_logging_v2/logging.dart';
 import 'package:google_cloud_shelf/google_cloud_shelf.dart';
+import 'package:googleapis_auth/auth_io.dart' as auth;
+import 'package:http/http.dart' as http;
 import 'package:shelf/shelf.dart';
 import 'package:test/test.dart';
+import 'package:test_utils/cloud.dart';
 
 const internalServerErrorMessage = 'Internal Server Error';
 
@@ -211,6 +215,83 @@ Details:
 
     // Wait a bit for the timer to fire and ensure no crash happens.
     await Future<void>.delayed(const Duration(milliseconds: 10));
+  });
+
+  group('logging server', tags: 'google-cloud', () {
+    late CloudRunner runner;
+
+    setUpAll(() async {
+      runner = await CloudRunner.start(
+        'pkgs/google_cloud_shelf/test/logging_server.dart',
+      );
+    });
+
+    tearDownAll(() async {
+      await runner.stop();
+    });
+
+    test('print', () async {
+      final uniqueId = 'e2e-print-msg-${DateTime.now().microsecondsSinceEpoch}';
+
+      // Trigger a print.
+      final response = await http.get(
+        runner.serverUri.replace(
+          path: '/print',
+          queryParameters: {'msg': uniqueId},
+        ),
+      );
+      expect(response.statusCode, 200);
+
+      // 2. Authenticate with GCP Cloud Logging API
+      final client = await auth.clientViaApplicationDefaultCredentials(
+        scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+      );
+      final loggingService = LoggingServiceV2(client: client);
+
+      // 3. Query Cloud Logging for the print statement
+      final request = ListLogEntriesRequest(
+        resourceNames: ['projects/$projectId'],
+        filter: 'textPayload:"$uniqueId" OR jsonPayload.message:"$uniqueId"',
+        orderBy: 'timestamp desc',
+        pageSize: 10,
+      );
+
+      var found = false;
+      // Ingestion can take a few seconds, so we poll with retries
+      for (var attempt = 1; attempt <= 15; attempt++) {
+        await Future<void>.delayed(const Duration(seconds: 4));
+        try {
+          final listResult = await loggingService.listLogEntries(request);
+          print(listResult.entries);
+          if (listResult.entries.isNotEmpty) {
+            found = true;
+            final entry = listResult.entries.first;
+            print('Successfully found log entry on attempt $attempt:');
+            if (entry.jsonPayload != null) {
+              print(entry.jsonPayload!.toJson());
+              final payloadMap =
+                  entry.jsonPayload!.toJson() as Map<String, dynamic>;
+              expect(payloadMap['message'], contains(uniqueId));
+            } else if (entry.textPayload != null) {
+              print(entry.textPayload);
+              expect(entry.textPayload, contains(uniqueId));
+            }
+            break;
+          }
+        } catch (e) {
+          print('Attempt $attempt failed with error: $e');
+        }
+      }
+
+      loggingService.close();
+      expect(
+        found,
+        isTrue,
+        reason:
+            'Log entry with unique ID "$uniqueId" was '
+            'not found in Cloud Logging within timeout',
+      );
+    });
   });
 }
 

--- a/pkgs/google_cloud_shelf/test/logging_test.dart
+++ b/pkgs/google_cloud_shelf/test/logging_test.dart
@@ -25,6 +25,7 @@ import 'package:http/http.dart' as http;
 import 'package:shelf/shelf.dart';
 import 'package:test/test.dart';
 import 'package:test_utils/cloud.dart';
+import 'package:test_utils/random.dart';
 
 const internalServerErrorMessage = 'Internal Server Error';
 
@@ -229,7 +230,7 @@ Details:
     });
 
     test('print', () async {
-      final uniqueId = 'e2e-print-msg-${DateTime.now().microsecondsSinceEpoch}';
+      final uniqueId = 'Hello World: ${randomAlphaNumString(20)}';
 
       // Trigger a print.
       final response = await http.get(
@@ -240,7 +241,7 @@ Details:
       );
       expect(response.statusCode, 200);
 
-      final entries = await waitForLogs('textPayload:"$uniqueId"', 10);
+      final entries = await waitForLogs('textPayload:"$uniqueId"');
 
       expect(entries, isNotEmpty);
       final entry = entries.first;

--- a/pkgs/google_cloud_shelf/test/logging_test.dart
+++ b/pkgs/google_cloud_shelf/test/logging_test.dart
@@ -235,10 +235,7 @@ Details:
       final headers = <String, String>{};
       final token = await runner.getIdToken();
       if (token != null) {
-        print('Retrieved token (first 20 chars): ${token.substring(0, 20)}...');
         headers['Authorization'] = 'Bearer $token';
-      } else {
-        print('No token retrieved!');
       }
 
       // Trigger a print.

--- a/test_utils/lib/cloud.dart
+++ b/test_utils/lib/cloud.dart
@@ -13,3 +13,4 @@
 // limitations under the License.
 
 export 'src/cloud.dart';
+export 'src/cloud_runner.dart';

--- a/test_utils/lib/random.dart
+++ b/test_utils/lib/random.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test_utils/lib/random.dart
+++ b/test_utils/lib/random.dart
@@ -1,0 +1,15 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export 'src/random.dart';

--- a/test_utils/lib/src/cloud.dart
+++ b/test_utils/lib/src/cloud.dart
@@ -28,6 +28,14 @@ String get projectId =>
     Platform.environment['GOOGLE_CLOUD_PROJECT'] ??
     (throw StateError('Missing environment variable: GOOGLE_CLOUD_PROJECT'));
 
+/// Whether the project is the test project used by Google Cloud Build.
+bool get isTestProject => projectId == 'dart-sdk-testing';
+
+/// The service used by the Google Cloud build test project.
+const serviceAccount =
+    'projects/dart-sdk-testing/serviceAccounts/'
+    'integration-test-runner@dart-sdk-testing.iam.gserviceaccount.com';
+
 /// Return log entries matching [filter].
 ///
 /// Waits up to [timeout] for matching log entries to be available.

--- a/test_utils/lib/src/cloud.dart
+++ b/test_utils/lib/src/cloud.dart
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 import 'dart:io';
+import 'package:google_cloud_logging_v2/logging.dart';
+import 'package:googleapis_auth/auth_io.dart' as auth;
 
 /// A real Google test account managed by bquinlan@google.com using Rhea.
 const googleTestUser = 'daenerysstone.938939@gmail.com';
@@ -25,3 +27,39 @@ const googleTestUser = 'daenerysstone.938939@gmail.com';
 String get projectId =>
     Platform.environment['GOOGLE_CLOUD_PROJECT'] ??
     (throw StateError('Missing environment variable: GOOGLE_CLOUD_PROJECT'));
+
+/// Polls Cloud Logging until log entries matching [filter]
+/// are returned.
+///
+/// [filter] must be in [Logging query language][1]. For example,
+/// `'textPayload:"Hello World"'`.
+///
+/// [1]: (https://docs.cloud.google.com/logging/docs/view/logging-query-language)
+Future<List<LogEntry>> waitForLogs(String filter, int count) async {
+  final client = await auth.clientViaApplicationDefaultCredentials(
+    scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+  );
+  final loggingService = LoggingServiceV2(client: client);
+
+  final request = ListLogEntriesRequest(
+    resourceNames: ['projects/$projectId'],
+    filter: filter,
+    orderBy: 'timestamp desc',
+    pageSize: count,
+  );
+
+  try {
+    for (var attempt = 0; attempt <= 10; attempt++) {
+      await Future<void>.delayed(const Duration(seconds: 2));
+      final listResult = await loggingService.listLogEntries(request);
+      if (listResult.entries.isNotEmpty) {
+        return listResult.entries;
+      }
+    }
+    throw StateError(
+      'Log entries matching "$filter" were not found within the timeout.',
+    );
+  } finally {
+    loggingService.close();
+  }
+}

--- a/test_utils/lib/src/cloud.dart
+++ b/test_utils/lib/src/cloud.dart
@@ -45,17 +45,16 @@ Future<List<LogEntry>> waitForLogs(
     scopes: ['https://www.googleapis.com/auth/cloud-platform'],
   );
   final loggingService = LoggingServiceV2(client: client);
-
-  final request = ListLogEntriesRequest(
-    resourceNames: ['projects/$projectId'],
-    filter: filter,
-    orderBy: 'timestamp desc',
-    pageSize: count,
-  );
-
-  final endTime = DateTime.now().add(timeout);
-
   try {
+    final request = ListLogEntriesRequest(
+      resourceNames: ['projects/$projectId'],
+      filter: filter,
+      orderBy: 'timestamp desc',
+      pageSize: count,
+    );
+
+    final endTime = DateTime.now().add(timeout);
+
     var first = true;
     do {
       if (!first) {

--- a/test_utils/lib/src/cloud.dart
+++ b/test_utils/lib/src/cloud.dart
@@ -28,14 +28,19 @@ String get projectId =>
     Platform.environment['GOOGLE_CLOUD_PROJECT'] ??
     (throw StateError('Missing environment variable: GOOGLE_CLOUD_PROJECT'));
 
-/// Polls Cloud Logging until log entries matching [filter]
-/// are returned.
+/// Return log entries matching [filter].
+///
+/// Waits up to [timeout] for matching log entries to be available.
 ///
 /// [filter] must be in [Logging query language][1]. For example,
 /// `'textPayload:"Hello World"'`.
 ///
 /// [1]: (https://docs.cloud.google.com/logging/docs/view/logging-query-language)
-Future<List<LogEntry>> waitForLogs(String filter, int count) async {
+Future<List<LogEntry>> waitForLogs(
+  String filter, {
+  int count = 10,
+  Duration timeout = const Duration(seconds: 60),
+}) async {
   final client = await auth.clientViaApplicationDefaultCredentials(
     scopes: ['https://www.googleapis.com/auth/cloud-platform'],
   );
@@ -48,14 +53,20 @@ Future<List<LogEntry>> waitForLogs(String filter, int count) async {
     pageSize: count,
   );
 
+  final endTime = DateTime.now().add(timeout);
+
   try {
-    for (var attempt = 0; attempt <= 10; attempt++) {
-      await Future<void>.delayed(const Duration(seconds: 2));
+    var first = true;
+    do {
+      if (!first) {
+        await Future<void>.delayed(const Duration(seconds: 2));
+      }
+      first = false;
       final listResult = await loggingService.listLogEntries(request);
       if (listResult.entries.isNotEmpty) {
         return listResult.entries;
       }
-    }
+    } while (DateTime.now().isBefore(endTime));
     throw StateError(
       'Log entries matching "$filter" were not found within the timeout.',
     );

--- a/test_utils/lib/src/cloud_runner.dart
+++ b/test_utils/lib/src/cloud_runner.dart
@@ -100,8 +100,6 @@ class CloudRunner {
       if (projectId == 'dart-sdk-testing') ...[
         '--build-service-account',
         'projects/dart-sdk-testing/serviceAccounts/integration-test-runner@dart-sdk-testing.iam.gserviceaccount.com',
-        '--service-account',
-        'integration-test-runner@dart-sdk-testing.iam.gserviceaccount.com',
       ],
       serviceName,
       '--source',

--- a/test_utils/lib/src/cloud_runner.dart
+++ b/test_utils/lib/src/cloud_runner.dart
@@ -168,19 +168,21 @@ class CloudRunner {
     ]);
   }
 
-  Future<String?> _identityToken() async {
-    try {
-      final result = await Process.run('gcloud', [
-        'auth',
-        'print-identity-token',
-        '--audiences=$serverUri',
-      ]);
-      if (result.exitCode == 0) {
-        return result.stdout.toString().trim();
-      }
-    } catch (_) {}
-
-    return null;
+  Future<String> _identityToken() async {
+    final result = await Process.run('gcloud', [
+      'auth',
+      'print-identity-token',
+      '--audiences=$serverUri',
+    ]);
+    if (result.exitCode == 0) {
+      return result.stdout.toString().trim();
+    } else {
+      throw StateError(
+        'Failed to get Cloud Run service URL:\n'
+        'STDOUT:\n${result.stdout}\n'
+        'STDERR:\n${result.stderr}',
+      );
+    }
   }
 
   /// Authentication headers required to access [serverUri].

--- a/test_utils/lib/src/cloud_runner.dart
+++ b/test_utils/lib/src/cloud_runner.dart
@@ -177,31 +177,45 @@ class CloudRunner {
     // 1. Try Metadata Server
     try {
       final client = HttpClient();
-      final request = await client.getUrl(
-        Uri.parse(
-          'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=${serverUri.toString()}',
-        ),
+      final uri = Uri.parse(
+        'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=${serverUri.toString()}',
       );
+      print('Requesting ID token from Metadata Server: $uri');
+      final request = await client.getUrl(uri);
       request.headers.add('Metadata-Flavor', 'Google');
       final response = await request.close();
+      print('Metadata Server response status: ${response.statusCode}');
       if (response.statusCode == 200) {
         final body = await response.transform(utf8.decoder).join();
+        print('Successfully got ID token from Metadata Server');
         return body.trim();
+      } else {
+        final body = await response.transform(utf8.decoder).join();
+        print('Metadata Server failed: $body');
       }
-    } catch (_) {}
+    } catch (e, s) {
+      print('Metadata Server error: $e\n$s');
+    }
 
     // 2. Try gcloud auth print-identity-token
     try {
+      print('Running gcloud auth print-identity-token...');
       final result = await Process.run('gcloud', [
         'auth',
         'print-identity-token',
         '--audiences=${serverUri.toString()}',
       ]);
+      print('gcloud exitCode: ${result.exitCode}');
+      print('gcloud STDOUT: ${result.stdout}');
+      print('gcloud STDERR: ${result.stderr}');
       if (result.exitCode == 0) {
         return result.stdout.toString().trim();
       }
-    } catch (_) {}
+    } catch (e, s) {
+      print('gcloud run error: $e\n$s');
+    }
 
+    print('Failed to obtain any ID token!');
     return null;
   }
 

--- a/test_utils/lib/src/cloud_runner.dart
+++ b/test_utils/lib/src/cloud_runner.dart
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:convert';
 import 'dart:io';
 import 'package:path/path.dart' as p;
 import '../random.dart';
@@ -174,85 +173,17 @@ class CloudRunner {
 
   /// Gets an ID token for the service URL.
   Future<String?> getIdToken() async {
-    // 1. Try Metadata Server with dynamic service account discovery
     try {
-      final client = HttpClient();
-      final listUri = Uri.parse(
-        'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/',
-      );
-      print('Listing service accounts from Metadata Server: $listUri');
-      final listRequest = await client.getUrl(listUri);
-      listRequest.headers.add('Metadata-Flavor', 'Google');
-      final listResponse = await listRequest.close();
-      print('Metadata Server list response status: ${listResponse.statusCode}');
-
-      if (listResponse.statusCode == 200) {
-        final listBody = await listResponse.transform(utf8.decoder).join();
-        final accounts = listBody
-            .split('\n')
-            .map((e) => e.trim())
-            .where((e) => e.isNotEmpty)
-            .map((e) => e.endsWith('/') ? e.substring(0, e.length - 1) : e)
-            .toList();
-        print('Discovered service accounts: $accounts');
-
-        for (final accountName in accounts) {
-          try {
-            final tokenUri = Uri.parse(
-              'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/$accountName/identity?audience=${serverUri.toString()}',
-            );
-            print(
-              'Trying to get ID token for account "$accountName" at: $tokenUri',
-            );
-            final requestToken = await client.getUrl(tokenUri);
-            requestToken.headers.add('Metadata-Flavor', 'Google');
-            final responseToken = await requestToken.close();
-            if (responseToken.statusCode == 200) {
-              final tokenBody = await responseToken
-                  .transform(utf8.decoder)
-                  .join();
-              print('Successfully got ID token for account: $accountName');
-              return tokenBody.trim();
-            } else {
-              final tokenBody = await responseToken
-                  .transform(utf8.decoder)
-                  .join();
-              print(
-                'Failed to get ID token for account $accountName: '
-                '$tokenBody (${responseToken.statusCode})',
-              );
-            }
-          } catch (e) {
-            print('Error getting ID token for account $accountName: $e');
-          }
-        }
-      } else {
-        final listBody = await listResponse.transform(utf8.decoder).join();
-        print('Listing service accounts failed: $listBody');
-      }
-    } catch (e, s) {
-      print('Metadata Server error: $e\n$s');
-    }
-
-    // 2. Try gcloud auth print-identity-token
-    try {
-      print('Running gcloud auth print-identity-token...');
       final result = await Process.run('gcloud', [
         'auth',
         'print-identity-token',
-        '--audiences=${serverUri.toString()}',
+        '--audiences=$serverUri',
       ]);
-      print('gcloud exitCode: ${result.exitCode}');
-      print('gcloud STDOUT: ${result.stdout}');
-      print('gcloud STDERR: ${result.stderr}');
       if (result.exitCode == 0) {
         return result.stdout.toString().trim();
       }
-    } catch (e, s) {
-      print('gcloud run error: $e\n$s');
-    }
+    } catch (_) {}
 
-    print('Failed to obtain any ID token!');
     return null;
   }
 

--- a/test_utils/lib/src/cloud_runner.dart
+++ b/test_utils/lib/src/cloud_runner.dart
@@ -100,6 +100,8 @@ class CloudRunner {
       if (projectId == 'dart-sdk-testing') ...[
         '--build-service-account',
         'projects/dart-sdk-testing/serviceAccounts/integration-test-runner@dart-sdk-testing.iam.gserviceaccount.com',
+        '--service-account',
+        'projects/dart-sdk-testing/serviceAccounts/integration-test-runner@dart-sdk-testing.iam.gserviceaccount.com',
       ],
       serviceName,
       '--source',

--- a/test_utils/lib/src/cloud_runner.dart
+++ b/test_utils/lib/src/cloud_runner.dart
@@ -14,6 +14,7 @@
 
 import 'dart:io';
 import 'package:path/path.dart' as p;
+import '../random.dart';
 import 'cloud.dart';
 
 const _dockerTemplate = '''
@@ -42,7 +43,9 @@ String get repoRoot {
     }
     dir = parent;
   }
-  return Directory.current.absolute.path;
+  throw StateError(
+    'Could not find repository root starting from ${Directory.current.path}',
+  );
 }
 
 /// Runs Dart programs using Google Cloud Run.
@@ -85,8 +88,10 @@ class CloudRunner {
 
     await File(dockerPath).writeAsString(_dockerTemplate);
 
+    final now = DateTime.now();
     final serviceName =
-        'e2e-print-test-${DateTime.now().millisecondsSinceEpoch}';
+        'cloud-runner-${now.year}-${now.month}-${now.day}-'
+        '${randomAlphaNumString(10)}';
 
     // Start a server using the gcloud command.
     final deploy = await Process.run('gcloud', [

--- a/test_utils/lib/src/cloud_runner.dart
+++ b/test_utils/lib/src/cloud_runner.dart
@@ -1,0 +1,45 @@
+import 'dart:io';
+import 'package:path/path.dart' as p;
+
+const dockerTemplate = '''
+FROM dart:stable AS build
+
+WORKDIR /app
+
+# Copy the server
+COPY server .
+
+# Start server.
+EXPOSE 8080
+CMD ["/app/bin/server"]
+''';
+
+class CloudRunner {
+  final Uri serverUri;
+
+  // [path] is relative to the root of the directory
+  static Future<CloudRunner> start(String path) async {
+    final dir = Directory.systemTemp.createTempSync();
+    final serverPath = p.join(dir.absolute.path, 'server');
+    final dockerPath = p.join(dir.absolute.path, 'Dockerfile');
+    final sourcePath = p.join(repoRoot, path);
+
+    final compile = await Process.run('dart', [
+      'compile',
+      'exe',
+      '--target-os=linux',
+      '--target-arch=x64',
+      '--output={$serverPath}/server',
+      sourcePath,
+    ]);
+    if (compile.exitCode != 0) {
+      // TODO: Handle this case
+    }
+
+    await File(dockerPath).writeAsString(dockerTemplate);
+
+    Directory.current = dir;
+  }
+
+  Future<void> stop() async {}
+}

--- a/test_utils/lib/src/cloud_runner.dart
+++ b/test_utils/lib/src/cloud_runner.dart
@@ -97,6 +97,8 @@ class CloudRunner {
     final deploy = await Process.run('gcloud', [
       'run',
       'deploy',
+      '--build-service-account',
+      'projects/dart-sdk-testing/serviceAccounts/integration-test-runner@dart-sdk-testing.iam.gserviceaccount.com',
       serviceName,
       '--source',
       dir.absolute.path,

--- a/test_utils/lib/src/cloud_runner.dart
+++ b/test_utils/lib/src/cloud_runner.dart
@@ -1,45 +1,172 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import 'dart:io';
 import 'package:path/path.dart' as p;
+import 'cloud.dart';
 
-const dockerTemplate = '''
-FROM dart:stable AS build
+const _dockerTemplate = '''
+FROM debian:stable-slim
 
 WORKDIR /app
 
 # Copy the server
-COPY server .
+COPY server /app/server
 
 # Start server.
 EXPOSE 8080
-CMD ["/app/bin/server"]
+CMD ["/app/server"]
 ''';
 
+/// The absolute path of the repository on the local file system.
+String get repoRoot {
+  var dir = Directory.current.absolute;
+  while (true) {
+    if (File(p.join(dir.path, 'librarian.yaml')).existsSync()) {
+      return dir.path;
+    }
+    final parent = dir.parent;
+    if (parent.path == dir.path) {
+      break;
+    }
+    dir = parent;
+  }
+  return Directory.current.absolute.path;
+}
+
+/// Runs Dart programs using Google Cloud Run.
 class CloudRunner {
   final Uri serverUri;
+  final String serviceName;
+  final Directory _tempDir;
 
-  // [path] is relative to the root of the directory
-  static Future<CloudRunner> start(String path) async {
-    final dir = Directory.systemTemp.createTempSync();
+  CloudRunner._({
+    required this.serverUri,
+    required this.serviceName,
+    required Directory tempDir,
+  }) : _tempDir = tempDir;
+
+  /// Runs the given Dart program using Google Cloud Run.
+  ///
+  /// [dartPath] must be a path, relative to the workspace root, to a Dart
+  /// program. For example, `'pkgs/google_cloud_shelf/test/e2e_server.dart'`.
+  static Future<CloudRunner> start(String dartPath) async {
+    final dir = Directory.systemTemp.createTempSync('cloud_runner_');
     final serverPath = p.join(dir.absolute.path, 'server');
     final dockerPath = p.join(dir.absolute.path, 'Dockerfile');
-    final sourcePath = p.join(repoRoot, path);
+    final sourcePath = p.join(repoRoot, dartPath);
 
     final compile = await Process.run('dart', [
       'compile',
       'exe',
       '--target-os=linux',
       '--target-arch=x64',
-      '--output={$serverPath}/server',
+      '--output=$serverPath',
       sourcePath,
     ]);
     if (compile.exitCode != 0) {
-      // TODO: Handle this case
+      throw StateError(
+        'Failed to compile server:\n'
+        'STDOUT:\n${compile.stdout}\n'
+        'STDERR:\n${compile.stderr}',
+      );
     }
 
-    await File(dockerPath).writeAsString(dockerTemplate);
+    await File(dockerPath).writeAsString(_dockerTemplate);
 
-    Directory.current = dir;
+    final serviceName =
+        'e2e-print-test-${DateTime.now().millisecondsSinceEpoch}';
+
+    // Start a server using the gcloud command.
+    final deploy = await Process.run('gcloud', [
+      'run',
+      'deploy',
+      serviceName,
+      '--source',
+      dir.absolute.path,
+      '--region',
+      'us-central1',
+      '--allow-unauthenticated',
+      '--quiet',
+      '--project',
+      projectId,
+    ]);
+
+    if (deploy.exitCode != 0) {
+      try {
+        await dir.delete(recursive: true);
+      } catch (_) {}
+      throw StateError(
+        'Failed to deploy service to Cloud Run:\n'
+        'STDOUT:\n${deploy.stdout}\n'
+        'STDERR:\n${deploy.stderr}',
+      );
+    }
+
+    final describe = await Process.run('gcloud', [
+      'run',
+      'services',
+      'describe',
+      serviceName,
+      '--region',
+      'us-central1',
+      '--format',
+      'value(status.url)',
+      '--project',
+      projectId,
+    ]);
+
+    if (describe.exitCode != 0) {
+      await _deleteService(serviceName);
+      try {
+        await dir.delete(recursive: true);
+      } catch (_) {}
+      throw StateError(
+        'Failed to get Cloud Run service URL:\n'
+        'STDOUT:\n${describe.stdout}\n'
+        'STDERR:\n${describe.stderr}',
+      );
+    }
+
+    final serverUri = Uri.parse(describe.stdout.toString().trim());
+
+    return CloudRunner._(
+      serverUri: serverUri,
+      serviceName: serviceName,
+      tempDir: dir,
+    );
   }
 
-  Future<void> stop() async {}
+  static Future<void> _deleteService(String name) async {
+    await Process.run('gcloud', [
+      'run',
+      'services',
+      'delete',
+      name,
+      '--region',
+      'us-central1',
+      '--quiet',
+      '--project',
+      projectId,
+    ]);
+  }
+
+  /// Terminate the Google Cloud Run service.
+  Future<void> stop() async {
+    await _deleteService(serviceName);
+    try {
+      await _tempDir.delete(recursive: true);
+    } catch (_) {}
+  }
 }

--- a/test_utils/lib/src/cloud_runner.dart
+++ b/test_utils/lib/src/cloud_runner.dart
@@ -99,7 +99,7 @@ class CloudRunner {
       'deploy',
       if (projectId == 'dart-sdk-testing') ...[
         '--build-service-account',
-        'integration-test-runner@dart-sdk-testing.iam.gserviceaccount.com',
+        'projects/dart-sdk-testing/serviceAccounts/integration-test-runner@dart-sdk-testing.iam.gserviceaccount.com',
         '--service-account',
         'integration-test-runner@dart-sdk-testing.iam.gserviceaccount.com',
       ],

--- a/test_utils/lib/src/cloud_runner.dart
+++ b/test_utils/lib/src/cloud_runner.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:convert';
 import 'dart:io';
 import 'package:path/path.dart' as p;
 import '../random.dart';
@@ -169,6 +170,39 @@ class CloudRunner {
       '--project',
       projectId,
     ]);
+  }
+
+  /// Gets an ID token for the service URL.
+  Future<String?> getIdToken() async {
+    // 1. Try Metadata Server
+    try {
+      final client = HttpClient();
+      final request = await client.getUrl(
+        Uri.parse(
+          'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=${serverUri.toString()}',
+        ),
+      );
+      request.headers.add('Metadata-Flavor', 'Google');
+      final response = await request.close();
+      if (response.statusCode == 200) {
+        final body = await response.transform(utf8.decoder).join();
+        return body.trim();
+      }
+    } catch (_) {}
+
+    // 2. Try gcloud auth print-identity-token
+    try {
+      final result = await Process.run('gcloud', [
+        'auth',
+        'print-identity-token',
+        '--audiences=${serverUri.toString()}',
+      ]);
+      if (result.exitCode == 0) {
+        return result.stdout.toString().trim();
+      }
+    } catch (_) {}
+
+    return null;
   }
 
   /// Terminate the Google Cloud Run service.

--- a/test_utils/lib/src/cloud_runner.dart
+++ b/test_utils/lib/src/cloud_runner.dart
@@ -97,8 +97,10 @@ class CloudRunner {
     final deploy = await Process.run('gcloud', [
       'run',
       'deploy',
-      '--build-service-account',
-      'projects/dart-sdk-testing/serviceAccounts/integration-test-runner@dart-sdk-testing.iam.gserviceaccount.com',
+      if (projectId == 'dart-sdk-testing') ...[
+        '--build-service-account',
+        'projects/dart-sdk-testing/serviceAccounts/integration-test-runner@dart-sdk-testing.iam.gserviceaccount.com',
+      ],
       serviceName,
       '--source',
       dir.absolute.path,

--- a/test_utils/lib/src/cloud_runner.dart
+++ b/test_utils/lib/src/cloud_runner.dart
@@ -31,7 +31,7 @@ CMD ["/app/server"]
 ''';
 
 /// The absolute path of the repository on the local file system.
-String get repoRoot {
+String get _repoRoot {
   var dir = Directory.current.absolute;
   while (true) {
     if (File(p.join(dir.path, 'librarian.yaml')).existsSync()) {
@@ -68,7 +68,7 @@ class CloudRunner {
     final dir = Directory.systemTemp.createTempSync('cloud_runner_');
     final serverPath = p.join(dir.absolute.path, 'server');
     final dockerPath = p.join(dir.absolute.path, 'Dockerfile');
-    final sourcePath = p.join(repoRoot, dartPath);
+    final sourcePath = p.join(_repoRoot, dartPath);
 
     final compile = await Process.run('dart', [
       'compile',
@@ -97,10 +97,7 @@ class CloudRunner {
     final deploy = await Process.run('gcloud', [
       'run',
       'deploy',
-      if (projectId == 'dart-sdk-testing') ...[
-        '--build-service-account',
-        'projects/dart-sdk-testing/serviceAccounts/integration-test-runner@dart-sdk-testing.iam.gserviceaccount.com',
-      ],
+      if (isTestProject) ...['--build-service-account', serviceAccount],
       serviceName,
       '--source',
       dir.absolute.path,
@@ -171,8 +168,7 @@ class CloudRunner {
     ]);
   }
 
-  /// Gets an ID token for the service URL.
-  Future<String?> getIdToken() async {
+  Future<String?> _getIdToken() async {
     try {
       final result = await Process.run('gcloud', [
         'auth',
@@ -185,6 +181,14 @@ class CloudRunner {
     } catch (_) {}
 
     return null;
+  }
+
+  /// Authentication headers required to access [serverUri].
+  Future<Map<String, String>> headers() async {
+    if (isTestProject) {
+      return {'Authorization': 'Bearer ${await _getIdToken()}'};
+    }
+    return {};
   }
 
   /// Terminate the Google Cloud Run service.

--- a/test_utils/lib/src/cloud_runner.dart
+++ b/test_utils/lib/src/cloud_runner.dart
@@ -174,24 +174,61 @@ class CloudRunner {
 
   /// Gets an ID token for the service URL.
   Future<String?> getIdToken() async {
-    // 1. Try Metadata Server
+    // 1. Try Metadata Server with dynamic service account discovery
     try {
       final client = HttpClient();
-      final uri = Uri.parse(
-        'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=${serverUri.toString()}',
+      final listUri = Uri.parse(
+        'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/',
       );
-      print('Requesting ID token from Metadata Server: $uri');
-      final request = await client.getUrl(uri);
-      request.headers.add('Metadata-Flavor', 'Google');
-      final response = await request.close();
-      print('Metadata Server response status: ${response.statusCode}');
-      if (response.statusCode == 200) {
-        final body = await response.transform(utf8.decoder).join();
-        print('Successfully got ID token from Metadata Server');
-        return body.trim();
+      print('Listing service accounts from Metadata Server: $listUri');
+      final listRequest = await client.getUrl(listUri);
+      listRequest.headers.add('Metadata-Flavor', 'Google');
+      final listResponse = await listRequest.close();
+      print('Metadata Server list response status: ${listResponse.statusCode}');
+
+      if (listResponse.statusCode == 200) {
+        final listBody = await listResponse.transform(utf8.decoder).join();
+        final accounts = listBody
+            .split('\n')
+            .map((e) => e.trim())
+            .where((e) => e.isNotEmpty)
+            .map((e) => e.endsWith('/') ? e.substring(0, e.length - 1) : e)
+            .toList();
+        print('Discovered service accounts: $accounts');
+
+        for (final accountName in accounts) {
+          try {
+            final tokenUri = Uri.parse(
+              'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/$accountName/identity?audience=${serverUri.toString()}',
+            );
+            print(
+              'Trying to get ID token for account "$accountName" at: $tokenUri',
+            );
+            final requestToken = await client.getUrl(tokenUri);
+            requestToken.headers.add('Metadata-Flavor', 'Google');
+            final responseToken = await requestToken.close();
+            if (responseToken.statusCode == 200) {
+              final tokenBody = await responseToken
+                  .transform(utf8.decoder)
+                  .join();
+              print('Successfully got ID token for account: $accountName');
+              return tokenBody.trim();
+            } else {
+              final tokenBody = await responseToken
+                  .transform(utf8.decoder)
+                  .join();
+              print(
+                'Failed to get ID token for account $accountName: '
+                '$tokenBody (${responseToken.statusCode})',
+              );
+            }
+          } catch (e) {
+            print('Error getting ID token for account $accountName: $e');
+          }
+        }
       } else {
-        final body = await response.transform(utf8.decoder).join();
-        print('Metadata Server failed: $body');
+        final listBody = await listResponse.transform(utf8.decoder).join();
+        print('Listing service accounts failed: $listBody');
       }
     } catch (e, s) {
       print('Metadata Server error: $e\n$s');

--- a/test_utils/lib/src/cloud_runner.dart
+++ b/test_utils/lib/src/cloud_runner.dart
@@ -168,7 +168,7 @@ class CloudRunner {
     ]);
   }
 
-  Future<String?> _getIdToken() async {
+  Future<String?> _identityToken() async {
     try {
       final result = await Process.run('gcloud', [
         'auth',
@@ -186,7 +186,7 @@ class CloudRunner {
   /// Authentication headers required to access [serverUri].
   Future<Map<String, String>> headers() async {
     if (isTestProject) {
-      return {'Authorization': 'Bearer ${await _getIdToken()}'};
+      return {'Authorization': 'Bearer ${await _identityToken()}'};
     }
     return {};
   }

--- a/test_utils/lib/src/cloud_runner.dart
+++ b/test_utils/lib/src/cloud_runner.dart
@@ -99,9 +99,9 @@ class CloudRunner {
       'deploy',
       if (projectId == 'dart-sdk-testing') ...[
         '--build-service-account',
-        'projects/dart-sdk-testing/serviceAccounts/integration-test-runner@dart-sdk-testing.iam.gserviceaccount.com',
+        'integration-test-runner@dart-sdk-testing.iam.gserviceaccount.com',
         '--service-account',
-        'projects/dart-sdk-testing/serviceAccounts/integration-test-runner@dart-sdk-testing.iam.gserviceaccount.com',
+        'integration-test-runner@dart-sdk-testing.iam.gserviceaccount.com',
       ],
       serviceName,
       '--source',

--- a/test_utils/lib/src/random.dart
+++ b/test_utils/lib/src/random.dart
@@ -1,0 +1,22 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:math';
+
+const _chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
+final _random = Random();
+
+String randomAlphaNumString(int length) => [
+  for (int i = 0; i < length; i++) _chars[_random.nextInt(_chars.length)],
+].join();

--- a/test_utils/pubspec.yaml
+++ b/test_utils/pubspec.yaml
@@ -11,7 +11,9 @@ environment:
 dependencies:
   async: ^2.13.0
   collection: ^1.19.1
+  google_cloud_logging_v2: any
   google_cloud_protobuf: any
+  googleapis_auth: ^2.3.1
   http: ^1.5.0
   path: ^1.9.1
   test: ^1.26.3


### PR DESCRIPTION
Added an integration test that verifies that calling the `print` function in the context of a request results in a log entry.

The test works by running a shelf server using Google Cloud Run and then verifying that the correct logs written.

1. Changed the GCB image to one that includes `gcloud`
2. Changed the integration test install script to install dart
3. Added `waitForLogs` to `test_utils` (logs are ingested asynchronously)
4. Added a `CloudRunner` class to run a Dart program using Google Cloud Run.

