### PR TITLE
chore: add CHANGELOG.md to existing published packages

### DIFF
--- a/generated/google_cloud_ai_generativelanguage_v1beta/CHANGELOG.md
+++ b/generated/google_cloud_ai_generativelanguage_v1beta/CHANGELOG.md
@@ -1,0 +1,70 @@
+# Changelog
+
+## 0.5.3
+
+- chore: update librarian to v0.21.0 (#289)
+- fix(protobuf): fix `FieldMask` encoding (#257)
+
+## 0.5.2
+
+- fix: `NullValue` serialization and deserialization (#254)
+- chore: upgrade to latest sidekick (better fakes) (#248)
+- chore: upgrade to lastest sidekick (#247)
+
+## 0.5.1
+
+- chore: verify handling of `Empty` fields (#208)
+- chore: run all cloud integration tests on GCP (#176)
+- feat(gcs): support for downloading objects (#138)
+- chore: Move http tests recording into a subdirectory (#128)
+- chore: add librarian config (#120)
+
+## 0.5.0
+
+- chore: Update side and API sources and regen (#119)
+- feat: Update to latest API versions (#103)
+- fix(dart): Add proto serialization conformance tests (#102)
+
+## 0.4.0
+
+- feat: Create exception subclasses (#101)
+- chore: Mark test recordings as generated (#97)
+
+## 0.3.0
+
+- fix: Fix `repeated double` decoding (#91)
+
+## 0.2.1
+
+- chore: Single-quoted strings in config/examples (#87)
+- test: Add some conformance tests (#93)
+- chore: Use workspace analysis for all packages (#88)
+- test(google_cloud_aiplatform_v1beta1): Add integration tests (#79)
+- chore: Use sidekick @v1.0.1 (#75)
+- test: Add integration tests for `_ai_generative...` (#71)
+- feat: update using null-safety generator change (#69)
+- feat: add isNotDefault extension methods for core proto types (#68)
+
+## 0.2.0
+
+- feat: Move `_gax` functionality to `_rpc` (#67)
+
+## 0.1.2
+
+- fix: ConfigurationException in `fromApiKey` (#64)
+
+## 0.1.1
+
+- fix: Remove dependency on dart:io (#56)
+- feat: Remove protobuf dep on _gax (#52)
+- feat: update to the most recent sidekick version (#49)
+- chore: Update to the latest API sources (#39)
+- chore: Update to latest sidekick (#38)
+- docs(genai): Fix the heading level of text after Quickstart (#37)
+- docs(google_cloud_ai...): Add a note about model names (#32)
+- docs(google_cloud_ai...): Adds examples (#23)
+- feat: Use correct issue tracker urls (#31)
+
+## 0.1.0
+
+- initial release

--- a/generated/google_cloud_aiplatform_v1beta1/CHANGELOG.md
+++ b/generated/google_cloud_aiplatform_v1beta1/CHANGELOG.md
@@ -1,0 +1,65 @@
+# Changelog
+
+## 0.5.3
+
+- chore: update api sources (#311)
+- chore: update librarian to v0.21.0 (#289)
+- fix(protobuf): fix `FieldMask` encoding (#257)
+
+## 0.5.2
+
+- fix: `NullValue` serialization and deserialization (#254)
+- chore: upgrade to latest sidekick (better fakes) (#248)
+- chore: upgrade to lastest sidekick (#247)
+
+## 0.5.1
+
+- chore: verify handling of `Empty` fields (#208)
+- chore: run all cloud integration tests on GCP (#176)
+- chore: regen apis with latest librarian/apis (#170)
+- feat(gcs): support for downloading objects (#138)
+- chore: Move http tests recording into a subdirectory (#128)
+- chore: add librarian config (#120)
+
+## 0.5.0
+
+- chore: Update side and API sources and regen (#119)
+- test: Test all Compliance service methods (#106)
+- feat: Update to latest API versions (#103)
+- fix(dart): Add proto serialization conformance tests (#102)
+
+## 0.4.0
+
+- feat: Create exception subclasses (#101)
+- chore: Mark test recordings as generated (#97)
+
+## 0.3.0
+
+- fix: Fix `repeated double` decoding (#91)
+
+## 0.2.1
+
+- chore: Single-quoted strings in config/examples (#87)
+- test: Add some conformance tests (#93)
+- chore: Use workspace analysis for all packages (#88)
+- test(google_cloud_aiplatform_v1beta1): Add integration tests (#79)
+- chore: Use sidekick @v1.0.1 (#75)
+- feat: update using null-safety generator change (#69)
+- feat: add isNotDefault extension methods for core proto types (#68)
+
+## 0.2.0
+
+- feat: Move `_gax` functionality to `_rpc` (#67)
+
+## 0.1.2
+
+- fix: ConfigurationException in `fromApiKey` (#64)
+
+## 0.1.1
+
+- fix: Remove dependency on dart:io (#56)
+- feat: Remove protobuf dep on _gax (#52)
+
+## 0.1.0
+
+- initial release

--- a/generated/google_cloud_api/CHANGELOG.md
+++ b/generated/google_cloud_api/CHANGELOG.md
@@ -1,0 +1,59 @@
+# Changelog
+
+## 0.5.3
+
+- chore: update api sources (#311)
+- chore: update librarian to v0.21.0 (#289)
+- fix(protobuf): fix `FieldMask` encoding (#257)
+
+## 0.5.2
+
+- fix: `NullValue` serialization and deserialization (#254)
+- chore: upgrade to lastest sidekick (#247)
+
+## 0.5.1
+
+- chore: verify handling of `Empty` fields (#208)
+- chore: add librarian config (#120)
+
+## 0.5.0
+
+- chore: Update side and API sources and regen (#119)
+- fix(dart): Add proto serialization conformance tests (#102)
+
+## 0.4.0
+
+- feat: Create exception subclasses (#101)
+
+## 0.3.0
+
+- fix: Fix `repeated double` decoding (#91)
+
+## 0.2.1
+
+- chore: Single-quoted strings in config/examples (#87)
+- test: Add some conformance tests (#93)
+- chore: Use workspace analysis for all packages (#88)
+
+## 0.2.0
+
+- feat: update using null-safety generator change (#69)
+- feat: add isNotDefault extension methods for core proto types (#68)
+- feat: Move `_gax` functionality to `_rpc` (#67)
+
+## 0.1.2
+
+- fix: ConfigurationException in `fromApiKey` (#64)
+
+## 0.1.1
+
+- fix: Remove dependency on dart:io (#56)
+- feat: Remove protobuf dep on _gax (#52)
+- feat: update to the most recent sidekick version (#49)
+- feat: Use correct issue tracker urls (#31)
+- chore: Upgrade Sidekick to head (#10)
+- chore: Sync with google-cloud/rust/dart
+
+## 0.1.0
+
+- initial release

--- a/generated/google_cloud_common/CHANGELOG.md
+++ b/generated/google_cloud_common/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+## 0.5.3
+
+- chore: update librarian to v0.21.0 (#289)
+- fix(protobuf): fix `FieldMask` encoding (#257)
+
+## 0.5.2
+
+- fix: `NullValue` serialization and deserialization (#254)
+- chore: upgrade to lastest sidekick (#247)
+
+## 0.5.1
+
+- chore: verify handling of `Empty` fields (#208)
+- chore: add librarian config (#120)
+
+## 0.5.0
+
+- chore: Update side and API sources and regen (#119)
+- fix(dart): Add proto serialization conformance tests (#102)
+
+## 0.4.0
+
+- feat: Create exception subclasses (#101)
+
+## 0.3.0
+
+- fix: Fix `repeated double` decoding (#91)
+
+## 0.2.1
+
+- chore: Single-quoted strings in config/examples (#87)
+- chore: Use workspace analysis for all packages (#88)
+- feat: update using null-safety generator change (#69)
+- feat: add isNotDefault extension methods for core proto types (#68)
+
+## 0.2.0
+
+- feat: Move `_gax` functionality to `_rpc` (#67)
+
+## 0.1.2
+
+- fix: ConfigurationException in `fromApiKey` (#64)
+
+## 0.1.1
+
+- fix: Remove dependency on dart:io (#56)
+- feat: Remove protobuf dep on _gax (#52)
+- feat: update to the most recent sidekick version (#49)
+- feat: Use correct issue tracker urls (#31)
+- chore: Upgrade Sidekick to head (#10)
+- chore: Sync with google-cloud/rust/dart
+
+## 0.1.0
+
+- initial release

--- a/generated/google_cloud_firestore_v1/CHANGELOG.md
+++ b/generated/google_cloud_firestore_v1/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## 0.5.3
+
+- chore: update api sources (#311)
+- chore: update librarian to v0.21.0 (#289)
+- fix(protobuf): fix `FieldMask` encoding (#257)
+
+## 0.5.2
+
+- fix: `NullValue` serialization and deserialization (#254)
+
+## 0.5.1
+
+- initial release

--- a/generated/google_cloud_functions_v2/CHANGELOG.md
+++ b/generated/google_cloud_functions_v2/CHANGELOG.md
@@ -1,0 +1,62 @@
+# Changelog
+
+## 0.5.3
+
+- chore: update librarian to v0.21.0 (#289)
+- fix(protobuf): fix `FieldMask` encoding (#257)
+
+## 0.5.2
+
+- fix: `NullValue` serialization and deserialization (#254)
+- chore: upgrade to latest sidekick (better fakes) (#248)
+- chore: upgrade to lastest sidekick (#247)
+
+## 0.5.1
+
+- chore: verify handling of `Empty` fields (#208)
+- chore: add librarian config (#120)
+
+## 0.5.0
+
+- chore: Update side and API sources and regen (#119)
+- test: Test all Compliance service methods (#106)
+- fix(dart): Add proto serialization conformance tests (#102)
+
+## 0.4.0
+
+- feat: Create exception subclasses (#101)
+
+## 0.3.0
+
+- fix: Fix `repeated double` decoding (#91)
+
+## 0.2.1
+
+- chore: Single-quoted strings in config/examples (#87)
+- chore: Use workspace analysis for all packages (#88)
+- chore: Use sidekick @v1.0.1 (#75)
+- feat: update using null-safety generator change (#69)
+- feat: add isNotDefault extension methods for core proto types (#68)
+
+## 0.2.0
+
+- feat: Move `_gax` functionality to `_rpc` (#67)
+
+## 0.1.2
+
+- fix: ConfigurationException in `fromApiKey` (#64)
+
+## 0.1.1
+
+- fix: Remove dependency on dart:io (#56)
+- feat: Remove protobuf dep on _gax (#52)
+- feat: update to the most recent sidekick version (#49)
+- chore: Update to latest sidekick (#38)
+- feat: Use correct issue tracker urls (#31)
+- chore: Update to sidekick v0.3.1-0.20251013160330-f7a65558c218 (#20)
+- chore: Upgrade Sidekick to head (#10)
+- chore: Sync with google-cloud/rust/dart
+
+## 0.1.0
+
+- initial release

--- a/generated/google_cloud_iam_v1/CHANGELOG.md
+++ b/generated/google_cloud_iam_v1/CHANGELOG.md
@@ -1,0 +1,61 @@
+# Changelog
+
+## 0.5.3
+
+- chore: update librarian to v0.21.0 (#289)
+- fix(protobuf): fix `FieldMask` encoding (#257)
+
+## 0.5.2
+
+- fix: `NullValue` serialization and deserialization (#254)
+- chore: upgrade to latest sidekick (better fakes) (#248)
+- chore: upgrade to lastest sidekick (#247)
+
+## 0.5.1
+
+- chore: verify handling of `Empty` fields (#208)
+- chore: add librarian config (#120)
+
+## 0.5.0
+
+- chore: Update side and API sources and regen (#119)
+- fix(dart): Add proto serialization conformance tests (#102)
+
+## 0.4.0
+
+- feat: Create exception subclasses (#101)
+
+## 0.3.0
+
+- fix: Fix `repeated double` decoding (#91)
+
+## 0.2.1
+
+- chore: Single-quoted strings in config/examples (#87)
+- test: Add some conformance tests (#93)
+- chore: Use workspace analysis for all packages (#88)
+- feat: update using null-safety generator change (#69)
+- feat: add isNotDefault extension methods for core proto types (#68)
+
+## 0.2.0
+
+- feat: Move `_gax` functionality to `_rpc` (#67)
+
+## 0.1.2
+
+- fix: ConfigurationException in `fromApiKey` (#64)
+
+## 0.1.1
+
+- fix: Remove dependency on dart:io (#56)
+- feat: Remove protobuf dep on _gax (#52)
+- feat: update to the most recent sidekick version (#49)
+- chore: Update to latest sidekick (#38)
+- feat: Use correct issue tracker urls (#31)
+- chore: Update to sidekick v0.3.1-0.20251013160330-f7a65558c218 (#20)
+- chore: Upgrade Sidekick to head (#10)
+- chore: Sync with google-cloud/rust/dart
+
+## 0.1.0
+
+- initial release

--- a/generated/google_cloud_language_v2/CHANGELOG.md
+++ b/generated/google_cloud_language_v2/CHANGELOG.md
@@ -1,0 +1,60 @@
+# Changelog
+
+## 0.5.3
+
+- chore: update librarian to v0.21.0 (#289)
+- fix(protobuf): fix `FieldMask` encoding (#257)
+
+## 0.5.2
+
+- fix: `NullValue` serialization and deserialization (#254)
+- chore: upgrade to latest sidekick (better fakes) (#248)
+- chore: upgrade to lastest sidekick (#247)
+
+## 0.5.1
+
+- chore: verify handling of `Empty` fields (#208)
+- chore: add librarian config (#120)
+
+## 0.5.0
+
+- chore: Update side and API sources and regen (#119)
+- fix(dart): Add proto serialization conformance tests (#102)
+
+## 0.4.0
+
+- feat: Create exception subclasses (#101)
+
+## 0.3.0
+
+- fix: Fix `repeated double` decoding (#91)
+
+## 0.2.1
+
+- chore: Single-quoted strings in config/examples (#87)
+- chore: Use workspace analysis for all packages (#88)
+- feat: update using null-safety generator change (#69)
+- feat: add isNotDefault extension methods for core proto types (#68)
+
+## 0.2.0
+
+- feat: Move `_gax` functionality to `_rpc` (#67)
+
+## 0.1.2
+
+- fix: ConfigurationException in `fromApiKey` (#64)
+
+## 0.1.1
+
+- fix: Remove dependency on dart:io (#56)
+- feat: Remove protobuf dep on _gax (#52)
+- feat: update to the most recent sidekick version (#49)
+- chore: Update to latest sidekick (#38)
+- feat: Use correct issue tracker urls (#31)
+- chore: Update to sidekick v0.3.1-0.20251013160330-f7a65558c218 (#20)
+- chore: Upgrade Sidekick to head (#10)
+- chore: Sync with google-cloud/rust/dart
+
+## 0.1.0
+
+- initial release

--- a/generated/google_cloud_location/CHANGELOG.md
+++ b/generated/google_cloud_location/CHANGELOG.md
@@ -1,0 +1,60 @@
+# Changelog
+
+## 0.5.3
+
+- chore: update librarian to v0.21.0 (#289)
+- fix(protobuf): fix `FieldMask` encoding (#257)
+
+## 0.5.2
+
+- fix: `NullValue` serialization and deserialization (#254)
+- chore: upgrade to latest sidekick (better fakes) (#248)
+- chore: upgrade to lastest sidekick (#247)
+
+## 0.5.1
+
+- chore: verify handling of `Empty` fields (#208)
+- chore: add librarian config (#120)
+
+## 0.5.0
+
+- chore: Update side and API sources and regen (#119)
+- fix(dart): Add proto serialization conformance tests (#102)
+
+## 0.4.0
+
+- feat: Create exception subclasses (#101)
+
+## 0.3.0
+
+- fix: Fix `repeated double` decoding (#91)
+
+## 0.2.1
+
+- chore: Single-quoted strings in config/examples (#87)
+- chore: Use workspace analysis for all packages (#88)
+- feat: update using null-safety generator change (#69)
+- feat: add isNotDefault extension methods for core proto types (#68)
+
+## 0.2.0
+
+- feat: Move `_gax` functionality to `_rpc` (#67)
+
+## 0.1.2
+
+- fix: ConfigurationException in `fromApiKey` (#64)
+
+## 0.1.1
+
+- fix: Remove dependency on dart:io (#56)
+- feat: Remove protobuf dep on _gax (#52)
+- feat: update to the most recent sidekick version (#49)
+- chore: Update to latest sidekick (#38)
+- feat: Use correct issue tracker urls (#31)
+- chore: Update to sidekick v0.3.1-0.20251013160330-f7a65558c218 (#20)
+- chore: Upgrade Sidekick to head (#10)
+- chore: Sync with google-cloud/rust/dart
+
+## 0.1.0
+
+- initial release

--- a/generated/google_cloud_logging_type/CHANGELOG.md
+++ b/generated/google_cloud_logging_type/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+## 0.5.3
+
+- chore: update librarian to v0.21.0 (#289)
+- fix(protobuf): fix `FieldMask` encoding (#257)
+
+## 0.5.2
+
+- fix: `NullValue` serialization and deserialization (#254)
+- chore: upgrade to lastest sidekick (#247)
+
+## 0.5.1
+
+- chore: verify handling of `Empty` fields (#208)
+- chore: add librarian config (#120)
+
+## 0.5.0
+
+- chore: Update side and API sources and regen (#119)
+- fix(dart): Add proto serialization conformance tests (#102)
+
+## 0.4.0
+
+- feat: Create exception subclasses (#101)
+
+## 0.3.0
+
+- fix: Fix `repeated double` decoding (#91)
+
+## 0.2.1
+
+- chore: Single-quoted strings in config/examples (#87)
+- chore: Use workspace analysis for all packages (#88)
+
+## 0.2.0
+
+- initial release

--- a/generated/google_cloud_logging_v2/CHANGELOG.md
+++ b/generated/google_cloud_logging_v2/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+## 0.5.3
+
+- chore: update librarian to v0.21.0 (#289)
+- fix(protobuf): fix `FieldMask` encoding (#257)
+
+## 0.5.2
+
+- fix: `NullValue` serialization and deserialization (#254)
+- chore: upgrade to latest sidekick (better fakes) (#248)
+- chore: upgrade to lastest sidekick (#247)
+
+## 0.5.1
+
+- chore: verify handling of `Empty` fields (#208)
+- chore: fix syntax error in  `tests` workflow (#205)
+- chore: run all cloud integration tests on GCP (#176)
+- feat(gcs): support for downloading objects (#138)
+- chore: Move http tests recording into a subdirectory (#128)
+- chore: add librarian config (#120)
+
+## 0.5.0
+
+- chore: Update side and API sources and regen (#119)
+- fix(dart): Add proto serialization conformance tests (#102)
+
+## 0.4.0
+
+- feat: Create exception subclasses (#101)
+- chore: Mark test recordings as generated (#97)
+
+## 0.3.0
+
+- fix: Fix `repeated double` decoding (#91)
+
+## 0.2.1
+
+- chore: Single-quoted strings in config/examples (#87)
+- chore: Use workspace analysis for all packages (#88)
+
+## 0.2.0
+
+- initial release

--- a/generated/google_cloud_longrunning/CHANGELOG.md
+++ b/generated/google_cloud_longrunning/CHANGELOG.md
@@ -1,0 +1,61 @@
+# Changelog
+
+## 0.5.3
+
+- chore: update librarian to v0.21.0 (#289)
+- fix(protobuf): fix `FieldMask` encoding (#257)
+
+## 0.5.2
+
+- fix: `NullValue` serialization and deserialization (#254)
+- chore: upgrade to latest sidekick (better fakes) (#248)
+- chore: upgrade to lastest sidekick (#247)
+
+## 0.5.1
+
+- chore: verify handling of `Empty` fields (#208)
+- chore: add librarian config (#120)
+
+## 0.5.0
+
+- chore: Update side and API sources and regen (#119)
+- fix(dart): Add proto serialization conformance tests (#102)
+
+## 0.4.0
+
+- feat: Create exception subclasses (#101)
+
+## 0.3.0
+
+- fix: Fix `repeated double` decoding (#91)
+
+## 0.2.1
+
+- chore: Single-quoted strings in config/examples (#87)
+- chore: Use workspace analysis for all packages (#88)
+- feat: update using null-safety generator change (#69)
+- feat: add isNotDefault extension methods for core proto types (#68)
+
+## 0.2.0
+
+- feat: Move `_gax` functionality to `_rpc` (#67)
+
+## 0.1.2
+
+- fix: ConfigurationException in `fromApiKey` (#64)
+
+## 0.1.1
+
+- fix: Remove dependency on dart:io (#56)
+- feat: Remove protobuf dep on _gax (#52)
+- feat: update to the most recent sidekick version (#49)
+- chore: Update to the latest API sources (#39)
+- chore: Update to latest sidekick (#38)
+- feat: Use correct issue tracker urls (#31)
+- chore: Update to sidekick v0.3.1-0.20251013160330-f7a65558c218 (#20)
+- chore: Upgrade Sidekick to head (#10)
+- chore: Sync with google-cloud/rust/dart
+
+## 0.1.0
+
+- initial release

--- a/generated/google_cloud_protobuf/CHANGELOG.md
+++ b/generated/google_cloud_protobuf/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog
+
+## 0.5.3
+
+- chore: update api sources (#311)
+- chore: update librarian to v0.21.0 (#289)
+- fix(protobuf): ensure fraction digits in Duration JSON (#258)
+- fix(protobuf): fix `FieldMask` encoding (#257)
+
+## 0.5.2
+
+- fix: `NullValue` serialization and deserialization (#254)
+- chore: upgrade to lastest sidekick (#247)
+
+## 0.5.1
+
+- chore: verify handling of `Empty` fields (#208)
+- chore: regen apis with latest librarian/apis (#170)
+- chore: add librarian config (#120)
+
+## 0.5.0
+
+- chore: Update side and API sources and regen (#119)
+- feat(google_cloud_storage): Bucket creation (#111)
+- feat: Add a skeleton GCS client (#108)
+- fix(dart): Add proto serialization conformance tests (#102)
+
+## 0.4.0
+
+- feat: Create exception subclasses (#101)
+
+## 0.3.0
+
+- fix: Fix `repeated double` decoding (#91)
+
+## 0.2.1
+
+- chore: Single-quoted strings in config/examples (#87)
+- test: Add some conformance tests (#93)
+- chore: Use workspace analysis for all packages (#88)
+
+## 0.2.0
+
+- feat: update using null-safety generator change (#69)
+
+## 0.1.1
+
+- feat: add isNotDefault extension methods for core proto types (#68)
+
+## 0.1.0
+
+- initial release

--- a/generated/google_cloud_rpc/CHANGELOG.md
+++ b/generated/google_cloud_rpc/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+## 0.5.3
+
+- feat(storage): support ifMetagenerationNotMatch (#304)
+- chore: update api sources (#311)
+- chore: update librarian to v0.21.0 (#289)
+- fix(protobuf): fix `FieldMask` encoding (#257)
+
+## 0.5.2
+
+- fix: `NullValue` serialization and deserialization (#254)
+- chore: upgrade to lastest sidekick (#247)
+- test(storage): add support for Storage TestBench (#210)
+
+## 0.5.1
+
+- chore: verify handling of `Empty` fields (#208)
+- chore: add librarian config (#120)
+
+## 0.5.0
+
+- chore: Update side and API sources and regen (#119)
+- fix(dart): Add proto serialization conformance tests (#102)
+
+## 0.4.0
+
+- feat: Create exception subclasses (#101)
+
+## 0.3.0
+
+- fix: Fix `repeated double` decoding (#91)
+
+## 0.2.1
+
+- chore: Single-quoted strings in config/examples (#87)
+- test: Add some conformance tests (#93)
+- chore: Use workspace analysis for all packages (#88)
+- test: Start of showcase conformance tests (#78)
+- feat: update using null-safety generator change (#69)
+- feat: add isNotDefault extension methods for core proto types (#68)
+
+## 0.2.0
+
+- feat: Move `_gax` functionality to `_rpc` (#67)
+
+## 0.1.0
+
+- fix: ConfigurationException in `fromApiKey` (#64)
+
+## 0.1.1
+
+- initial release

--- a/generated/google_cloud_secretmanager_v1/CHANGELOG.md
+++ b/generated/google_cloud_secretmanager_v1/CHANGELOG.md
@@ -1,0 +1,70 @@
+# Changelog
+
+## 0.5.3
+
+- chore: update api sources (#311)
+- chore: update librarian to v0.21.0 (#289)
+- fix(protobuf): fix `FieldMask` encoding (#257)
+
+## 0.5.2
+
+- fix: `NullValue` serialization and deserialization (#254)
+- chore: upgrade to latest sidekick (better fakes) (#248)
+- chore: upgrade to lastest sidekick (#247)
+
+## 0.5.1
+
+- chore: verify handling of `Empty` fields (#208)
+- chore: run all cloud integration tests on GCP (#176)
+- feat(gcs): support for downloading objects (#138)
+- chore: Move http tests recording into a subdirectory (#128)
+- chore: add librarian config (#120)
+
+## 0.5.0
+
+- chore: Update side and API sources and regen (#119)
+- test: Test all Compliance service methods (#106)
+- fix(dart): Add proto serialization conformance tests (#102)
+
+## 0.4.0
+
+- feat: Create exception subclasses (#101)
+- chore: Mark test recordings as generated (#97)
+
+## 0.3.0
+
+- fix: Fix `repeated double` decoding (#91)
+
+## 0.2.1
+
+- chore: Single-quoted strings in config/examples (#87)
+- test: Add some conformance tests (#93)
+- chore: Use workspace analysis for all packages (#88)
+- test: integration tests for secret manager (#76)
+- chore: Use sidekick @v1.0.1 (#75)
+- feat: update using null-safety generator change (#69)
+- feat: add isNotDefault extension methods for core proto types (#68)
+
+## 0.2.0
+
+- feat: Move `_gax` functionality to `_rpc` (#67)
+
+## 0.1.2
+
+- fix: ConfigurationException in `fromApiKey` (#64)
+
+## 0.1.1
+
+- fix: Remove dependency on dart:io (#56)
+- feat: Remove protobuf dep on _gax (#52)
+- feat: update to the most recent sidekick version (#49)
+- chore: Update to the latest API sources (#39)
+- chore: Update to latest sidekick (#38)
+- feat: Use correct issue tracker urls (#31)
+- chore: Update to sidekick v0.3.1-0.20251013160330-f7a65558c218 (#20)
+- chore: Upgrade Sidekick to head (#10)
+- chore: Sync with google-cloud/rust/dart
+
+## 0.1.0
+
+- initial release

--- a/generated/google_cloud_type/CHANGELOG.md
+++ b/generated/google_cloud_type/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+## 0.5.3
+
+- chore: update api sources (#311)
+- chore: update librarian to v0.21.0 (#289)
+- fix(protobuf): fix `FieldMask` encoding (#257)
+
+## 0.5.2
+
+- fix: `NullValue` serialization and deserialization (#254)
+- chore: upgrade to lastest sidekick (#247)
+
+## 0.5.1
+
+- chore: verify handling of `Empty` fields (#208)
+- chore: add librarian config (#120)
+
+## 0.5.0
+
+- chore: Update side and API sources and regen (#119)
+- fix(dart): Add proto serialization conformance tests (#102)
+
+## 0.4.0
+
+- feat: Create exception subclasses (#101)
+
+## 0.3.0
+
+- fix: Fix `repeated double` decoding (#91)
+
+## 0.2.1
+
+- chore: Single-quoted strings in config/examples (#87)
+- chore: Use workspace analysis for all packages (#88)
+
+## 0.2.0
+
+- feat: update using null-safety generator change (#69)
+- feat: add isNotDefault extension methods for core proto types (#68)
+
+## 0.1.0
+
+- fix: ConfigurationException in `fromApiKey` (#64)
+
+## 0.1.1
+
+- initial release

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -403,7 +403,6 @@ libraries:
     apis:
       - path: src/google/protobuf
     keep:
-      - CHANGELOG.md
       - test/serialization_test.dart
     output: generated/google_cloud_protojson_conformance
     roots:
@@ -453,7 +452,6 @@ libraries:
       - path: schema/google/showcase/v1beta1
     copyright_year: "2025"
     keep:
-      - CHANGELOG.md
       - dart_test.yaml
       - test/compliance_test.dart
       - test/echo_test.dart

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -63,6 +63,7 @@ libraries:
       - path: google/ai/generativelanguage/v1beta
     copyright_year: "2025"
     keep:
+      - CHANGELOG.md
       - dart_test.yaml
       - example/application_default_credentials.dart
       - example/main.dart
@@ -152,6 +153,7 @@ libraries:
     version: 0.5.3
     copyright_year: "2025"
     keep:
+      - CHANGELOG.md
       - dart_test.yaml
       - example/main.dart
       - test/generate_test.dart
@@ -258,6 +260,8 @@ libraries:
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_aiplatform_v1beta1
       supports_sse: true
   - name: google_cloud_api
+    keep:
+      - CHANGELOG.md
     version: 0.5.3
     apis:
       - path: google/api
@@ -266,6 +270,8 @@ libraries:
       name_override: api
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_api
   - name: google_cloud_common
+    keep:
+      - CHANGELOG.md
     version: 0.5.3
     copyright_year: "2025"
     dart:
@@ -276,6 +282,7 @@ libraries:
       - path: google/firestore/v1
     copyright_year: "2026"
     keep:
+      - CHANGELOG.md
       - dart_test.yaml
       - example/main.dart
       - test/firestore_test.dart
@@ -287,11 +294,15 @@ libraries:
         > [`package:google_cloud_firestore`](https://pub.dev/packages/google_cloud_firestore).
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_firestore_v1
   - name: google_cloud_functions_v2
+    keep:
+      - CHANGELOG.md
     version: 0.5.3
     copyright_year: "2025"
     dart:
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_functions_v2
   - name: google_cloud_iam_v1
+    keep:
+      - CHANGELOG.md
     version: 0.5.3
     apis:
       - path: google/iam/v1
@@ -300,17 +311,23 @@ libraries:
       name_override: iam
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_iam_v1
   - name: google_cloud_language_v2
+    keep:
+      - CHANGELOG.md
     version: 0.5.3
     copyright_year: "2025"
     dart:
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_language_v2
   - name: google_cloud_location
+    keep:
+      - CHANGELOG.md
     version: 0.5.3
     copyright_year: "2025"
     dart:
       name_override: location
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_location
   - name: google_cloud_logging_type
+    keep:
+      - CHANGELOG.md
     version: 0.5.3
     apis:
       - path: google/logging/type
@@ -325,6 +342,7 @@ libraries:
       - path: google/logging/v2
     copyright_year: "2025"
     keep:
+      - CHANGELOG.md
       - dart_test.yaml
       - test/write_log_test.dart
     dart:
@@ -336,6 +354,7 @@ libraries:
       - path: google/longrunning
     copyright_year: "2025"
     keep:
+      - CHANGELOG.md
       - test/operation_test.dart
       - lib/src/longrunning.p.dart
     dart:
@@ -349,6 +368,7 @@ libraries:
       - path: google/protobuf
     copyright_year: "2025"
     keep:
+      - CHANGELOG.md
       - lib/src/encoding.dart
       - test/any_test.dart
       - test/duration_test.dart
@@ -383,6 +403,7 @@ libraries:
     apis:
       - path: src/google/protobuf
     keep:
+      - CHANGELOG.md
       - test/serialization_test.dart
     output: generated/google_cloud_protojson_conformance
     roots:
@@ -400,6 +421,7 @@ libraries:
       - path: google/rpc
     copyright_year: "2025"
     keep:
+      - CHANGELOG.md
       - lib/exceptions.dart
       - lib/service_client.dart
       - lib/src/exceptions.dart
@@ -419,6 +441,7 @@ libraries:
     version: 0.5.3
     copyright_year: "2025"
     keep:
+      - CHANGELOG.md
       - dart_test.yaml
       - test/secret_test.dart
     dart:
@@ -430,6 +453,7 @@ libraries:
       - path: schema/google/showcase/v1beta1
     copyright_year: "2025"
     keep:
+      - CHANGELOG.md
       - dart_test.yaml
       - test/compliance_test.dart
       - test/echo_test.dart
@@ -444,6 +468,8 @@ libraries:
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_showcase_v1beta1
       supports_sse: true
   - name: google_cloud_type
+    keep:
+      - CHANGELOG.md
     version: 0.5.3
     apis:
       - path: google/type

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -260,20 +260,20 @@ libraries:
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_aiplatform_v1beta1
       supports_sse: true
   - name: google_cloud_api
-    keep:
-      - CHANGELOG.md
     version: 0.5.3
     apis:
       - path: google/api
     copyright_year: "2025"
+    keep:
+      - CHANGELOG.md
     dart:
       name_override: api
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_api
   - name: google_cloud_common
-    keep:
-      - CHANGELOG.md
     version: 0.5.3
     copyright_year: "2025"
+    keep:
+      - CHANGELOG.md
     dart:
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_common
   - name: google_cloud_firestore_v1
@@ -294,44 +294,44 @@ libraries:
         > [`package:google_cloud_firestore`](https://pub.dev/packages/google_cloud_firestore).
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_firestore_v1
   - name: google_cloud_functions_v2
-    keep:
-      - CHANGELOG.md
     version: 0.5.3
     copyright_year: "2025"
+    keep:
+      - CHANGELOG.md
     dart:
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_functions_v2
   - name: google_cloud_iam_v1
-    keep:
-      - CHANGELOG.md
     version: 0.5.3
     apis:
       - path: google/iam/v1
     copyright_year: "2025"
+    keep:
+      - CHANGELOG.md
     dart:
       name_override: iam
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_iam_v1
   - name: google_cloud_language_v2
-    keep:
-      - CHANGELOG.md
     version: 0.5.3
     copyright_year: "2025"
+    keep:
+      - CHANGELOG.md
     dart:
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_language_v2
   - name: google_cloud_location
-    keep:
-      - CHANGELOG.md
     version: 0.5.3
     copyright_year: "2025"
+    keep:
+      - CHANGELOG.md
     dart:
       name_override: location
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_location
   - name: google_cloud_logging_type
-    keep:
-      - CHANGELOG.md
     version: 0.5.3
     apis:
       - path: google/logging/type
     copyright_year: "2025"
+    keep:
+      - CHANGELOG.md
     dart:
       name_override: logging_type
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_logging_type
@@ -466,11 +466,11 @@ libraries:
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_showcase_v1beta1
       supports_sse: true
   - name: google_cloud_type
-    keep:
-      - CHANGELOG.md
     version: 0.5.3
     apis:
       - path: google/type
     copyright_year: "2025"
+    keep:
+      - CHANGELOG.md
     dart:
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_type


### PR DESCRIPTION
Adds `generated/<package>/CHANGELOG.md` for all generated packages.

For future releases, `librarian bump` will keep the `CHANGELOG.md`s up-to-date.