### PR TITLE
fix(logging,shelf): widen meta constraint to unblock Flutter stable compatibility

### DIFF
--- a/pkgs/google_cloud_logging/CHANGELOG.md
+++ b/pkgs/google_cloud_logging/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.6.0+2-wip
+## 0.6.0+2
 
 - Widened the `meta` constraint from `^1.18.2` to `^1.17.0`.
 

--- a/pkgs/google_cloud_logging/CHANGELOG.md
+++ b/pkgs/google_cloud_logging/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.0+2-wip
+
+- Widened the `meta` constraint from `^1.18.2` to `^1.17.0`.
+
 ## 0.6.0+1
 
 - Removed unexported `createStructuredLog` from library doc comment.

--- a/pkgs/google_cloud_logging/pubspec.yaml
+++ b/pkgs/google_cloud_logging/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_cloud_logging
 description: >-
   Structured logging for Google Cloud environments with trace correlation
   and automatic formatting.
-version: 0.6.0+2-wip
+version: 0.6.0+2
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/pkgs/google_cloud_logging
 
 resolution: workspace

--- a/pkgs/google_cloud_logging/pubspec.yaml
+++ b/pkgs/google_cloud_logging/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_cloud_logging
 description: >-
   Structured logging for Google Cloud environments with trace correlation
   and automatic formatting.
-version: 0.6.0+1
+version: 0.6.0+2-wip
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/pkgs/google_cloud_logging
 
 resolution: workspace
@@ -14,7 +14,7 @@ dependencies:
   google_cloud_logging_type: ^0.5.2
   google_cloud_logging_v2: ^0.5.2
   logging: ^1.3.0
-  meta: ^1.18.2
+  meta: ^1.17.0
   stack_trace: ^1.11.0
   web: ^1.1.1
 

--- a/pkgs/google_cloud_shelf/CHANGELOG.md
+++ b/pkgs/google_cloud_shelf/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.0+2-wip
+
+- Widened the `meta` constraint from `^1.18.2` to `^1.17.0`.
+
 ## 0.6.0+1
 
 - Updated `README.md` to reference `StructuredLogger` instead of

--- a/pkgs/google_cloud_shelf/CHANGELOG.md
+++ b/pkgs/google_cloud_shelf/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.6.0+2-wip
+## 0.6.0+2
 
 - Widened the `meta` constraint from `^1.18.2` to `^1.17.0`.
 

--- a/pkgs/google_cloud_shelf/pubspec.yaml
+++ b/pkgs/google_cloud_shelf/pubspec.yaml
@@ -1,5 +1,5 @@
 name: google_cloud_shelf
-version: 0.6.0+2-wip
+version: 0.6.0+2
 description: >-
   Shelf middleware for Google Cloud environments providing structured
   logging, trace correlation, exception mapping, and graceful shutdown

--- a/pkgs/google_cloud_shelf/pubspec.yaml
+++ b/pkgs/google_cloud_shelf/pubspec.yaml
@@ -1,5 +1,5 @@
 name: google_cloud_shelf
-version: 0.6.0+1
+version: 0.6.0+2-wip
 description: >-
   Shelf middleware for Google Cloud environments providing structured
   logging, trace correlation, exception mapping, and graceful shutdown
@@ -14,7 +14,7 @@ environment:
 dependencies:
   google_cloud_logging: ^0.6.0
   http: ^1.6.0
-  meta: ^1.18.2
+  meta: ^1.17.0
   shelf: ^1.4.2
   stack_trace: ^1.12.1
 


### PR DESCRIPTION
Fixes firebase/firebase-functions-dart#236.

`google_cloud_shelf` and `google_cloud_logging` pin `meta: ^1.18.2`, but Flutter stable currently bundles exactly `meta 1.18.0`. Since Flutter pins the SDK's `meta` version, any pub workspace that mixes a Flutter app with either package — for example sharing code between a Flutter client and a Dart Cloud Functions backend built on `firebase_functions` — fails to resolve.