### PR TITLE
chore: add a default tag format

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -29,6 +29,7 @@ sources:
     sha256: 146a5a3d26f3c8abef8862f4d6122674f2c4d0d362a5981fc283c1cc1c52339a
 default:
   output: generated/
+  tag_format: '{name}/v{version}'
   dart:
     api_keys_environment_variables: GOOGLE_API_KEY
     issue_tracker_url: https://github.com/googleapis/google-cloud-dart/issues

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -149,7 +149,7 @@ libraries:
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_ai_generativelanguage_v1beta
       supports_sse: true
   - name: google_cloud_aiplatform_v1beta1
-    version: 0.5.3
+    version: 0.5.4
     copyright_year: "2025"
     keep:
       - dart_test.yaml

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -149,7 +149,7 @@ libraries:
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_ai_generativelanguage_v1beta
       supports_sse: true
   - name: google_cloud_aiplatform_v1beta1
-    version: 0.5.4
+    version: 0.5.3
     copyright_year: "2025"
     keep:
       - dart_test.yaml

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -29,7 +29,7 @@ sources:
     sha256: 146a5a3d26f3c8abef8862f4d6122674f2c4d0d362a5981fc283c1cc1c52339a
 default:
   output: generated/
-  tag_format: '{name}/v{version}'
+  tag_format: '{name}-v{version}'
   dart:
     api_keys_environment_variables: GOOGLE_API_KEY
     issue_tracker_url: https://github.com/googleapis/google-cloud-dart/issues


### PR DESCRIPTION
This is used by `librarian tag` to generate the Git tags that are used to mark package releases.