### PR TITLE
docs: fix documentation and export references in google_cloud_logging and google_cloud_shelf

### DIFF
--- a/pkgs/google_cloud_logging/CHANGELOG.md
+++ b/pkgs/google_cloud_logging/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.6.0+1
+
+- Removed unexported `createStructuredLog` from library doc comment.
+- Fixed grammatical error and broken `ARCHITECTURE.md` link in `interop.dart` doc comments.
+- Fixed doc comment typo in `traceparent.dart`.
+
 ## 0.6.0
 
 - Replaced `CloudLogger` with `StructuredLogger` which writes directly to

--- a/pkgs/google_cloud_logging/lib/google_cloud_logging.dart
+++ b/pkgs/google_cloud_logging/lib/google_cloud_logging.dart
@@ -17,14 +17,12 @@
 /// Includes:
 ///
 /// - [StructuredLogger]: for creating and writing structured logs
-/// - [createStructuredLog]: for creating structured logs
 ///
 /// Exports [LogSeverity] and [LogEntry] from other packages for easy access.
 ///
 /// @docImport 'package:google_cloud_logging_type/logging_type.dart';
 /// @docImport 'package:google_cloud_logging_v2/logging.dart';
 /// @docImport 'src/structured_logger.dart';
-/// @docImport 'src/structured_logging.dart';
 library;
 
 export 'package:google_cloud_logging_type/logging_type.dart' show LogSeverity;

--- a/pkgs/google_cloud_logging/lib/interop.dart
+++ b/pkgs/google_cloud_logging/lib/interop.dart
@@ -36,15 +36,12 @@
 ///    logging fields (`logging.googleapis.com/trace` and
 ///    `logging.googleapis.com/spanId`).
 ///
-/// For a detailed visual representation and description of this
-/// request-to-zone-to-logging flow, see the
-/// [Architecture Document][1].
+/// For more details on structured logging and Shelf request correlation, see
+/// `package:google_cloud_shelf` documentation.
 ///
 /// > [!TIP]
-/// > Application developers should not to use this library, instead use
+/// > Application developers should not use this library, instead use
 /// > `package:google_cloud_logging/google_cloud_logging.dart`.
-///
-/// [1]: https://github.com/googleapis/google-cloud-dart/tree/main/pkgs/google_cloud_logging/ARCHITECTURE.md
 ///
 /// @docImport 'dart:async';
 /// @docImport 'src/interop.dart';

--- a/pkgs/google_cloud_logging/lib/src/traceparent.dart
+++ b/pkgs/google_cloud_logging/lib/src/traceparent.dart
@@ -50,7 +50,7 @@ final _traceParentRegex = RegExp(
   caseSensitive: false,
 );
 
-/// Parsers a `'traceparent'` header.
+/// Parses a `'traceparent'` header.
 ///
 /// See https://www.w3.org/TR/trace-context/
 @visibleForTesting

--- a/pkgs/google_cloud_logging/pubspec.yaml
+++ b/pkgs/google_cloud_logging/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_cloud_logging
 description: >-
   Structured logging for Google Cloud environments with trace correlation
   and automatic formatting.
-version: 0.6.0
+version: 0.6.0+1
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/pkgs/google_cloud_logging
 
 resolution: workspace

--- a/pkgs/google_cloud_shelf/CHANGELOG.md
+++ b/pkgs/google_cloud_shelf/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.0+1
+
+- Updated `README.md` to reference `StructuredLogger` instead of `currentLogger` and specify W3C `traceparent` headers.
+- Expanded doc comments on `createLoggingMiddleware` and `cloudLoggingMiddleware` to explain `Zone` variable injection and `StructuredLogger` correlation.
+
 ## 0.6.0
 
 - Added the trace context to each request's `Zone` so that

--- a/pkgs/google_cloud_shelf/CHANGELOG.md
+++ b/pkgs/google_cloud_shelf/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## 0.6.0+1
 
-- Updated `README.md` to reference `StructuredLogger` instead of `currentLogger` and specify W3C `traceparent` headers.
-- Expanded doc comments on `createLoggingMiddleware` and `cloudLoggingMiddleware` to explain `Zone` variable injection and `StructuredLogger` correlation.
+- Updated `README.md` to reference `StructuredLogger` instead of
+  `currentLogger` and specify W3C `traceparent` headers.
+- Expanded doc comments on `createLoggingMiddleware` and
+  `cloudLoggingMiddleware` to explain `Zone` variable injection and
+  `StructuredLogger` correlation.
 
 ## 0.6.0
 

