### PR TITLE
chore: make version per-package

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -25,8 +25,8 @@ sources:
     sha256: a030bff1e5b696affcb89240deb20a34325d9d2c23f82c1623332e820a3cf2ab
     subpath: src
   showcase:
-    commit: 7d5b4ab7839ce346428ae6882b60ce15ab493297
-    sha256: 146a5a3d26f3c8abef8862f4d6122674f2c4d0d362a5981fc283c1cc1c52339a
+    commit: e4edbeb96b139f8512720482e022c2d928b9bc52
+    sha256: 526fdbd4ef2f0b7637bb3a2b5e35838d3c077c12684e677e6e1e3bf01e801681
 default:
   output: generated/
   dart:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -55,9 +55,9 @@ default:
       proto:google.protobuf: package:google_cloud_protobuf/protobuf.dart
       proto:google.rpc: package:google_cloud_rpc/rpc.dart
       proto:google.type: package:google_cloud_type/type.dart
-    version: 0.5.3
 libraries:
   - name: google_cloud_ai_generativelanguage_v1beta
+    version: 0.5.3
     apis:
       - path: google/ai/generativelanguage/v1beta
     copyright_year: "2025"
@@ -148,6 +148,7 @@ libraries:
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_ai_generativelanguage_v1beta
       supports_sse: true
   - name: google_cloud_aiplatform_v1beta1
+    version: 0.5.3
     copyright_year: "2025"
     keep:
       - dart_test.yaml
@@ -256,6 +257,7 @@ libraries:
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_aiplatform_v1beta1
       supports_sse: true
   - name: google_cloud_api
+    version: 0.5.3
     apis:
       - path: google/api
     copyright_year: "2025"
@@ -263,10 +265,12 @@ libraries:
       name_override: api
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_api
   - name: google_cloud_common
+    version: 0.5.3
     copyright_year: "2025"
     dart:
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_common
   - name: google_cloud_firestore_v1
+    version: 0.5.3
     apis:
       - path: google/firestore/v1
     copyright_year: "2026"
@@ -282,10 +286,12 @@ libraries:
         > [`package:google_cloud_firestore`](https://pub.dev/packages/google_cloud_firestore).
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_firestore_v1
   - name: google_cloud_functions_v2
+    version: 0.5.3
     copyright_year: "2025"
     dart:
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_functions_v2
   - name: google_cloud_iam_v1
+    version: 0.5.3
     apis:
       - path: google/iam/v1
     copyright_year: "2025"
@@ -293,15 +299,18 @@ libraries:
       name_override: iam
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_iam_v1
   - name: google_cloud_language_v2
+    version: 0.5.3
     copyright_year: "2025"
     dart:
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_language_v2
   - name: google_cloud_location
+    version: 0.5.3
     copyright_year: "2025"
     dart:
       name_override: location
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_location
   - name: google_cloud_logging_type
+    version: 0.5.3
     apis:
       - path: google/logging/type
     copyright_year: "2025"
@@ -310,6 +319,7 @@ libraries:
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_logging_type
       title_override: Logging types
   - name: google_cloud_logging_v2
+    version: 0.5.3
     apis:
       - path: google/logging/v2
     copyright_year: "2025"
@@ -320,6 +330,7 @@ libraries:
       dev_dependencies: googleapis_auth,test,test_utils
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_logging_v2
   - name: google_cloud_longrunning
+    version: 0.5.3
     apis:
       - path: google/longrunning
     copyright_year: "2025"
@@ -332,6 +343,7 @@ libraries:
       part_file: longrunning.p.dart
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_longrunning
   - name: google_cloud_protobuf
+    version: 0.5.3
     apis:
       - path: google/protobuf
     copyright_year: "2025"
@@ -366,6 +378,7 @@ libraries:
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_protobuf
       title_override: Core Protobuf Types
   - name: google_cloud_protobuf_test_messages_proto3
+    version: 0.5.3
     apis:
       - path: src/google/protobuf
     keep:
@@ -381,6 +394,7 @@ libraries:
       library_path_override: google_cloud_protobuf_test_messages_proto3.dart
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_protojson_conformance
   - name: google_cloud_rpc
+    version: 0.5.3
     apis:
       - path: google/rpc
     copyright_year: "2025"
@@ -401,6 +415,7 @@ libraries:
       part_file: rpc.p.dart
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_rpc
   - name: google_cloud_secretmanager_v1
+    version: 0.5.3
     copyright_year: "2025"
     keep:
       - dart_test.yaml
@@ -409,6 +424,7 @@ libraries:
       dev_dependencies: googleapis_auth,test,test_utils
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_secretmanager_v1
   - name: google_cloud_showcase_v1beta1
+    version: 0.5.3
     apis:
       - path: schema/google/showcase/v1beta1
     copyright_year: "2025"
@@ -427,6 +443,7 @@ libraries:
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_showcase_v1beta1
       supports_sse: true
   - name: google_cloud_type
+    version: 0.5.3
     apis:
       - path: google/type
     copyright_year: "2025"

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -25,8 +25,8 @@ sources:
     sha256: a030bff1e5b696affcb89240deb20a34325d9d2c23f82c1623332e820a3cf2ab
     subpath: src
   showcase:
-    commit: e4edbeb96b139f8512720482e022c2d928b9bc52
-    sha256: 526fdbd4ef2f0b7637bb3a2b5e35838d3c077c12684e677e6e1e3bf01e801681
+    commit: 7d5b4ab7839ce346428ae6882b60ce15ab493297
+    sha256: 146a5a3d26f3c8abef8862f4d6122674f2c4d0d362a5981fc283c1cc1c52339a
 default:
   output: generated/
   dart:


### PR DESCRIPTION
This is ground work for supporting versioning packages separately.

The latest release of showcase is broken, which is why the CI is failing.