### PR TITLE
fix(ci): pin gapic-showcase and stabilize cloud integration tests

### DIFF
--- a/generated/google_cloud_logging_v2/test/write_log_test.dart
+++ b/generated/google_cloud_logging_v2/test/write_log_test.dart
@@ -32,7 +32,7 @@ void main() async {
   late LoggingServiceV2 logService;
   late http.Client client;
 
-  group('LoggingServiceV2', () {
+  group('LoggingServiceV2', timeout: const Timeout(Duration(minutes: 2)), () {
     setUp(() async {
       Future<auth.AutoRefreshingAuthClient> authClient() async =>
           await auth.clientViaApplicationDefaultCredentials(
@@ -95,9 +95,13 @@ void main() async {
           ],
         ),
       );
-      addTearDown(
-        () => logService.deleteLog(DeleteLogRequest(logName: logName)),
-      );
+      addTearDown(() async {
+        try {
+          await logService.deleteLog(DeleteLogRequest(logName: logName));
+        } on NotFoundException {
+          // Ignored if the log was not indexed before test ended.
+        }
+      });
 
       final list = await waitForLogs('logName:"$logName"');
       expect(list, hasLength(1));

--- a/generated/google_cloud_logging_v2/test/write_log_test.dart
+++ b/generated/google_cloud_logging_v2/test/write_log_test.dart
@@ -95,22 +95,14 @@ void main() async {
           ],
         ),
       );
-      // Writes are not always committed instantly.
-      await Future<void>.delayed(const Duration(seconds: 15));
       addTearDown(
         () => logService.deleteLog(DeleteLogRequest(logName: logName)),
       );
 
-      final list = await logService.listLogEntries(
-        ListLogEntriesRequest(
-          filter: 'logName:"$logName"',
-          orderBy: 'timestamp desc',
-          resourceNames: ['projects/$projectId'],
-        ),
-      );
-      expect(list.entries, hasLength(1));
-      expect(list.entries[0].severity, LogSeverity.critical);
-      expect(list.entries[0].textPayload, 'Hello World!');
+      final list = await waitForLogs('logName:"$logName"');
+      expect(list, hasLength(1));
+      expect(list[0].severity, LogSeverity.critical);
+      expect(list[0].textPayload, 'Hello World!');
     });
   });
 }

--- a/generated/google_cloud_showcase_v1beta1/test/echo_test.dart
+++ b/generated/google_cloud_showcase_v1beta1/test/echo_test.dart
@@ -68,17 +68,13 @@ void main() async {
       );
     });
 
-    test(
-      'request_id unset',
-      () async {
-        final response = await echoService.echo(
-          EchoRequest(content: 'request_id unset'),
-        );
-        expect(response.requestId, isNotEmpty);
-        expect(response.otherRequestId, isNotEmpty);
-      },
-      skip: 'https://github.com/googleapis/google-cloud-dart/issues/80',
-    );
+    test('request_id unset', () async {
+      final response = await echoService.echo(
+        EchoRequest(content: 'request_id unset'),
+      );
+      expect(response.requestId, isNotEmpty);
+      expect(response.otherRequestId, isNotEmpty);
+    }, skip: 'https://github.com/googleapis/google-cloud-dart/issues/80');
 
     test('request_id custom', () async {
       const requestId = '92500ce6-fba2-4fc5-92ad-b7250282c2fc';

--- a/generated/google_cloud_showcase_v1beta1/test/echo_test.dart
+++ b/generated/google_cloud_showcase_v1beta1/test/echo_test.dart
@@ -68,13 +68,17 @@ void main() async {
       );
     });
 