--- a/pkgs/google_cloud_shelf/README.md
+++ b/pkgs/google_cloud_shelf/README.md
@@ -26,9 +26,9 @@ mapping, and graceful shutdown orchestration.
   (`createLoggingMiddleware`, `cloudLoggingMiddleware`,
   `errorLoggingMiddleware`) that automatically formats application and error
   logs in GCP's native structured format.
-* **Trace Correlation:** Automatically parses Google Cloud trace context
-  headers (`X-Cloud-Trace-Context`). Any log entry emitted using
-  `currentLogger` or standard `print()` within request execution is correlated
+* **Trace Correlation:** Automatically parses W3C trace context
+  headers (`traceparent`). Any log entry emitted using
+  `StructuredLogger` or standard `print()` within request execution is correlated
   and nested directly under the HTTP request log entry in the Cloud Logging
   viewer.
 * **Standardized HTTP Exception Mapping:** Throw client-safe exceptions in your
@@ -65,7 +65,7 @@ Future<void> main() async {
 ### 2. Contextual Logging & Trace Correlation
 
 Enable request-log nesting in the Google Cloud Console by providing a
-`projectId` to `createLoggingMiddleware`. Any logs written to `currentLogger`
+`projectId` to `createLoggingMiddleware`. Any logs written using `StructuredLogger`
 or sent to standard `print()` inside the handler's execution flow are grouped
 with the request log.
 

--- a/pkgs/google_cloud_shelf/lib/src/http_logging.dart
+++ b/pkgs/google_cloud_shelf/lib/src/http_logging.dart
@@ -45,6 +45,13 @@ const internalServerErrorMessage = 'Internal Server Error';
 /// [cloudLoggingMiddleware] (which delegates request logs to the Cloud host
 /// infrastructure to prevent duplicate logging, but formats error/uncaught logs
 /// in GCP's structured format).
+///
+/// When [projectId] is provided, this middleware extracts the W3C `traceparent`
+/// header from incoming requests and forks a new [Zone] with
+/// [googleCloudProjectIdZoneVariable] and
+/// [traceparentHeaderValueZoneVariable]. Logs written using [StructuredLogger]
+/// (from `package:google_cloud_logging`) or standard [print] inside the request
+/// handler implicitly read these zone variables to correlate with the request.
 Middleware createLoggingMiddleware({String? projectId}) => projectId == null
     ? errorLoggingMiddleware
     : cloudLoggingMiddleware(projectId);
@@ -201,7 +208,13 @@ String _formatDetailsAsPseudoYaml(List<Map<String, Object?>> details) {
 ///
 /// [projectId] is the Google Cloud Project ID used for trace correlation.
 ///
-/// Calls to [print] are formatted to include trace correlation.
+/// This middleware extracts the W3C `traceparent` header from incoming requests
+/// and forks a new [Zone] containing [googleCloudProjectIdZoneVariable] and
+/// [traceparentHeaderValueZoneVariable].
+///
+/// Logs written using [StructuredLogger] (from `package:google_cloud_logging`)
+/// or calls to [print] inside the handler are formatted to include trace
+/// correlation.
 ///
 /// {@macro exceptionResponseMapping}
 Middleware cloudLoggingMiddleware(String projectId) {

--- a/pkgs/google_cloud_shelf/pubspec.yaml
+++ b/pkgs/google_cloud_shelf/pubspec.yaml
@@ -1,5 +1,5 @@
 name: google_cloud_shelf
-version: 0.6.0
+version: 0.6.0+1
 description: >-
   Shelf middleware for Google Cloud environments providing structured
   logging, trace correlation, exception mapping, and graceful shutdown


### PR DESCRIPTION
## Summary

- Removed unexported `createStructuredLog` from `google_cloud_logging.dart` doc comment.
- Fixed grammatical error and replaced broken `ARCHITECTURE.md` link in `interop.dart` doc comments.
- Fixed typo in `traceparent.dart` doc comment (`Parsers` -> `Parses`).
- Replaced outdated `currentLogger` references with `StructuredLogger` and updated trace correlation header mentions to `traceparent` in `google_cloud_shelf` README.
- Expanded doc comments on `createLoggingMiddleware` and `cloudLoggingMiddleware` in `http_logging.dart` to explain `Zone` variable injection and `StructuredLogger` correlation.
- Bumped both package versions to `0.6.0+1` and updated `CHANGELOG.md` files.