### PR TITLE
refactor(google_cloud_logging)!: namespace zone variable keys

### DIFF
--- a/pkgs/google_cloud_logging/ARCHITECTURE.md
+++ b/pkgs/google_cloud_logging/ARCHITECTURE.md
@@ -53,7 +53,7 @@ flowchart TD
 
     subgraph Shelf["package:google_cloud_shelf"]
         MW("cloudLoggingMiddleware")
-        Zone(["Forks Zone and sets: <br><code>Zone.current['traceparent']</code> <br><code>Zone.current['google_cloud_project']</code>"])
+        Zone(["Forks Zone and sets: <br><code>Zone.current['google_cloud_logging.traceparent']</code> <br><code>Zone.current['google_cloud_logging.google_cloud_project']</code>"])
         Handler("Request Handler <br><code>logger.info('something')</code>")
 
         Req --> MW

--- a/pkgs/google_cloud_logging/lib/src/interop.dart
+++ b/pkgs/google_cloud_logging/lib/src/interop.dart
@@ -19,7 +19,8 @@ library;
 ///
 /// This variable is looked up in the current [Zone] to correlate logs with the
 /// GCP project context. Framework middleware should set this in a forked zone.
-const googleCloudProjectIdZoneVariable = 'google_cloud_project';
+const googleCloudProjectIdZoneVariable =
+    'google_cloud_logging.google_cloud_project';
 
 /// The [String] value for the `traceparent` W3C HTTP header.
 ///
@@ -27,4 +28,4 @@ const googleCloudProjectIdZoneVariable = 'google_cloud_project';
 /// with the trace and span context of the incoming request.
 ///
 /// See https://www.w3.org/TR/trace-context/
-const traceparentHeaderValueZoneVariable = 'traceparent';
+const traceparentHeaderValueZoneVariable = 'google_cloud_logging.traceparent';

--- a/pkgs/google_cloud_logging/test/structured_logging_test.dart
+++ b/pkgs/google_cloud_logging/test/structured_logging_test.dart
@@ -15,6 +15,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'package:google_cloud_logging/google_cloud_logging.dart';
+import 'package:google_cloud_logging/interop.dart';
 import 'package:google_cloud_logging/src/structured_logging.dart';
 import 'package:test/test.dart';
 
@@ -321,9 +322,9 @@ void main() {
           });
         },
         zoneValues: {
-          'traceparent':
+          traceparentHeaderValueZoneVariable:
               '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
-          'google_cloud_project': 'zone-project',
+          googleCloudProjectIdZoneVariable: 'zone-project',
         },
       );
     });

--- a/pkgs/google_cloud_logging/test/traceparent_test.dart
+++ b/pkgs/google_cloud_logging/test/traceparent_test.dart
@@ -14,6 +14,7 @@
 
 import 'dart:async';
 
+import 'package:google_cloud_logging/interop.dart';
 import 'package:google_cloud_logging/src/traceparent.dart';
 import 'package:test/test.dart';
 
@@ -133,9 +134,9 @@ void main() {
           });
         },
         zoneValues: {
-          'traceparent':
+          traceparentHeaderValueZoneVariable:
               '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
-          'google_cloud_project': 'zone-project',
+          googleCloudProjectIdZoneVariable: 'zone-project',
         },
       );
     });
@@ -152,9 +153,9 @@ void main() {
           });
         },
         zoneValues: {
-          'traceparent':
+          traceparentHeaderValueZoneVariable:
               '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
-          'google_cloud_project': 'zone-project',
+          googleCloudProjectIdZoneVariable: 'zone-project',
         },
       );
     });


### PR DESCRIPTION
Prefix googleCloudProjectIdZoneVariable and traceparentHeaderValueZoneVariable with 'google_cloud_logging.' to namespace them and improve debuggability when inspecting zone values.

BREAKING-CHANGE: Any external consumers directly reading or setting zone variables using the raw strings 'google_cloud_project' or 'traceparent' must migrate to use 'google_cloud_logging.google_cloud_project' and 'google_cloud_logging.traceparent'.