-    test('request_id unset', () async {
-      final response = await echoService.echo(
-        EchoRequest(content: 'request_id unset'),
-      );
-      expect(response.requestId, isNotEmpty);
-      expect(response.otherRequestId, isNotEmpty);
-    }, skip: 'https://github.com/googleapis/google-cloud-dart/issues/80');
+    test(
+      'request_id unset',
+      () async {
+        final response = await echoService.echo(
+          EchoRequest(content: 'request_id unset'),
+        );
+        expect(response.requestId, isNotEmpty);
+        expect(response.otherRequestId, isNotEmpty);
+      },
+      skip: 'https://github.com/googleapis/google-cloud-dart/issues/80',
+    );
 
     test('request_id custom', () async {
       const requestId = '92500ce6-fba2-4fc5-92ad-b7250282c2fc';

--- a/generated/google_cloud_showcase_v1beta1/test/showcase_server.dart
+++ b/generated/google_cloud_showcase_v1beta1/test/showcase_server.dart
@@ -36,7 +36,7 @@ class ShowcaseServer {
     // able to kill it.
     final result = await Process.run('go', [
       'install',
-      'github.com/googleapis/gapic-showcase/cmd/gapic-showcase@latest',
+      'github.com/googleapis/gapic-showcase/cmd/gapic-showcase@v0.40.0',
     ]);
     if (result.exitCode != 0) {
       throw Exception('showcase installation failed ${result.stderr}');

--- a/pkgs/google_cloud_shelf/test/logging_test.dart
+++ b/pkgs/google_cloud_shelf/test/logging_test.dart
@@ -315,11 +315,11 @@ Details:
           headers: await runner.headers(),
         );
         expect(response.statusCode, 200);
-        final entries = await waitForLogs('jsonPayload.message:"$uniqueId"');
+        final entries = await waitForLogs('textPayload:"$uniqueId"');
 
         expect(entries, isNotEmpty);
         final entry = entries.first;
-        expect(entry.jsonPayload?.toJson(), {'message': uniqueId});
+        expect(entry.textPayload, uniqueId);
         expect(entry.severity, LogSeverity.emergency);
         expect(entry.trace, startsWith('projects/$projectId/traces/'));
         expect(entry.spanId, isNotEmpty);

--- a/pkgs/google_cloud_shelf/test/logging_test.dart
+++ b/pkgs/google_cloud_shelf/test/logging_test.dart
@@ -216,110 +216,116 @@ Details:
     await Future<void>.delayed(const Duration(milliseconds: 10));
   });
 
-  group('logging server', tags: 'google-cloud', () {
-    late CloudRunner runner;
+  group(
+    'logging server',
+    tags: 'google-cloud',
+    timeout: const Timeout(Duration(minutes: 2)),
+    () {
+      late CloudRunner runner;
 
-    setUpAll(() async {
-      runner = await CloudRunner.start(
-        'pkgs/google_cloud_shelf/test/logging_server.dart',
-      );
-    });
-
-    tearDownAll(() async {
-      await runner.stop();
-    });
-
-    test('print', () async {
-      final uniqueId = 'print: ${randomAlphaNumString(20)}';
-
-      final response = await http.get(
-        runner.serverUri.replace(
-          path: '/print',
-          queryParameters: {'msg': uniqueId},
-        ),
-        headers: await runner.headers(),
-      );
-      expect(response.statusCode, 200);
-      final entries = await waitForLogs('textPayload:"$uniqueId"');
-
-      expect(entries, isNotEmpty);
-      final entry = entries.first;
-      expect(entry.textPayload, uniqueId);
-      expect(entry.severity, LogSeverity.info);
-      expect(entry.trace, startsWith('projects/$projectId/traces/'));
-      expect(entry.spanId, isNotEmpty);
-    });
-
-    test('throw', () async {
-      final uniqueId = 'throw: ${randomAlphaNumString(20)}';
-
-      final response = await http.get(
-        runner.serverUri.replace(
-          path: '/throw',
-          queryParameters: {'msg': uniqueId},
-        ),
-        headers: await runner.headers(),
-      );
-      expect(response.statusCode, 500);
-      final entries = await waitForLogs(
-        'jsonPayload.message:"Exception: $uniqueId"',
-      );
-
-      expect(entries, isNotEmpty);
-      final entry = entries.first;
-      expect(entry.jsonPayload?.toJson(), {
-        'message': 'Exception: $uniqueId',
-        'stack_trace': contains('logging_server.dart'),
+      setUpAll(() async {
+        runner = await CloudRunner.start(
+          'pkgs/google_cloud_shelf/test/logging_server.dart',
+        );
       });
-      expect(entry.severity, LogSeverity.error);
-      expect(entry.trace, startsWith('projects/$projectId/traces/'));
-      expect(entry.spanId, isNotEmpty);
-    });
 
-    test('logging', () async {
-      final uniqueId = 'log: ${randomAlphaNumString(20)}';
-
-      final response = await http.get(
-        runner.serverUri.replace(
-          path: '/logging',
-          queryParameters: {'msg': uniqueId},
-        ),
-        headers: await runner.headers(),
-      );
-      expect(response.statusCode, 200);
-      final entries = await waitForLogs('jsonPayload.message:"$uniqueId"');
-
-      expect(entries, isNotEmpty);
-      final entry = entries.first;
-      expect(entry.jsonPayload?.toJson(), {
-        'loggerName': 'MyClass',
-        'message': uniqueId,
+      tearDownAll(() async {
+        await runner.stop();
       });
-      expect(entry.severity, LogSeverity.error);
-      expect(entry.trace, startsWith('projects/$projectId/traces/'));
-      expect(entry.spanId, isNotEmpty);
-    });
 
-    test('structured logging', () async {
-      final uniqueId = 'structured: ${randomAlphaNumString(20)}';
+      test('print', () async {
+        final uniqueId = 'print: ${randomAlphaNumString(20)}';
 
-      final response = await http.get(
-        runner.serverUri.replace(
-          path: '/structured',
-          queryParameters: {'msg': uniqueId},
-        ),
-        headers: await runner.headers(),
-      );
-      expect(response.statusCode, 200);
-      final entries = await waitForLogs('textPayload:"$uniqueId"');
+        final response = await http.get(
+          runner.serverUri.replace(
+            path: '/print',
+            queryParameters: {'msg': uniqueId},
+          ),
+          headers: await runner.headers(),
+        );
+        expect(response.statusCode, 200);
+        final entries = await waitForLogs('textPayload:"$uniqueId"');
 
-      expect(entries, isNotEmpty);
-      final entry = entries.first;
-      expect(entry.severity, LogSeverity.emergency);
-      expect(entry.trace, startsWith('projects/$projectId/traces/'));
-      expect(entry.spanId, isNotEmpty);
-    });
-  });
+        expect(entries, isNotEmpty);
+        final entry = entries.first;
+        expect(entry.textPayload, uniqueId);
+        expect(entry.severity, LogSeverity.info);
+        expect(entry.trace, startsWith('projects/$projectId/traces/'));
+        expect(entry.spanId, isNotEmpty);
+      });
+
+      test('throw', () async {
+        final uniqueId = 'throw: ${randomAlphaNumString(20)}';
+
+        final response = await http.get(
+          runner.serverUri.replace(
+            path: '/throw',
+            queryParameters: {'msg': uniqueId},
+          ),
+          headers: await runner.headers(),
+        );
+        expect(response.statusCode, 500);
+        final entries = await waitForLogs(
+          'jsonPayload.message:"Exception: $uniqueId"',
+        );
+
+        expect(entries, isNotEmpty);
+        final entry = entries.first;
+        expect(entry.jsonPayload?.toJson(), {
+          'message': 'Exception: $uniqueId',
+          'stack_trace': contains('logging_server.dart'),
+        });
+        expect(entry.severity, LogSeverity.error);
+        expect(entry.trace, startsWith('projects/$projectId/traces/'));
+        expect(entry.spanId, isNotEmpty);
+      });
+
+      test('logging', () async {
+        final uniqueId = 'log: ${randomAlphaNumString(20)}';
+
+        final response = await http.get(
+          runner.serverUri.replace(
+            path: '/logging',
+            queryParameters: {'msg': uniqueId},
+          ),
+          headers: await runner.headers(),
+        );
+        expect(response.statusCode, 200);
+        final entries = await waitForLogs('jsonPayload.message:"$uniqueId"');
+
+        expect(entries, isNotEmpty);
+        final entry = entries.first;
+        expect(entry.jsonPayload?.toJson(), {
+          'loggerName': 'MyClass',
+          'message': uniqueId,
+        });
+        expect(entry.severity, LogSeverity.error);
+        expect(entry.trace, startsWith('projects/$projectId/traces/'));
+        expect(entry.spanId, isNotEmpty);
+      });
+
+      test('structured logging', () async {
+        final uniqueId = 'structured: ${randomAlphaNumString(20)}';
+
+        final response = await http.get(
+          runner.serverUri.replace(
+            path: '/structured',
+            queryParameters: {'msg': uniqueId},
+          ),
+          headers: await runner.headers(),
+        );
+        expect(response.statusCode, 200);
+        final entries = await waitForLogs('jsonPayload.message:"$uniqueId"');
+
+        expect(entries, isNotEmpty);
+        final entry = entries.first;
+        expect(entry.jsonPayload?.toJson(), {'message': uniqueId});
+        expect(entry.severity, LogSeverity.emergency);
+        expect(entry.trace, startsWith('projects/$projectId/traces/'));
+        expect(entry.spanId, isNotEmpty);
+      });
+    },
+  );
 }
 
 enum _ResponseScenarios {

--- a/test_utils/lib/src/cloud.dart
+++ b/test_utils/lib/src/cloud.dart
@@ -61,18 +61,30 @@ Future<List<LogEntry>> waitForLogs(
       pageSize: count,
     );
 
-    final endTime = DateTime.now().add(timeout);
+    final startTime = DateTime.now();
+    final endTime = startTime.add(timeout);
 
     var first = true;
+    var attempt = 1;
     do {
       if (!first) {
         await Future<void>.delayed(const Duration(seconds: 2));
       }
       first = false;
+      final elapsed = DateTime.now().difference(startTime);
       final listResult = await loggingService.listLogEntries(request);
       if (listResult.entries.isNotEmpty) {
+        print(
+          '[waitForLogs] Found ${listResult.entries.length} log entry(ies) '
+          'for "$filter" in ${elapsed.inSeconds}s (attempt $attempt).',
+        );
         return listResult.entries;
       }
+      print(
+        '[waitForLogs] Waiting for logs matching "$filter"... '
+        'elapsed: ${elapsed.inSeconds}s (attempt $attempt)',
+      );
+      attempt++;
     } while (DateTime.now().isBefore(endTime));
     throw StateError(
       'Log entries matching "$filter" were not found within the timeout.',

--- a/test_utils/lib/src/cloud.dart
+++ b/test_utils/lib/src/cloud.dart
@@ -76,12 +76,12 @@ Future<List<LogEntry>> waitForLogs(
       if (listResult.entries.isNotEmpty) {
         print(
           '[waitForLogs] Found ${listResult.entries.length} log entry(ies) '
-          'for "$filter" in ${elapsed.inSeconds}s (attempt $attempt).',
+          'in ${elapsed.inSeconds}s (attempt $attempt).',
         );
         return listResult.entries;
       }
       print(
-        '[waitForLogs] Waiting for logs matching "$filter"... '
+        '[waitForLogs] Waiting for logs... '
         'elapsed: ${elapsed.inSeconds}s (attempt $attempt)',
       );
       attempt++;

--- a/test_utils/lib/src/cloud.dart
+++ b/test_utils/lib/src/cloud.dart
@@ -15,6 +15,7 @@
 import 'dart:io';
 import 'package:google_cloud_logging_v2/logging.dart';
 import 'package:googleapis_auth/auth_io.dart' as auth;
+import 'package:test/test.dart';
 
 /// A real Google test account managed by bquinlan@google.com using Rhea.
 const googleTestUser = 'daenerysstone.938939@gmail.com';
@@ -72,18 +73,18 @@ Future<List<LogEntry>> waitForLogs(
       }
       first = false;
       final elapsed = DateTime.now().difference(startTime);
+      printOnFailure(
+        '[waitForLogs] Waiting for logs matching "$filter"... '
+        'elapsed: ${elapsed.inSeconds}s (attempt $attempt)',
+      );
       final listResult = await loggingService.listLogEntries(request);
       if (listResult.entries.isNotEmpty) {
-        print(
+        printOnFailure(
           '[waitForLogs] Found ${listResult.entries.length} log entry(ies) '
-          'in ${elapsed.inSeconds}s (attempt $attempt).',
+          'for "$filter" in ${elapsed.inSeconds}s (attempt $attempt).',
         );
         return listResult.entries;
       }
-      print(
-        '[waitForLogs] Waiting for logs... '
-        'elapsed: ${elapsed.inSeconds}s (attempt $attempt)',
-      );
       attempt++;
     } while (DateTime.now().isBefore(endTime));
     throw StateError(

--- a/test_utils/lib/src/cloud.dart
+++ b/test_utils/lib/src/cloud.dart
@@ -62,8 +62,7 @@ Future<List<LogEntry>> waitForLogs(
       pageSize: count,
     );
 
-    final startTime = DateTime.now();
-    final endTime = startTime.add(timeout);
+    final stopwatch = Stopwatch()..start();
 
     var first = true;
     var attempt = 1;
@@ -72,21 +71,22 @@ Future<List<LogEntry>> waitForLogs(
         await Future<void>.delayed(const Duration(seconds: 2));
       }
       first = false;
-      final elapsed = DateTime.now().difference(startTime);
+      final elapsed = stopwatch.elapsed;
       printOnFailure(
         '[waitForLogs] Waiting for logs matching "$filter"... '
         'elapsed: ${elapsed.inSeconds}s (attempt $attempt)',
       );
       final listResult = await loggingService.listLogEntries(request);
       if (listResult.entries.isNotEmpty) {
+        final finalElapsed = stopwatch.elapsed;
         printOnFailure(
           '[waitForLogs] Found ${listResult.entries.length} log entry(ies) '
-          'for "$filter" in ${elapsed.inSeconds}s (attempt $attempt).',
+          'for "$filter" in ${finalElapsed.inSeconds}s (attempt $attempt).',
         );
         return listResult.entries;
       }
       attempt++;
-    } while (DateTime.now().isBefore(endTime));
+    } while (stopwatch.elapsed < timeout);
     throw StateError(
       'Log entries matching "$filter" were not found within the timeout.',
     );


### PR DESCRIPTION
Fixes CI failures across GitHub Actions and Cloud Build integration tests:

- **Showcase Tests**: Pin `gapic-showcase` installation to `v0.40.0` in [generated/google_cloud_showcase_v1beta1/test/showcase_server.dart](https://github.com/googleapis/google-cloud-dart/blob/main/generated/google_cloud_showcase_v1beta1/test/showcase_server.dart) (upstream `v0.42.0` fails compilation due to an undefined Go TLS identifier).
- **Shelf Logging Integration Tests**: Add a 2-minute timeout to the `logging server` test group in [pkgs/google_cloud_shelf/test/logging_test.dart](https://github.com/googleapis/google-cloud-dart/blob/main/pkgs/google_cloud_shelf/test/logging_test.dart) to account for Cloud Logging ingestion latency.
- **Logging V2 Integration Tests**: In [generated/google_cloud_logging_v2/test/write_log_test.dart](https://github.com/googleapis/google-cloud-dart/blob/main/generated/google_cloud_logging_v2/test/write_log_test.dart), switch from a fixed 15s sleep to `waitForLogs` with a 2-minute group timeout, and ignore `NotFoundException` during tearDown log cleanup.
- **Test Utilities**: In [test_utils/lib/src/cloud.dart](https://github.com/googleapis/google-cloud-dart/blob/main/test_utils/lib/src/cloud.dart), record polling attempts and elapsed time in `waitForLogs` using `printOnFailure` so diagnostic details appear on test failures without polluting stdout in passing runs.