### PR TITLE
feat: add setup and test agentic skills 

### DIFF
--- a/.github/workflows/dart_checks.yaml
+++ b/.github/workflows/dart_checks.yaml
@@ -27,7 +27,7 @@ on:
 env:
   DART_VERSION: 3.9.2
   GOOGLE_CLOUD_PROJECT: test-project
-  LIBRARIAN_VERSION: v0.27.2-0.20260717183731-fbc93ee987c1
+  LIBRARIAN_VERSION: v0.37.1-0.20260817221324-78bd51d27276
 name: Dart Checks
 jobs:
   analyze_and_format:

--- a/.github/workflows/dart_checks.yaml
+++ b/.github/workflows/dart_checks.yaml
@@ -27,7 +27,7 @@ on:
 env:
   DART_VERSION: 3.9.2
   GOOGLE_CLOUD_PROJECT: test-project
-  LIBRARIAN_VERSION: v0.38.1-0.20260818203020-f72812a888ca
+  LIBRARIAN_VERSION: v0.38.1-0.20260821182830-14f8e3362192
 name: Dart Checks
 jobs:
   analyze_and_format:

--- a/.github/workflows/dart_checks.yaml
+++ b/.github/workflows/dart_checks.yaml
@@ -27,7 +27,7 @@ on:
 env:
   DART_VERSION: 3.9.2
   GOOGLE_CLOUD_PROJECT: test-project
-  LIBRARIAN_VERSION: v0.37.1-0.20260817221324-78bd51d27276
+  LIBRARIAN_VERSION: v0.38.1-0.20260818203020-f72812a888ca
 name: Dart Checks
 jobs:
   analyze_and_format:

--- a/generated/README.md
+++ b/generated/README.md
@@ -1,67 +1,27 @@
 # Generated packages
 
 This directory contains Google Cloud API packages that are automatically
-generated from API descriptions.
+generated from API descriptions using
+[Librarian](https://github.com/googleapis/librarian).
 
-## Developing
+## Releasing and Updating
 
-### Librarian
+To update Librarian or API sources, regenerate packages, or create a release,
+see the step-by-step process in [RELEASING.md](RELEASING.md).
 
-[Librarian](https://github.com/googleapis/librarian/blob/main/README.md)
-is the tool used to generate Dart packages from API descriptions.
+## Local Development
 
-#### Regenerating the Dart packages
+### Regenerating from a locally modified Librarian
 
-From the root of the project:
-
-```bash
-go run github.com/googleapis/librarian/cmd/librarian@main generate -all
-```
-
-> [!NOTE]
-> You will have to [update Librarian](#updating-librarian) if you want to merge these changes.
-
-#### Regenerating from a locally modified Librarian
-
-Clone https://github.com/googleapis/librarian as a sibling directory to this
-repo, make any desired changes to Librarian, then - from the root of the
-project - run:
+When developing changes in Librarian itself, clone
+https://github.com/googleapis/librarian as a sibling directory to this repo,
+make your changes, then build and run Librarian locally:
 
 ```bash
 # Build the binary
 go -C ../librarian build -o ../librarian/librarian ./cmd/librarian
-# Run library regeneration
-../librarian/librarian generate -all
-```
-> [!NOTE]
-> Use `-f` to ignore the librarian version check since the local version is likely not the same
-> as the one in [../librarian.yaml](../librarian.yaml).
 
-#### Updating Librarian
-
-[Workflow automation](../.github/workflows/dart_checks.yaml) ensures that all
-generated code matches what the generator would actually produce.
-
-To prevent Librarian changes from causing workflow automation failures in this
-repository, the version of Librarian used by this automation is pinned.
-
-After making changes to Librarian you must 
-[regenerate the Dart packages](#regenerating-the-dart-packages) and update
-the version of Librarian used in the automation:
-1. Find the head version of Librarian by running this command:
-   
-   `GOPROXY=direct go list -m -u -f '{{.Version}}' github.com/googleapis/librarian@main`
-2. Modify the Librarian invocation in [../.github/workflows/dart_checks.yaml](../.github/workflows/dart_checks.yaml)
-
-#### Updating API sources
-
-Configuration for API source descriptions is found in the `[sources]`
-section of the root [`../librarian.yaml`](../librarian.yaml).
-
-You can update these sources to their latest versions by running
-(from the root of the project):
-
-```bash
-go run github.com/googleapis/librarian/cmd/librarian@main update sources.conformance sources.googleapis sources.protobuf sources.showcase
+# Run library regeneration (-f ignores the librarian version check)
+../librarian/librarian generate -all -f
 ```
 

--- a/generated/README.md
+++ b/generated/README.md
@@ -22,6 +22,6 @@ make your changes, then build and run Librarian locally:
 go -C ../librarian build -o ../librarian/librarian ./cmd/librarian
 
 # Run library regeneration (-f ignores the librarian version check)
-../librarian/librarian generate -all -f
+../librarian/librarian generate -all
 ```
 

--- a/generated/README.md
+++ b/generated/README.md
@@ -18,10 +18,7 @@ https://github.com/googleapis/librarian as a sibling directory to this repo,
 make your changes, then build and run Librarian locally:
 
 ```bash
-# Build the binary
 go -C ../librarian build -o ../librarian/librarian ./cmd/librarian
-
-# Run library regeneration (-f ignores the librarian version check)
 ../librarian/librarian generate -all
 ```
 

--- a/generated/RELEASING.md
+++ b/generated/RELEASING.md
@@ -22,9 +22,10 @@ export LIBRARIAN_VERSION=$(GOPROXY=direct go list -m -u -f '{{.Version}}' \
 echo $LIBRARIAN_VERSION
 ```
 
-Update the `LIBRARIAN_VERSION` environment variable in
-[`.github/workflows/dart_checks.yaml`](../.github/workflows/dart_checks.yaml)
-to match this version.
+Update the version in both:
+- `LIBRARIAN_VERSION` in
+  [`.github/workflows/dart_checks.yaml`](../.github/workflows/dart_checks.yaml)
+- The top-level `version` field in [`../librarian.yaml`](../librarian.yaml)
 
 ## 2. Update API sources (optional)
 

--- a/generated/RELEASING.md
+++ b/generated/RELEASING.md
@@ -1,39 +1,73 @@
 
-## Install prerequesits
+# Releasing Generated Packages
 
-dart pub global activate dart_apitool
+This document describes how to update API descriptions and release generated
+packages.
 
-# 1: Upgrade to the latest version of librarian
+## Prerequisites
+
+Install `dart_apitool` for checking API compatibility:
 
 ```bash
-export LIBRARY_VERSION=$(go list -m -u -f '{{.Version}}' github.com/googleapis/librarian@main)
-echo $LIBRARY_VERSION
+dart pub global activate dart_apitool
+```
+
+## 1. Upgrade to the latest version of Librarian
+
+Find the latest version of Librarian on `@main`:
+
+```bash
+export LIBRARIAN_VERSION=$(GOPROXY=direct go list -m -u -f '{{.Version}}' \
+  github.com/googleapis/librarian@main)
+echo $LIBRARIAN_VERSION
 ```
 
 Update the `LIBRARIAN_VERSION` environment variable in
-[.github/workflows/dart_checks.yaml](../.github/workflows/dart_checks.yaml).
+[`.github/workflows/dart_checks.yaml`](../.github/workflows/dart_checks.yaml)
+to match this version.
 
-# 2: Update API sources
+## 2. Update API sources (optional)
 
-```bash
-go run github.com/googleapis/librarian/cmd/librarian@${LIBRARIAN_VERSION} update sources.conformance sources.googleapis sources.protobuf sources.showcase
-```
-
-> [!NOTE]
-> Configuration for API source descriptions is found in the `[sources]`
-> section of the root [`../librarian.yaml`](../librarian.yaml).
-
-# 3: Regenerate the Dart packages
+Update the API source descriptions in [`../librarian.yaml`](../librarian.yaml)
+to their latest versions:
 
 ```bash
-go run github.com/googleapis/librarian/cmd/librarian@${LIBRARIAN_VERSION} generate --all
+go run github.com/googleapis/librarian/cmd/librarian@${LIBRARIAN_VERSION} \
+  update \
+  sources.conformance sources.googleapis sources.protobuf sources.showcase
 ```
 
-# 4: Create a PR and merge it
+## 3. Regenerate the Dart packages
 
-TODO: what details do I need here?
+Regenerate all packages, tidy configuration, and update documentation:
+
+```bash
+go run github.com/googleapis/librarian/cmd/librarian@${LIBRARIAN_VERSION} \
+  generate -all
+go run github.com/googleapis/librarian/cmd/librarian@${LIBRARIAN_VERSION} \
+  tidy
+dart run tool/update_docs.dart
+```
+
+## 4. Create a PR and merge it
+
+1. Verify that all tests and analysis pass locally:
+   ```bash
+   dart analyze
+   dart test
+   ```
+2. Commit the changes and open a pull request against `main`. Use a commit
+   message that describes the functionality added from the point-of-view of
+   the developer, e.g., "feat: add setup and test agentic skills".
 
 > [!TIP]
-> Steps 1-4 can and should be done multiple times (as needed) prior to
-> creating the release. Each PR will add a `CHANGELOG.md` entry to
-> affected generated packages.
+> Steps 1–4 can and should be done multiple times (as needed) prior to
+> creating a release. Each PR adds changelog entries to affected packages.
+> For example, if you update librarian to add a picture of a cat in the
+> `README.md` of the generated packages, you could perform steps 1, 2, 4 with
+> the PR title `"docs: add a picture of a cat to README.md"`. When released,
+> each package will have a `CHANGELOG.md` entry like:
+>
+> ```
+> - docs: add a picture of a cat to README.md
+> ```

--- a/generated/RELEASING.md
+++ b/generated/RELEASING.md
@@ -2,11 +2,11 @@
 # Releasing Generated Packages
 
 This document describes how to update API descriptions and release generated
-packages.
+packages. All commands should be run from the repository root.
 
 ## Prerequisites
 
-Install `dart_apitool` for checking API compatibility:
+Install `dart_apitool` (used to identify breaking changes):
 
 ```bash
 dart pub global activate dart_apitool
@@ -54,7 +54,7 @@ dart run tool/update_docs.dart
 1. Verify that all tests and analysis pass locally:
    ```bash
    dart analyze
-   dart test
+   dart test .
    ```
 2. Commit the changes and open a pull request against `main`. Use a commit
    message that describes the functionality added from the point-of-view of
@@ -64,10 +64,11 @@ dart run tool/update_docs.dart
 > Steps 1–4 can and should be done multiple times (as needed) prior to
 > creating a release. Each PR adds changelog entries to affected packages.
 > For example, if you update librarian to add a picture of a cat in the
-> `README.md` of the generated packages, you could perform steps 1, 2, 4 with
-> the PR title `"docs: add a picture of a cat to README.md"`. When released,
-> each package will have a `CHANGELOG.md` entry like:
+> `README.md` of the generated packages, you could perform steps 1, 3, and 4
+> with the PR title `"docs: add a picture of a cat to README.md"`. When
+> released, each package will have a `CHANGELOG.md` entry like:
 >
-> ```
+> ```markdown
 > - docs: add a picture of a cat to README.md
 > ```
+

--- a/generated/RELEASING.md
+++ b/generated/RELEASING.md
@@ -1,0 +1,39 @@
+
+## Install prerequesits
+
+dart pub global activate dart_apitool
+
+# 1: Upgrade to the latest version of librarian
+
+```bash
+export LIBRARY_VERSION=$(go list -m -u -f '{{.Version}}' github.com/googleapis/librarian@main)
+echo $LIBRARY_VERSION
+```
+
+Update the `LIBRARIAN_VERSION` environment variable in
+[.github/workflows/dart_checks.yaml](../.github/workflows/dart_checks.yaml).
+
+# 2: Update API sources
+
+```bash
+go run github.com/googleapis/librarian/cmd/librarian@${LIBRARIAN_VERSION} update sources.conformance sources.googleapis sources.protobuf sources.showcase
+```
+
+> [!NOTE]
+> Configuration for API source descriptions is found in the `[sources]`
+> section of the root [`../librarian.yaml`](../librarian.yaml).
+
+# 3: Regenerate the Dart packages
+
+```bash
+go run github.com/googleapis/librarian/cmd/librarian@${LIBRARIAN_VERSION} generate --all
+```
+
+# 4: Create a PR and merge it
+
+TODO: what details do I need here?
+
+> [!TIP]
+> Steps 1-4 can and should be done multiple times (as needed) prior to
+> creating the release. Each PR will add a `CHANGELOG.md` entry to
+> affected generated packages.

--- a/generated/google_cloud_ai_generativelanguage_v1beta/README.md
+++ b/generated/google_cloud_ai_generativelanguage_v1beta/README.md
@@ -31,6 +31,19 @@ The Google Cloud client library for the Generative Language API.
 
 The Google Cloud client library for the Generative Language API.
 
+## Agent Skills
+
+This package supports [Agent Skills](https://agentskills.io/home).
+
+To add this package to your application and install the skills for use by your
+Agent, run:
+
+```shell
+dart pub add google_cloud_ai_generativelanguage_v1beta
+dart pub get
+dart run skills@ get
+```
+
 The Gemini API allows developers to build generative AI applications using
 Gemini models. Gemini is our most capable model, built from the ground up
 to be multimodal. It can generalize and seamlessly understand, operate

--- a/generated/google_cloud_ai_generativelanguage_v1beta/lib/generativelanguage.dart
+++ b/generated/google_cloud_ai_generativelanguage_v1beta/lib/generativelanguage.dart
@@ -29,6 +29,8 @@ library;
 // ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: unintended_html_in_doc_comment
 
+export 'package:google_cloud_rpc/exceptions.dart';
+
 export 'src/api.g.dart'
     hide
         FakeCacheService,

--- a/generated/google_cloud_ai_generativelanguage_v1beta/lib/src/api.g.dart
+++ b/generated/google_cloud_ai_generativelanguage_v1beta/lib/src/api.g.dart
@@ -23,6 +23,8 @@
 /// images, audio, video, and code. You can use the Gemini API for use cases
 /// like reasoning across text and images, content generation, dialogue
 /// agents, summarization and classification systems, and more.
+///
+/// @docImport 'package:google_cloud_rpc/exceptions.dart';
 library;
 
 // ignore_for_file: camel_case_types
@@ -36,7 +38,6 @@ library;
 import 'package:google_cloud_longrunning/longrunning.dart';
 import 'package:google_cloud_protobuf/protobuf.dart';
 import 'package:google_cloud_protobuf/src/encoding.dart';
-import 'package:google_cloud_rpc/exceptions.dart';
 import 'package:google_cloud_rpc/rpc.dart';
 import 'package:google_cloud_rpc/service_client.dart';
 import 'package:google_cloud_type/type.dart';

--- a/generated/google_cloud_ai_generativelanguage_v1beta/skills/google_cloud_ai_generativelanguage_v1beta-setup/SKILL.md
+++ b/generated/google_cloud_ai_generativelanguage_v1beta/skills/google_cloud_ai_generativelanguage_v1beta-setup/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: google-cloud-ai-generativelanguage-v1beta-setup
+description: >-
+  Use this skill to help the developer get started with
+  package:google_cloud_ai_generativelanguage_v1beta
+---
+
+## Getting Started with package:google_cloud_ai_generativelanguage_v1beta
+
+### 1. Add the package to your pubspec.yaml
+
+```shell
+dart pub add google_cloud_ai_generativelanguage_v1beta
+```
+
+### 2. Import the library
+
+In your Dart code, import the library:
+
+```dart
+import 'package:google_cloud_ai_generativelanguage_v1beta/generativelanguage.dart';
+```
+
+### 3. Initialize the client
+
+To call the client, you need to create an instance of the service that
+you want to use, e.g., `FileService`.
+
+There are two ways of creating an instance with the necessary credentials.
+
+#### Option A: Using Application Default Credentials (ADC) (Recommended)
+
+Recommended for production environments, server-side backends, and when
+running on Google Cloud (such as Cloud Run, GCE, GKE).
+
+When running on Google Cloud, Application Default Credentials are automatically
+available.
+
+When running locally, the `gcloud` command must be available (see
+[Install the Google Cloud CLI](https://docs.cloud.google.com/sdk/docs/install-sdk)).
+To obtain Application Default Credentials, run:
+
+```shell
+gcloud auth application-default login
+```
+
+Add `googleapis_auth` to your dependencies:
+
+```shell
+dart pub add googleapis_auth
+```
+
+```dart
+import 'package:googleapis_auth/auth_io.dart';
+import 'package:google_cloud_ai_generativelanguage_v1beta/generativelanguage.dart';
+
+Future<void> main() async {
+  final authClient = await clientViaApplicationDefaultCredentials(
+    scopes: [
+      'https://www.googleapis.com/auth/cloud-platform',
+    ],
+  );
+
+  final client = FileService(client: authClient);
+
+  try {
+    // Call a method on the client.
+    final response = await client.createFile(
+      CreateFileRequest(),
+    );
+    print('Response: $response');
+  } finally {
+    // Always close the client to release resources.
+    client.close();
+  }
+}
+```
+
+#### Option B: Using an API Key (Simple)
+
+Recommended for quick testing or prototyping because the setup is simple.
+
+If the user does not have an API key, then they can obtain one using the
+[Google Cloud Console](https://console.cloud.google.com/apis/credentials).
+
+Add the API key to one of these environment variables:
+- `GOOGLE_API_KEY`
+- `GEMINI_API_KEY`
+
+
+```dart
+import 'package:google_cloud_ai_generativelanguage_v1beta/generativelanguage.dart';
+
+Future<void> main() async {
+  final client = FileService.fromApiKey();
+
+  try {
+    // Call a method on the client.
+    final response = await client.createFile(
+      CreateFileRequest(),
+    );
+    print('Response: $response');
+  } finally {
+    // Always close the client to release resources.
+    client.close();
+  }
+}
+```
+

--- a/generated/google_cloud_ai_generativelanguage_v1beta/skills/google_cloud_ai_generativelanguage_v1beta-tests/SKILL.md
+++ b/generated/google_cloud_ai_generativelanguage_v1beta/skills/google_cloud_ai_generativelanguage_v1beta-tests/SKILL.md
@@ -94,8 +94,8 @@ void main() {
           return CreateFileResponse();
       },
     );
-    // Instead of verifying that `functionUnderTest`, you should verify the
-    // relevant properties of the result.
+    // Instead of verifying that `functionUnderTest` completes, you should verify
+    // the relevant properties of the result.
     await expectLater(functionUnderTest(fake), completes);
   });
 }

--- a/generated/google_cloud_ai_generativelanguage_v1beta/skills/google_cloud_ai_generativelanguage_v1beta-tests/SKILL.md
+++ b/generated/google_cloud_ai_generativelanguage_v1beta/skills/google_cloud_ai_generativelanguage_v1beta-tests/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: google-cloud-ai-generativelanguage-v1beta-tests
+description: >-
+  Use this skill when writing tests for code that uses
+  package:google_cloud_ai_generativelanguage_v1beta
+---
+
+## Testing with Fakes
+
+Most unit tests should use fakes instead of making network requests to Google
+services.
+
+- Code that uses `CacheService` can be tested by injecting the
+  fake `FakeCacheService`.
+- Code that uses `DiscussService` can be tested by injecting the
+  fake `FakeDiscussService`.
+- Code that uses `FileService` can be tested by injecting the
+  fake `FakeFileService`.
+- Code that uses `GenerativeService` can be tested by injecting the
+  fake `FakeGenerativeService`.
+- Code that uses `ModelService` can be tested by injecting the
+  fake `FakeModelService`.
+- Code that uses `PermissionService` can be tested by injecting the
+  fake `FakePermissionService`.
+- Code that uses `PredictionService` can be tested by injecting the
+  fake `FakePredictionService`.
+- Code that uses `RetrieverService` can be tested by injecting the
+  fake `FakeRetrieverService`.
+- Code that uses `TextService` can be tested by injecting the
+  fake `FakeTextService`.
+
+Import the fakes from the testing library:
+
+```dart
+import 'package:google_cloud_ai_generativelanguage_v1beta/testing.dart';
+```
+
+### Option A: Using Constructor Closures (Recommended)
+
+You can inject behavior by passing optional function callbacks to the fake's
+constructor. Methods that are not provided will throw an `UnsupportedError`.
+
+```dart
+import 'package:google_cloud_ai_generativelanguage_v1beta/generativelanguage.dart';
+import 'package:google_cloud_ai_generativelanguage_v1beta/testing.dart';
+
+final fake = FakeFileService(
+  createFile: (request) async {
+    // Assert request contents here if needed.
+    return CreateFileResponse();
+  },
+);
+```
+
+### Option B: Subclassing the Fake
+
+For more complex test setups or shared states, you can subclass the fake and
+override its methods. Methods that are not overridden will throw an
+`UnsupportedError`.
+
+```dart
+import 'package:google_cloud_ai_generativelanguage_v1beta/generativelanguage.dart';
+import 'package:google_cloud_ai_generativelanguage_v1beta/testing.dart';
+
+final class MyFakeFileService extends FakeFileService {
+  @override
+  Future<CreateFileResponse> createFile(
+    CreateFileRequest request,
+  ) async {
+    // Assert request contents here if needed.
+    return CreateFileResponse();
+  }
+}
+```
+
+## A Simple Test
+
+```dart
+import 'package:google_cloud_ai_generativelanguage_v1beta/generativelanguage.dart';
+import 'package:google_cloud_ai_generativelanguage_v1beta/testing.dart';
+import 'package:test/test.dart';
+
+Future<void> functionUnderTest(FileService service) async {
+  // Application logic here.
+  await service.createFile(CreateFileRequest());
+  // More application logic here.
+}
+
+void main() {
+  test('test', () async {
+    final fake = FakeFileService(
+      createFile: (request) async {
+          // Assert request contents here.
+          return CreateFileResponse();
+      },
+    );
+    // Instead of verifying that `functionUnderTest`, you should verify the
+    // relevant properties of the result.
+    await expectLater(functionUnderTest(fake), completes);
+  });
+}
+```

--- a/generated/google_cloud_aiplatform_v1beta1/README.md
+++ b/generated/google_cloud_aiplatform_v1beta1/README.md
@@ -31,6 +31,19 @@ The Google Cloud client library for the Vertex AI API.
 
 The Google Cloud client library for the Vertex AI API.
 
+## Agent Skills
+
+This package supports [Agent Skills](https://agentskills.io/home).
+
+To add this package to your application and install the skills for use by your
+Agent, run:
+
+```shell
+dart pub add google_cloud_aiplatform_v1beta1
+dart pub get
+dart run skills@ get
+```
+
 Train high-quality custom machine learning models with minimal machine
 learning expertise and effort.
 

--- a/generated/google_cloud_aiplatform_v1beta1/lib/aiplatform.dart
+++ b/generated/google_cloud_aiplatform_v1beta1/lib/aiplatform.dart
@@ -24,6 +24,8 @@ library;
 // ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: unintended_html_in_doc_comment
 
+export 'package:google_cloud_rpc/exceptions.dart';
+
 export 'src/api.g.dart'
     hide
         FakeDatasetService,

--- a/generated/google_cloud_aiplatform_v1beta1/lib/src/api.g.dart
+++ b/generated/google_cloud_aiplatform_v1beta1/lib/src/api.g.dart
@@ -38670,6 +38670,14 @@ final class BatchPredictionJob extends ProtoMessage {
   /// Exactly one of model and unmanaged_container_model must be set.
   final UnmanagedContainerModel? unmanagedContainerModel;
 
+  /// For Bring-Your-Own-Endpoint (BYOE), the name of the Endpoint resource that
+  /// produces the predictions via this job, must share the same ancestor
+  /// Location. Exactly one of model, unmanaged_container_model, or endpoint must
+  /// be set.
+  /// Example:
+  /// `projects/193595526740/locations/us-central1/endpoints/4203439000301600768`
+  final String endpoint;
+
   /// Required. Input configuration of the instances on which predictions are
   /// performed. The schema of any single instance may be specified via the
   /// [Model's][google.cloud.aiplatform.v1beta1.BatchPredictionJob.model]
@@ -38847,6 +38855,7 @@ final class BatchPredictionJob extends ProtoMessage {
     this.model = '',
     this.modelVersionId = '',
     this.unmanagedContainerModel,
+    this.endpoint = '',
     required this.inputConfig,
     this.instanceConfig,
     this.modelParameters,
@@ -38898,6 +38907,10 @@ final class BatchPredictionJob extends ProtoMessage {
       unmanagedContainerModel: switch (json['unmanagedContainerModel']) {
         null => null,
         Object $1 => UnmanagedContainerModel.fromJson($1),
+      },
+      endpoint: switch (json['endpoint']) {
+        null => '',
+        Object $1 => decodeString($1),
       },
       inputConfig: switch (json['inputConfig']) {
         null => null,
@@ -39032,6 +39045,7 @@ final class BatchPredictionJob extends ProtoMessage {
     if (model.isNotDefault) 'model': model,
     if (modelVersionId.isNotDefault) 'modelVersionId': modelVersionId,
     'unmanagedContainerModel': ?unmanagedContainerModel?.toJson(),
+    if (endpoint.isNotDefault) 'endpoint': endpoint,
     'inputConfig': ?inputConfig?.toJson(),
     'instanceConfig': ?instanceConfig?.toJson(),
     if (modelParameters case final $1?) 'modelParameters': $1.toJson(),
@@ -39074,6 +39088,7 @@ final class BatchPredictionJob extends ProtoMessage {
       'displayName=$displayName',
       'model=$model',
       'modelVersionId=$modelVersionId',
+      'endpoint=$endpoint',
       'serviceAccount=$serviceAccount',
       'generateExplanation=$generateExplanation',
       'state=$state',
@@ -42118,7 +42133,9 @@ final class GroundingChunk_RetrievedContext extends ProtoMessage {
   }
 }
 
-/// Chunk from Google Maps.
+/// A `Maps` chunk is a piece of evidence that comes from Google Maps,
+/// containing information about places or routes. This is used to provide
+/// the user with rich, location-based information.
 final class GroundingChunk_Maps extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.aiplatform.v1beta1.GroundingChunk.Maps';
@@ -42141,12 +42158,16 @@ final class GroundingChunk_Maps extends ProtoMessage {
   /// answer, as well as uris to flag content.
   final GroundingChunk_Maps_PlaceAnswerSources? placeAnswerSources;
 
+  /// Output only. Route information.
+  final GroundingChunk_Maps_Route? route;
+
   GroundingChunk_Maps({
     this.uri,
     this.title,
     this.text,
     this.placeId,
     this.placeAnswerSources,
+    this.route,
   }) : super(fullyQualifiedName);
 
   factory GroundingChunk_Maps.fromJson(Object? j) {
@@ -42172,6 +42193,10 @@ final class GroundingChunk_Maps extends ProtoMessage {
         null => null,
         Object $1 => GroundingChunk_Maps_PlaceAnswerSources.fromJson($1),
       },
+      route: switch (json['route']) {
+        null => null,
+        Object $1 => GroundingChunk_Maps_Route.fromJson($1),
+      },
     );
   }
 
@@ -42182,6 +42207,7 @@ final class GroundingChunk_Maps extends ProtoMessage {
     'text': ?text,
     'placeId': ?placeId,
     'placeAnswerSources': ?placeAnswerSources?.toJson(),
+    'route': ?route?.toJson(),
   };
 
   @override
@@ -42287,6 +42313,62 @@ final class GroundingChunk_Maps_PlaceAnswerSources_ReviewSnippet
       'title=$title',
     ].join(',');
     return 'ReviewSnippet(${$contents})';
+  }
+}
+
+/// Route information from Google Maps.
+final class GroundingChunk_Maps_Route extends ProtoMessage {
+  static const String fullyQualifiedName =
+      'google.cloud.aiplatform.v1beta1.GroundingChunk.Maps.Route';
+
+  /// The total distance of the route, in meters.
+  final int distanceMeters;
+
+  /// The total duration of the route.
+  final protobuf.Duration? duration;
+
+  /// An encoded polyline of the route. See
+  /// https://developers.google.com/maps/documentation/utilities/polylinealgorithm
+  final String encodedPolyline;
+
+  GroundingChunk_Maps_Route({
+    this.distanceMeters = 0,
+    this.duration,
+    this.encodedPolyline = '',
+  }) : super(fullyQualifiedName);
+
+  factory GroundingChunk_Maps_Route.fromJson(Object? j) {
+    final json = j as Map<String, Object?>;
+    return GroundingChunk_Maps_Route(
+      distanceMeters: switch (json['distanceMeters']) {
+        null => 0,
+        Object $1 => decodeInt($1),
+      },
+      duration: switch (json['duration']) {
+        null => null,
+        Object $1 => protobuf.Duration.fromJson($1),
+      },
+      encodedPolyline: switch (json['encodedPolyline']) {
+        null => '',
+        Object $1 => decodeString($1),
+      },
+    );
+  }
+
+  @override
+  Object toJson() => {
+    if (distanceMeters.isNotDefault) 'distanceMeters': distanceMeters,
+    'duration': ?duration?.toJson(),
+    if (encodedPolyline.isNotDefault) 'encodedPolyline': encodedPolyline,
+  };
+
+  @override
+  String toString() {
+    final $contents = [
+      'distanceMeters=$distanceMeters',
+      'encodedPolyline=$encodedPolyline',
+    ].join(',');
+    return 'Route(${$contents})';
   }
 }
 
@@ -114052,6 +114134,9 @@ final class ReasoningEngineSpec extends ProtoMessage {
   /// used.
   final ReasoningEngineSpec_IdentityType identityType;
 
+  /// Optional. Configuration for building container image.
+  final ReasoningEngineSpec_BuildSpec? buildSpec;
+
   ReasoningEngineSpec({
     this.sourceCodeSpec,
     this.containerSpec,
@@ -114061,6 +114146,7 @@ final class ReasoningEngineSpec extends ProtoMessage {
     this.classMethods = const [],
     this.agentFramework = '',
     this.identityType = ReasoningEngineSpec_IdentityType.$default,
+    this.buildSpec,
   }) : super(fullyQualifiedName);
 
   factory ReasoningEngineSpec.fromJson(Object? j) {
@@ -114099,6 +114185,10 @@ final class ReasoningEngineSpec extends ProtoMessage {
         null => ReasoningEngineSpec_IdentityType.$default,
         Object $1 => ReasoningEngineSpec_IdentityType.fromJson($1),
       },
+      buildSpec: switch (json['buildSpec']) {
+        null => null,
+        Object $1 => ReasoningEngineSpec_BuildSpec.fromJson($1),
+      },
     );
   }
 
@@ -114113,6 +114203,7 @@ final class ReasoningEngineSpec extends ProtoMessage {
       'classMethods': [for (final i in classMethods) i.toJson()],
     if (agentFramework.isNotDefault) 'agentFramework': agentFramework,
     if (identityType.isNotDefault) 'identityType': identityType.toJson(),
+    'buildSpec': ?buildSpec?.toJson(),
   };
 
   @override
@@ -114657,6 +114748,62 @@ final class ReasoningEngineSpec_ContainerSpec extends ProtoMessage {
   String toString() {
     final $contents = ['imageUri=$imageUri'].join(',');
     return 'ContainerSpec(${$contents})';
+  }
+}
+
+/// Specification for building container image.
+final class ReasoningEngineSpec_BuildSpec extends ProtoMessage {
+  static const String fullyQualifiedName =
+      'google.cloud.aiplatform.v1beta1.ReasoningEngineSpec.BuildSpec';
+
+  /// Optional. The resource name of the Cloud Build WorkerPool to use for
+  /// the build.
+  /// Format:
+  /// `projects/{project}/locations/{location}/workerPools/{worker_pool}`
+  final String workerPool;
+
+  /// Optional. The service account that Cloud Build uses to run the build.
+  ///
+  /// This field is only applicable when `worker_pool` is specified (i.e., for
+  /// custom worker pools). If `worker_pool` is not specified, this field is
+  /// ignored and the build runs using the Google-managed service agent.
+  ///
+  /// Format: `projects/{project}/serviceAccounts/{service_account}` or
+  /// `{service_account}@{project}.iam.gserviceaccount.com`
+  final String serviceAccount;
+
+  ReasoningEngineSpec_BuildSpec({
+    this.workerPool = '',
+    this.serviceAccount = '',
+  }) : super(fullyQualifiedName);
+
+  factory ReasoningEngineSpec_BuildSpec.fromJson(Object? j) {
+    final json = j as Map<String, Object?>;
+    return ReasoningEngineSpec_BuildSpec(
+      workerPool: switch (json['workerPool']) {
+        null => '',
+        Object $1 => decodeString($1),
+      },
+      serviceAccount: switch (json['serviceAccount']) {
+        null => '',
+        Object $1 => decodeString($1),
+      },
+    );
+  }
+
+  @override
+  Object toJson() => {
+    if (workerPool.isNotDefault) 'workerPool': workerPool,
+    if (serviceAccount.isNotDefault) 'serviceAccount': serviceAccount,
+  };
+
+  @override
+  String toString() {
+    final $contents = [
+      'workerPool=$workerPool',
+      'serviceAccount=$serviceAccount',
+    ].join(',');
+    return 'BuildSpec(${$contents})';
   }
 }
 
@@ -124346,6 +124493,11 @@ final class Tool extends ProtoMessage {
   /// Parallel.ai and presented to the model for response generation
   final Tool_ParallelAiSearch? parallelAiSearch;
 
+  /// Optional. Uses Exa.ai to search for information to
+  /// answer user queries. The search results will be grounded on Exa.ai
+  /// and presented to the model for response generation
+  final Tool_ExaAiSearch? exaAiSearch;
+
   /// Optional. CodeExecution tool type.
   /// Enables the model to execute code as part of generation.
   final Tool_CodeExecution? codeExecution;
@@ -124366,6 +124518,7 @@ final class Tool extends ProtoMessage {
     this.googleMaps,
     this.enterpriseWebSearch,
     this.parallelAiSearch,
+    this.exaAiSearch,
     this.codeExecution,
     this.urlContext,
     this.computerUse,
@@ -124407,6 +124560,10 @@ final class Tool extends ProtoMessage {
         null => null,
         Object $1 => Tool_ParallelAiSearch.fromJson($1),
       },
+      exaAiSearch: switch (json['exaAiSearch']) {
+        null => null,
+        Object $1 => Tool_ExaAiSearch.fromJson($1),
+      },
       codeExecution: switch (json['codeExecution']) {
         null => null,
         Object $1 => Tool_CodeExecution.fromJson($1),
@@ -124434,6 +124591,7 @@ final class Tool extends ProtoMessage {
     'googleMaps': ?googleMaps?.toJson(),
     'enterpriseWebSearch': ?enterpriseWebSearch?.toJson(),
     'parallelAiSearch': ?parallelAiSearch?.toJson(),
+    'exaAiSearch': ?exaAiSearch?.toJson(),
     'codeExecution': ?codeExecution?.toJson(),
     'urlContext': ?urlContext?.toJson(),
     'computerUse': ?computerUse?.toJson(),
@@ -124550,6 +124708,49 @@ final class Tool_ParallelAiSearch extends ProtoMessage {
   String toString() {
     final $contents = ['apiKey=$apiKey'].join(',');
     return 'ParallelAiSearch(${$contents})';
+  }
+}
+
+/// ExaAiSearch tool type.
+/// A tool that uses the Exa.ai search engine for grounding.
+final class Tool_ExaAiSearch extends ProtoMessage {
+  static const String fullyQualifiedName =
+      'google.cloud.aiplatform.v1beta1.Tool.ExaAiSearch';
+
+  /// Required. The API key for ExaAiSearch.
+  final String apiKey;
+
+  /// Optional. This field can be used to pass any parameter from the Exa.ai
+  /// Search API.
+  final protobuf.Struct? customConfigs;
+
+  Tool_ExaAiSearch({required this.apiKey, this.customConfigs})
+    : super(fullyQualifiedName);
+
+  factory Tool_ExaAiSearch.fromJson(Object? j) {
+    final json = j as Map<String, Object?>;
+    return Tool_ExaAiSearch(
+      apiKey: switch (json['apiKey']) {
+        null => '',
+        Object $1 => decodeString($1),
+      },
+      customConfigs: switch (json['customConfigs']) {
+        null => null,
+        Object $1 => protobuf.Struct.fromJson($1),
+      },
+    );
+  }
+
+  @override
+  Object toJson() => {
+    'apiKey': apiKey,
+    'customConfigs': ?customConfigs?.toJson(),
+  };
+
+  @override
+  String toString() {
+    final $contents = ['apiKey=$apiKey'].join(',');
+    return 'ExaAiSearch(${$contents})';
   }
 }
 

--- a/generated/google_cloud_aiplatform_v1beta1/lib/src/api.g.dart
+++ b/generated/google_cloud_aiplatform_v1beta1/lib/src/api.g.dart
@@ -18,6 +18,8 @@
 ///
 /// Train high-quality custom machine learning models with minimal machine
 /// learning expertise and effort.
+///
+/// @docImport 'package:google_cloud_rpc/exceptions.dart';
 library;
 
 // ignore_for_file: camel_case_types
@@ -35,7 +37,6 @@ import 'package:google_cloud_longrunning/longrunning.dart';
 import 'package:google_cloud_protobuf/protobuf.dart';
 import 'package:google_cloud_protobuf/protobuf.dart' as protobuf;
 import 'package:google_cloud_protobuf/src/encoding.dart';
-import 'package:google_cloud_rpc/exceptions.dart';
 import 'package:google_cloud_rpc/rpc.dart';
 import 'package:google_cloud_rpc/service_client.dart';
 import 'package:google_cloud_type/type.dart';

--- a/generated/google_cloud_aiplatform_v1beta1/skills/google_cloud_aiplatform_v1beta1-setup/SKILL.md
+++ b/generated/google_cloud_aiplatform_v1beta1/skills/google_cloud_aiplatform_v1beta1-setup/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: google-cloud-aiplatform-v1beta1-setup
+description: >-
+  Use this skill to help the developer get started with
+  package:google_cloud_aiplatform_v1beta1
+---
+
+## Getting Started with package:google_cloud_aiplatform_v1beta1
+
+### 1. Add the package to your pubspec.yaml
+
+```shell
+dart pub add google_cloud_aiplatform_v1beta1
+```
+
+### 2. Import the library
+
+In your Dart code, import the library:
+
+```dart
+import 'package:google_cloud_aiplatform_v1beta1/aiplatform.dart';
+```
+
+### 3. Initialize the client
+
+To call the client, you need to create an instance of the service that
+you want to use, e.g., `FeatureOnlineStoreService`.
+
+There are two ways of creating an instance with the necessary credentials.
+
+#### Option A: Using Application Default Credentials (ADC) (Recommended)
+
+Recommended for production environments, server-side backends, and when
+running on Google Cloud (such as Cloud Run, GCE, GKE).
+
+When running on Google Cloud, Application Default Credentials are automatically
+available.
+
+When running locally, the `gcloud` command must be available (see
+[Install the Google Cloud CLI](https://docs.cloud.google.com/sdk/docs/install-sdk)).
+To obtain Application Default Credentials, run:
+
+```shell
+gcloud auth application-default login
+```
+
+Add `googleapis_auth` to your dependencies:
+
+```shell
+dart pub add googleapis_auth
+```
+
+```dart
+import 'package:googleapis_auth/auth_io.dart';
+import 'package:google_cloud_aiplatform_v1beta1/aiplatform.dart';
+
+Future<void> main() async {
+  final authClient = await clientViaApplicationDefaultCredentials(
+    scopes: [
+      'https://www.googleapis.com/auth/cloud-platform',
+    ],
+  );
+
+  final client = FeatureOnlineStoreService(client: authClient);
+
+  try {
+    // Call a method on the client.
+    final response = await client.generateFetchAccessToken(
+      GenerateFetchAccessTokenRequest(),
+    );
+    print('Response: $response');
+  } finally {
+    // Always close the client to release resources.
+    client.close();
+  }
+}
+```
+
+#### Option B: Using an API Key (Simple)
+
+Recommended for quick testing or prototyping because the setup is simple.
+
+If the user does not have an API key, then they can obtain one using the
+[Google Cloud Console](https://console.cloud.google.com/apis/credentials).
+
+Add the API key to one of these environment variables:
+- `GOOGLE_API_KEY`
+
+
+```dart
+import 'package:google_cloud_aiplatform_v1beta1/aiplatform.dart';
+
+Future<void> main() async {
+  final client = FeatureOnlineStoreService.fromApiKey();
+
+  try {
+    // Call a method on the client.
+    final response = await client.generateFetchAccessToken(
+      GenerateFetchAccessTokenRequest(),
+    );
+    print('Response: $response');
+  } finally {
+    // Always close the client to release resources.
+    client.close();
+  }
+}
+```
+

--- a/generated/google_cloud_aiplatform_v1beta1/skills/google_cloud_aiplatform_v1beta1-tests/SKILL.md
+++ b/generated/google_cloud_aiplatform_v1beta1/skills/google_cloud_aiplatform_v1beta1-tests/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: google-cloud-aiplatform-v1beta1-tests
+description: >-
+  Use this skill when writing tests for code that uses
+  package:google_cloud_aiplatform_v1beta1
+---
+
+## Testing with Fakes
+
+Most unit tests should use fakes instead of making network requests to Google
+services.
+
+- Code that uses `DatasetService` can be tested by injecting the
+  fake `FakeDatasetService`.
+- Code that uses `DeploymentResourcePoolService` can be tested by injecting the
+  fake `FakeDeploymentResourcePoolService`.
+- Code that uses `EndpointService` can be tested by injecting the
+  fake `FakeEndpointService`.
+- Code that uses `EvaluationService` can be tested by injecting the
+  fake `FakeEvaluationService`.
+- Code that uses `ExampleStoreService` can be tested by injecting the
+  fake `FakeExampleStoreService`.
+- Code that uses `ExtensionExecutionService` can be tested by injecting the
+  fake `FakeExtensionExecutionService`.
+- Code that uses `ExtensionRegistryService` can be tested by injecting the
+  fake `FakeExtensionRegistryService`.
+- Code that uses `FeatureOnlineStoreAdminService` can be tested by injecting the
+  fake `FakeFeatureOnlineStoreAdminService`.
+- Code that uses `FeatureOnlineStoreService` can be tested by injecting the
+  fake `FakeFeatureOnlineStoreService`.
+- Code that uses `FeatureRegistryService` can be tested by injecting the
+  fake `FakeFeatureRegistryService`.
+- Code that uses `FeaturestoreOnlineServingService` can be tested by injecting the
+  fake `FakeFeaturestoreOnlineServingService`.
+- Code that uses `FeaturestoreService` can be tested by injecting the
+  fake `FakeFeaturestoreService`.
+- Code that uses `GenAiCacheService` can be tested by injecting the
+  fake `FakeGenAiCacheService`.
+- Code that uses `GenAiTuningService` can be tested by injecting the
+  fake `FakeGenAiTuningService`.
+- Code that uses `IndexEndpointService` can be tested by injecting the
+  fake `FakeIndexEndpointService`.
+- Code that uses `IndexService` can be tested by injecting the
+  fake `FakeIndexService`.
+- Code that uses `JobService` can be tested by injecting the
+  fake `FakeJobService`.
+- Code that uses `LlmUtilityService` can be tested by injecting the
+  fake `FakeLlmUtilityService`.
+- Code that uses `MatchService` can be tested by injecting the
+  fake `FakeMatchService`.
+- Code that uses `MemoryBankService` can be tested by injecting the
+  fake `FakeMemoryBankService`.
+- Code that uses `MetadataService` can be tested by injecting the
+  fake `FakeMetadataService`.
+- Code that uses `MigrationService` can be tested by injecting the
+  fake `FakeMigrationService`.
+- Code that uses `ModelGardenService` can be tested by injecting the
+  fake `FakeModelGardenService`.
+- Code that uses `ModelMonitoringService` can be tested by injecting the
+  fake `FakeModelMonitoringService`.
+- Code that uses `ModelService` can be tested by injecting the
+  fake `FakeModelService`.
+- Code that uses `NotebookService` can be tested by injecting the
+  fake `FakeNotebookService`.
+- Code that uses `OnlineEvaluatorService` can be tested by injecting the
+  fake `FakeOnlineEvaluatorService`.
+- Code that uses `PersistentResourceService` can be tested by injecting the
+  fake `FakePersistentResourceService`.
+- Code that uses `PipelineService` can be tested by injecting the
+  fake `FakePipelineService`.
+- Code that uses `PredictionService` can be tested by injecting the
+  fake `FakePredictionService`.
+- Code that uses `ReasoningEngineExecutionService` can be tested by injecting the
+  fake `FakeReasoningEngineExecutionService`.
+- Code that uses `ReasoningEngineRuntimeRevisionService` can be tested by injecting the
+  fake `FakeReasoningEngineRuntimeRevisionService`.
+- Code that uses `ReasoningEngineService` can be tested by injecting the
+  fake `FakeReasoningEngineService`.
+- Code that uses `ScheduleService` can be tested by injecting the
+  fake `FakeScheduleService`.
+- Code that uses `SessionService` can be tested by injecting the
+  fake `FakeSessionService`.
+- Code that uses `SpecialistPoolService` can be tested by injecting the
+  fake `FakeSpecialistPoolService`.
+- Code that uses `TensorboardService` can be tested by injecting the
+  fake `FakeTensorboardService`.
+- Code that uses `VertexRagDataService` can be tested by injecting the
+  fake `FakeVertexRagDataService`.
+- Code that uses `VertexRagService` can be tested by injecting the
+  fake `FakeVertexRagService`.
+- Code that uses `VizierService` can be tested by injecting the
+  fake `FakeVizierService`.
+
+Import the fakes from the testing library:
+
+```dart
+import 'package:google_cloud_aiplatform_v1beta1/testing.dart';
+```
+
+### Option A: Using Constructor Closures (Recommended)
+
+You can inject behavior by passing optional function callbacks to the fake's
+constructor. Methods that are not provided will throw an `UnsupportedError`.
+
+```dart
+import 'package:google_cloud_aiplatform_v1beta1/aiplatform.dart';
+import 'package:google_cloud_aiplatform_v1beta1/testing.dart';
+
+final fake = FakeFeatureOnlineStoreService(
+  generateFetchAccessToken: (request) async {
+    // Assert request contents here if needed.
+    return GenerateFetchAccessTokenResponse();
+  },
+);
+```
+
+### Option B: Subclassing the Fake
+
+For more complex test setups or shared states, you can subclass the fake and
+override its methods. Methods that are not overridden will throw an
+`UnsupportedError`.
+
+```dart
+import 'package:google_cloud_aiplatform_v1beta1/aiplatform.dart';
+import 'package:google_cloud_aiplatform_v1beta1/testing.dart';
+
+final class MyFakeFeatureOnlineStoreService extends FakeFeatureOnlineStoreService {
+  @override
+  Future<GenerateFetchAccessTokenResponse> generateFetchAccessToken(
+    GenerateFetchAccessTokenRequest request,
+  ) async {
+    // Assert request contents here if needed.
+    return GenerateFetchAccessTokenResponse();
+  }
+}
+```
+
+## A Simple Test
+
+```dart
+import 'package:google_cloud_aiplatform_v1beta1/aiplatform.dart';
+import 'package:google_cloud_aiplatform_v1beta1/testing.dart';
+import 'package:test/test.dart';
+
+Future<void> functionUnderTest(FeatureOnlineStoreService service) async {
+  // Application logic here.
+  await service.generateFetchAccessToken(GenerateFetchAccessTokenRequest());
+  // More application logic here.
+}
+
+void main() {
+  test('test', () async {
+    final fake = FakeFeatureOnlineStoreService(
+      generateFetchAccessToken: (request) async {
+          // Assert request contents here.
+          return GenerateFetchAccessTokenResponse();
+      },
+    );
+    // Instead of verifying that `functionUnderTest`, you should verify the
+    // relevant properties of the result.
+    await expectLater(functionUnderTest(fake), completes);
+  });
+}
+```

--- a/generated/google_cloud_aiplatform_v1beta1/skills/google_cloud_aiplatform_v1beta1-tests/SKILL.md
+++ b/generated/google_cloud_aiplatform_v1beta1/skills/google_cloud_aiplatform_v1beta1-tests/SKILL.md
@@ -156,8 +156,8 @@ void main() {
           return GenerateFetchAccessTokenResponse();
       },
     );
-    // Instead of verifying that `functionUnderTest`, you should verify the
-    // relevant properties of the result.
+    // Instead of verifying that `functionUnderTest` completes, you should verify
+    // the relevant properties of the result.
     await expectLater(functionUnderTest(fake), completes);
   });
 }

--- a/generated/google_cloud_firestore_v1/README.md
+++ b/generated/google_cloud_firestore_v1/README.md
@@ -26,5 +26,18 @@ The Google Cloud client library for the Cloud Firestore API.
 
 The Google Cloud client library for the Cloud Firestore API.
 
+## Agent Skills
+
+This package supports [Agent Skills](https://agentskills.io/home).
+
+To add this package to your application and install the skills for use by your
+Agent, run:
+
+```shell
+dart pub add google_cloud_firestore_v1
+dart pub get
+dart run skills@ get
+```
+
 Accesses the NoSQL document database built for automatic scaling, high
 performance, and ease of application development.

--- a/generated/google_cloud_firestore_v1/lib/firestore.dart
+++ b/generated/google_cloud_firestore_v1/lib/firestore.dart
@@ -24,4 +24,6 @@ library;
 // ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: unintended_html_in_doc_comment
 
+export 'package:google_cloud_rpc/exceptions.dart';
+
 export 'src/api.g.dart' hide FakeFirestore;

--- a/generated/google_cloud_firestore_v1/lib/src/api.g.dart
+++ b/generated/google_cloud_firestore_v1/lib/src/api.g.dart
@@ -101,6 +101,9 @@ final class Firestore {
           'mask.fieldPaths': $1,
         if (request.transaction case final $1?) 'transaction': encodeBytes($1)!,
         if (request.readTime case final $1?) 'readTime': $1.toJson(),
+        if (request.requestOptions?.requestTags case final $1?
+            when $1.isNotDefault)
+          'requestOptions.requestTags': $1,
       },
     );
     final response = await _client.get(url);
@@ -129,6 +132,9 @@ final class Firestore {
         if (request.readTime case final $1?) 'readTime': $1.toJson(),
         if (request.showMissing case final $1 when $1.isNotDefault)
           'showMissing': '${$1}',
+        if (request.requestOptions?.requestTags case final $1?
+            when $1.isNotDefault)
+          'requestOptions.requestTags': $1,
       },
     );
     final response = await _client.get(url);
@@ -152,6 +158,9 @@ final class Firestore {
           'currentDocument.exists': '${$1}',
         if (request.currentDocument?.updateTime case final $1?)
           'currentDocument.updateTime': $1.toJson(),
+        if (request.requestOptions?.requestTags case final $1?
+            when $1.isNotDefault)
+          'requestOptions.requestTags': $1,
       },
     );
     final response = await _client.patch(url, body: request.document);
@@ -171,6 +180,9 @@ final class Firestore {
           'currentDocument.exists': '${$1}',
         if (request.currentDocument?.updateTime case final $1?)
           'currentDocument.updateTime': $1.toJson(),
+        if (request.requestOptions?.requestTags case final $1?
+            when $1.isNotDefault)
+          'requestOptions.requestTags': $1,
       },
     );
     await _client.delete(url);
@@ -356,6 +368,9 @@ final class Firestore {
           'documentId': $1,
         if (request.mask?.fieldPaths case final $1? when $1.isNotDefault)
           'mask.fieldPaths': $1,
+        if (request.requestOptions?.requestTags case final $1?
+            when $1.isNotDefault)
+          'requestOptions.requestTags': $1,
       },
     );
     final response = await _client.post(url, body: request.document);
@@ -1252,6 +1267,33 @@ final class TransactionOptions_ConcurrencyMode extends ProtoEnum {
   String toString() => 'ConcurrencyMode.$value';
 }
 
+/// Options for a server request.
+final class RequestOptions extends ProtoMessage {
+  static const String fullyQualifiedName = 'google.firestore.v1.RequestOptions';
+
+  /// The request tags for the request.
+  final List<String> requestTags;
+
+  RequestOptions({this.requestTags = const []}) : super(fullyQualifiedName);
+
+  factory RequestOptions.fromJson(Object? j) {
+    final json = j as Map<String, Object?>;
+    return RequestOptions(
+      requestTags: switch (json['requestTags']) {
+        null => [],
+        List<Object?> $1 => [for (final i in $1) decodeString(i)],
+        _ => throw const FormatException('"requestTags" is not a list'),
+      },
+    );
+  }
+
+  @override
+  Object toJson() => {if (requestTags.isNotDefault) 'requestTags': requestTags};
+
+  @override
+  String toString() => 'RequestOptions()';
+}
+
 /// A Firestore document.
 ///
 /// Must not exceed 1 MiB - 4 bytes.
@@ -1856,11 +1898,15 @@ final class GetDocumentRequest extends ProtoMessage {
   /// minute timestamp within the past 7 days.
   final Timestamp? readTime;
 
+  /// Optional. Any additional options for the request.
+  final RequestOptions? requestOptions;
+
   GetDocumentRequest({
     required this.name,
     this.mask,
     this.transaction,
     this.readTime,
+    this.requestOptions,
   }) : super(fullyQualifiedName);
 
   factory GetDocumentRequest.fromJson(Object? j) {
@@ -1882,6 +1928,10 @@ final class GetDocumentRequest extends ProtoMessage {
         null => null,
         Object $1 => Timestamp.fromJson($1),
       },
+      requestOptions: switch (json['requestOptions']) {
+        null => null,
+        Object $1 => RequestOptions.fromJson($1),
+      },
     );
   }
 
@@ -1891,6 +1941,7 @@ final class GetDocumentRequest extends ProtoMessage {
     'mask': ?mask?.toJson(),
     if (transaction case final $1?) 'transaction': encodeBytes($1),
     'readTime': ?readTime?.toJson(),
+    'requestOptions': ?requestOptions?.toJson(),
   };
 
   @override
@@ -1974,6 +2025,9 @@ final class ListDocumentsRequest extends ProtoMessage {
   /// Requests with `show_missing` may not specify `where` or `order_by`.
   final bool showMissing;
 
+  /// Optional. Any additional options for the request.
+  final RequestOptions? requestOptions;
+
   ListDocumentsRequest({
     required this.parent,
     this.collectionId = '',
@@ -1984,6 +2038,7 @@ final class ListDocumentsRequest extends ProtoMessage {
     this.transaction,
     this.readTime,
     this.showMissing = false,
+    this.requestOptions,
   }) : super(fullyQualifiedName);
 
   factory ListDocumentsRequest.fromJson(Object? j) {
@@ -2025,6 +2080,10 @@ final class ListDocumentsRequest extends ProtoMessage {
         null => false,
         Object $1 => decodeBool($1),
       },
+      requestOptions: switch (json['requestOptions']) {
+        null => null,
+        Object $1 => RequestOptions.fromJson($1),
+      },
     );
   }
 
@@ -2039,6 +2098,7 @@ final class ListDocumentsRequest extends ProtoMessage {
     if (transaction case final $1?) 'transaction': encodeBytes($1),
     'readTime': ?readTime?.toJson(),
     if (showMissing.isNotDefault) 'showMissing': showMissing,
+    'requestOptions': ?requestOptions?.toJson(),
   };
 
   @override
@@ -2131,12 +2191,16 @@ final class CreateDocumentRequest extends ProtoMessage {
   /// will not be returned in the response.
   final DocumentMask? mask;
 
+  /// Optional. Any additional options for the request.
+  final RequestOptions? requestOptions;
+
   CreateDocumentRequest({
     required this.parent,
     required this.collectionId,
     this.documentId = '',
     required this.document,
     this.mask,
+    this.requestOptions,
   }) : super(fullyQualifiedName);
 
   factory CreateDocumentRequest.fromJson(Object? j) {
@@ -2162,6 +2226,10 @@ final class CreateDocumentRequest extends ProtoMessage {
         null => null,
         Object $1 => DocumentMask.fromJson($1),
       },
+      requestOptions: switch (json['requestOptions']) {
+        null => null,
+        Object $1 => RequestOptions.fromJson($1),
+      },
     );
   }
 
@@ -2172,6 +2240,7 @@ final class CreateDocumentRequest extends ProtoMessage {
     if (documentId.isNotDefault) 'documentId': documentId,
     'document': ?document?.toJson(),
     'mask': ?mask?.toJson(),
+    'requestOptions': ?requestOptions?.toJson(),
   };
 
   @override
@@ -2214,11 +2283,15 @@ final class UpdateDocumentRequest extends ProtoMessage {
   /// The request will fail if this is set and not met by the target document.
   final Precondition? currentDocument;
 
+  /// Optional. Any additional options for the request.
+  final RequestOptions? requestOptions;
+
   UpdateDocumentRequest({
     required this.document,
     this.updateMask,
     this.mask,
     this.currentDocument,
+    this.requestOptions,
   }) : super(fullyQualifiedName);
 
   factory UpdateDocumentRequest.fromJson(Object? j) {
@@ -2240,6 +2313,10 @@ final class UpdateDocumentRequest extends ProtoMessage {
         null => null,
         Object $1 => Precondition.fromJson($1),
       },
+      requestOptions: switch (json['requestOptions']) {
+        null => null,
+        Object $1 => RequestOptions.fromJson($1),
+      },
     );
   }
 
@@ -2249,6 +2326,7 @@ final class UpdateDocumentRequest extends ProtoMessage {
     'updateMask': ?updateMask?.toJson(),
     'mask': ?mask?.toJson(),
     'currentDocument': ?currentDocument?.toJson(),
+    'requestOptions': ?requestOptions?.toJson(),
   };
 
   @override
@@ -2269,8 +2347,14 @@ final class DeleteDocumentRequest extends ProtoMessage {
   /// The request will fail if this is set and not met by the target document.
   final Precondition? currentDocument;
 
-  DeleteDocumentRequest({required this.name, this.currentDocument})
-    : super(fullyQualifiedName);
+  /// Optional. Any additional options for the request.
+  final RequestOptions? requestOptions;
+
+  DeleteDocumentRequest({
+    required this.name,
+    this.currentDocument,
+    this.requestOptions,
+  }) : super(fullyQualifiedName);
 
   factory DeleteDocumentRequest.fromJson(Object? j) {
     final json = j as Map<String, Object?>;
@@ -2283,6 +2367,10 @@ final class DeleteDocumentRequest extends ProtoMessage {
         null => null,
         Object $1 => Precondition.fromJson($1),
       },
+      requestOptions: switch (json['requestOptions']) {
+        null => null,
+        Object $1 => RequestOptions.fromJson($1),
+      },
     );
   }
 
@@ -2290,6 +2378,7 @@ final class DeleteDocumentRequest extends ProtoMessage {
   Object toJson() => {
     'name': name,
     'currentDocument': ?currentDocument?.toJson(),
+    'requestOptions': ?requestOptions?.toJson(),
   };
 
   @override
@@ -2337,6 +2426,9 @@ final class BatchGetDocumentsRequest extends ProtoMessage {
   /// minute timestamp within the past 7 days.
   final Timestamp? readTime;
 
+  /// Optional. Any additional options for the request.
+  final RequestOptions? requestOptions;
+
   BatchGetDocumentsRequest({
     required this.database,
     this.documents = const [],
@@ -2344,6 +2436,7 @@ final class BatchGetDocumentsRequest extends ProtoMessage {
     this.transaction,
     this.newTransaction,
     this.readTime,
+    this.requestOptions,
   }) : super(fullyQualifiedName);
 
   factory BatchGetDocumentsRequest.fromJson(Object? j) {
@@ -2374,6 +2467,10 @@ final class BatchGetDocumentsRequest extends ProtoMessage {
         null => null,
         Object $1 => Timestamp.fromJson($1),
       },
+      requestOptions: switch (json['requestOptions']) {
+        null => null,
+        Object $1 => RequestOptions.fromJson($1),
+      },
     );
   }
 
@@ -2385,6 +2482,7 @@ final class BatchGetDocumentsRequest extends ProtoMessage {
     if (transaction case final $1?) 'transaction': encodeBytes($1),
     'newTransaction': ?newTransaction?.toJson(),
     'readTime': ?readTime?.toJson(),
+    'requestOptions': ?requestOptions?.toJson(),
   };
 
   @override
@@ -2484,8 +2582,14 @@ final class BeginTransactionRequest extends ProtoMessage {
   /// Defaults to a read-write transaction.
   final TransactionOptions? options;
 
-  BeginTransactionRequest({required this.database, this.options})
-    : super(fullyQualifiedName);
+  /// Optional. Any additional options for the request.
+  final RequestOptions? requestOptions;
+
+  BeginTransactionRequest({
+    required this.database,
+    this.options,
+    this.requestOptions,
+  }) : super(fullyQualifiedName);
 
   factory BeginTransactionRequest.fromJson(Object? j) {
     final json = j as Map<String, Object?>;
@@ -2498,11 +2602,19 @@ final class BeginTransactionRequest extends ProtoMessage {
         null => null,
         Object $1 => TransactionOptions.fromJson($1),
       },
+      requestOptions: switch (json['requestOptions']) {
+        null => null,
+        Object $1 => RequestOptions.fromJson($1),
+      },
     );
   }
 
   @override
-  Object toJson() => {'database': database, 'options': ?options?.toJson()};
+  Object toJson() => {
+    'database': database,
+    'options': ?options?.toJson(),
+    'requestOptions': ?requestOptions?.toJson(),
+  };
 
   @override
   String toString() {
@@ -2562,10 +2674,14 @@ final class CommitRequest extends ProtoMessage {
   /// If set, applies all writes in this transaction, and commits it.
   final Uint8List transaction;
 
+  /// Optional. Any additional options for the request.
+  final RequestOptions? requestOptions;
+
   CommitRequest({
     required this.database,
     this.writes = const [],
     Uint8List? transaction,
+    this.requestOptions,
   }) : transaction = transaction ?? Uint8List(0),
        super(fullyQualifiedName);
 
@@ -2585,6 +2701,10 @@ final class CommitRequest extends ProtoMessage {
         null => Uint8List(0),
         Object $1 => decodeBytes($1),
       },
+      requestOptions: switch (json['requestOptions']) {
+        null => null,
+        Object $1 => RequestOptions.fromJson($1),
+      },
     );
   }
 
@@ -2593,6 +2713,7 @@ final class CommitRequest extends ProtoMessage {
     'database': database,
     if (writes.isNotDefault) 'writes': [for (final i in writes) i.toJson()],
     if (transaction.isNotDefault) 'transaction': encodeBytes(transaction),
+    'requestOptions': ?requestOptions?.toJson(),
   };
 
   @override
@@ -2660,8 +2781,14 @@ final class RollbackRequest extends ProtoMessage {
   /// Required. The transaction to roll back.
   final Uint8List transaction;
 
-  RollbackRequest({required this.database, required this.transaction})
-    : super(fullyQualifiedName);
+  /// Optional. Any additional options for the request.
+  final RequestOptions? requestOptions;
+
+  RollbackRequest({
+    required this.database,
+    required this.transaction,
+    this.requestOptions,
+  }) : super(fullyQualifiedName);
 
   factory RollbackRequest.fromJson(Object? j) {
     final json = j as Map<String, Object?>;
@@ -2674,6 +2801,10 @@ final class RollbackRequest extends ProtoMessage {
         null => Uint8List(0),
         Object $1 => decodeBytes($1),
       },
+      requestOptions: switch (json['requestOptions']) {
+        null => null,
+        Object $1 => RequestOptions.fromJson($1),
+      },
     );
   }
 
@@ -2681,6 +2812,7 @@ final class RollbackRequest extends ProtoMessage {
   Object toJson() => {
     'database': database,
     'transaction': encodeBytes(transaction),
+    'requestOptions': ?requestOptions?.toJson(),
   };
 
   @override
@@ -2731,6 +2863,9 @@ final class RunQueryRequest extends ProtoMessage {
   /// statistics will be returned. If not, only query results will be returned.
   final ExplainOptions? explainOptions;
 
+  /// Optional. Any additional options for the request.
+  final RequestOptions? requestOptions;
+
   RunQueryRequest({
     required this.parent,
     this.structuredQuery,
@@ -2738,6 +2873,7 @@ final class RunQueryRequest extends ProtoMessage {
     this.newTransaction,
     this.readTime,
     this.explainOptions,
+    this.requestOptions,
   }) : super(fullyQualifiedName);
 
   factory RunQueryRequest.fromJson(Object? j) {
@@ -2767,6 +2903,10 @@ final class RunQueryRequest extends ProtoMessage {
         null => null,
         Object $1 => ExplainOptions.fromJson($1),
       },
+      requestOptions: switch (json['requestOptions']) {
+        null => null,
+        Object $1 => RequestOptions.fromJson($1),
+      },
     );
   }
 
@@ -2778,6 +2918,7 @@ final class RunQueryRequest extends ProtoMessage {
     'newTransaction': ?newTransaction?.toJson(),
     'readTime': ?readTime?.toJson(),
     'explainOptions': ?explainOptions?.toJson(),
+    'requestOptions': ?requestOptions?.toJson(),
   };
 
   @override
@@ -2925,6 +3066,9 @@ final class ExecutePipelineRequest extends ProtoMessage {
   /// `new_transaction`.
   final bool autoCommitTransaction;
 
+  /// Optional. Any additional options for the request.
+  final RequestOptions? requestOptions;
+
   ExecutePipelineRequest({
     required this.database,
     this.structuredPipeline,
@@ -2932,6 +3076,7 @@ final class ExecutePipelineRequest extends ProtoMessage {
     this.newTransaction,
     this.readTime,
     this.autoCommitTransaction = false,
+    this.requestOptions,
   }) : super(fullyQualifiedName);
 
   factory ExecutePipelineRequest.fromJson(Object? j) {
@@ -2961,6 +3106,10 @@ final class ExecutePipelineRequest extends ProtoMessage {
         null => false,
         Object $1 => decodeBool($1),
       },
+      requestOptions: switch (json['requestOptions']) {
+        null => null,
+        Object $1 => RequestOptions.fromJson($1),
+      },
     );
   }
 
@@ -2973,6 +3122,7 @@ final class ExecutePipelineRequest extends ProtoMessage {
     'readTime': ?readTime?.toJson(),
     if (autoCommitTransaction.isNotDefault)
       'autoCommitTransaction': autoCommitTransaction,
+    'requestOptions': ?requestOptions?.toJson(),
   };
 
   @override
@@ -3118,6 +3268,9 @@ final class RunAggregationQueryRequest extends ProtoMessage {
   /// statistics will be returned. If not, only query results will be returned.
   final ExplainOptions? explainOptions;
 
+  /// Optional. Any additional options for the request.
+  final RequestOptions? requestOptions;
+
   RunAggregationQueryRequest({
     required this.parent,
     this.structuredAggregationQuery,
@@ -3125,6 +3278,7 @@ final class RunAggregationQueryRequest extends ProtoMessage {
     this.newTransaction,
     this.readTime,
     this.explainOptions,
+    this.requestOptions,
   }) : super(fullyQualifiedName);
 
   factory RunAggregationQueryRequest.fromJson(Object? j) {
@@ -3154,6 +3308,10 @@ final class RunAggregationQueryRequest extends ProtoMessage {
         null => null,
         Object $1 => ExplainOptions.fromJson($1),
       },
+      requestOptions: switch (json['requestOptions']) {
+        null => null,
+        Object $1 => RequestOptions.fromJson($1),
+      },
     );
   }
 
@@ -3165,6 +3323,7 @@ final class RunAggregationQueryRequest extends ProtoMessage {
     'newTransaction': ?newTransaction?.toJson(),
     'readTime': ?readTime?.toJson(),
     'explainOptions': ?explainOptions?.toJson(),
+    'requestOptions': ?requestOptions?.toJson(),
   };
 
   @override
@@ -3313,6 +3472,9 @@ final class PartitionQueryRequest extends ProtoMessage {
   /// minute timestamp within the past 7 days.
   final Timestamp? readTime;
 
+  /// Optional. Any additional options for the request.
+  final RequestOptions? requestOptions;
+
   PartitionQueryRequest({
     required this.parent,
     this.structuredQuery,
@@ -3320,6 +3482,7 @@ final class PartitionQueryRequest extends ProtoMessage {
     this.pageToken = '',
     this.pageSize = 0,
     this.readTime,
+    this.requestOptions,
   }) : super(fullyQualifiedName);
 
   factory PartitionQueryRequest.fromJson(Object? j) {
@@ -3349,6 +3512,10 @@ final class PartitionQueryRequest extends ProtoMessage {
         null => null,
         Object $1 => Timestamp.fromJson($1),
       },
+      requestOptions: switch (json['requestOptions']) {
+        null => null,
+        Object $1 => RequestOptions.fromJson($1),
+      },
     );
   }
 
@@ -3361,6 +3528,7 @@ final class PartitionQueryRequest extends ProtoMessage {
     if (pageToken.isNotDefault) 'pageToken': pageToken,
     if (pageSize.isNotDefault) 'pageSize': pageSize,
     'readTime': ?readTime?.toJson(),
+    'requestOptions': ?requestOptions?.toJson(),
   };
 
   @override
@@ -3487,12 +3655,16 @@ final class WriteRequest extends ProtoMessage {
   /// Labels associated with this write request.
   final Map<String, String> labels;
 
+  /// Optional. Any additional options for the request.
+  final RequestOptions? requestOptions;
+
   WriteRequest({
     required this.database,
     this.streamId = '',
     this.writes = const [],
     Uint8List? streamToken,
     this.labels = const {},
+    this.requestOptions,
   }) : streamToken = streamToken ?? Uint8List(0),
        super(fullyQualifiedName);
 
@@ -3524,6 +3696,10 @@ final class WriteRequest extends ProtoMessage {
         },
         _ => throw const FormatException('"labels" is not an object'),
       },
+      requestOptions: switch (json['requestOptions']) {
+        null => null,
+        Object $1 => RequestOptions.fromJson($1),
+      },
     );
   }
 
@@ -3534,6 +3710,7 @@ final class WriteRequest extends ProtoMessage {
     if (writes.isNotDefault) 'writes': [for (final i in writes) i.toJson()],
     if (streamToken.isNotDefault) 'streamToken': encodeBytes(streamToken),
     if (labels.isNotDefault) 'labels': labels,
+    'requestOptions': ?requestOptions?.toJson(),
   };
 
   @override
@@ -3638,11 +3815,15 @@ final class ListenRequest extends ProtoMessage {
   /// Labels associated with this target change.
   final Map<String, String> labels;
 
+  /// Optional. Any additional options for the request.
+  final RequestOptions? requestOptions;
+
   ListenRequest({
     required this.database,
     this.addTarget,
     this.removeTarget,
     this.labels = const {},
+    this.requestOptions,
   }) : super(fullyQualifiedName);
 
   factory ListenRequest.fromJson(Object? j) {
@@ -3668,6 +3849,10 @@ final class ListenRequest extends ProtoMessage {
         },
         _ => throw const FormatException('"labels" is not an object'),
       },
+      requestOptions: switch (json['requestOptions']) {
+        null => null,
+        Object $1 => RequestOptions.fromJson($1),
+      },
     );
   }
 
@@ -3677,6 +3862,7 @@ final class ListenRequest extends ProtoMessage {
     'addTarget': ?addTarget?.toJson(),
     'removeTarget': ?removeTarget,
     if (labels.isNotDefault) 'labels': labels,
+    'requestOptions': ?requestOptions?.toJson(),
   };
 
   @override
@@ -4117,11 +4303,15 @@ final class ListCollectionIdsRequest extends ProtoMessage {
   /// minute timestamp within the past 7 days.
   final Timestamp? readTime;
 
+  /// Optional. Any additional options for the request.
+  final RequestOptions? requestOptions;
+
   ListCollectionIdsRequest({
     required this.parent,
     this.pageSize = 0,
     this.pageToken = '',
     this.readTime,
+    this.requestOptions,
   }) : super(fullyQualifiedName);
 
   factory ListCollectionIdsRequest.fromJson(Object? j) {
@@ -4143,6 +4333,10 @@ final class ListCollectionIdsRequest extends ProtoMessage {
         null => null,
         Object $1 => Timestamp.fromJson($1),
       },
+      requestOptions: switch (json['requestOptions']) {
+        null => null,
+        Object $1 => RequestOptions.fromJson($1),
+      },
     );
   }
 
@@ -4152,6 +4346,7 @@ final class ListCollectionIdsRequest extends ProtoMessage {
     if (pageSize.isNotDefault) 'pageSize': pageSize,
     if (pageToken.isNotDefault) 'pageToken': pageToken,
     'readTime': ?readTime?.toJson(),
+    'requestOptions': ?requestOptions?.toJson(),
   };
 
   @override
@@ -4230,10 +4425,14 @@ final class BatchWriteRequest extends ProtoMessage {
   /// Labels associated with this batch write.
   final Map<String, String> labels;
 
+  /// Optional. Any additional options for the request.
+  final RequestOptions? requestOptions;
+
   BatchWriteRequest({
     required this.database,
     this.writes = const [],
     this.labels = const {},
+    this.requestOptions,
   }) : super(fullyQualifiedName);
 
   factory BatchWriteRequest.fromJson(Object? j) {
@@ -4256,6 +4455,10 @@ final class BatchWriteRequest extends ProtoMessage {
         },
         _ => throw const FormatException('"labels" is not an object'),
       },
+      requestOptions: switch (json['requestOptions']) {
+        null => null,
+        Object $1 => RequestOptions.fromJson($1),
+      },
     );
   }
 
@@ -4264,6 +4467,7 @@ final class BatchWriteRequest extends ProtoMessage {
     'database': database,
     if (writes.isNotDefault) 'writes': [for (final i in writes) i.toJson()],
     if (labels.isNotDefault) 'labels': labels,
+    'requestOptions': ?requestOptions?.toJson(),
   };
 
   @override

--- a/generated/google_cloud_firestore_v1/lib/src/api.g.dart
+++ b/generated/google_cloud_firestore_v1/lib/src/api.g.dart
@@ -18,6 +18,8 @@
 ///
 /// Accesses the NoSQL document database built for automatic scaling, high
 /// performance, and ease of application development.
+///
+/// @docImport 'package:google_cloud_rpc/exceptions.dart';
 library;
 
 // ignore_for_file: camel_case_types
@@ -31,7 +33,6 @@ library;
 import 'package:google_cloud_longrunning/longrunning.dart';
 import 'package:google_cloud_protobuf/protobuf.dart';
 import 'package:google_cloud_protobuf/src/encoding.dart';
-import 'package:google_cloud_rpc/exceptions.dart';
 import 'package:google_cloud_rpc/rpc.dart';
 import 'package:google_cloud_rpc/service_client.dart';
 import 'package:google_cloud_type/type.dart';

--- a/generated/google_cloud_firestore_v1/skills/google_cloud_firestore_v1-setup/SKILL.md
+++ b/generated/google_cloud_firestore_v1/skills/google_cloud_firestore_v1-setup/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: google-cloud-firestore-v1-setup
+description: >-
+  Use this skill to help the developer get started with
+  package:google_cloud_firestore_v1
+---
+
+## Getting Started with package:google_cloud_firestore_v1
+
+### 1. Add the package to your pubspec.yaml
+
+```shell
+dart pub add google_cloud_firestore_v1
+```
+
+### 2. Import the library
+
+In your Dart code, import the library:
+
+```dart
+import 'package:google_cloud_firestore_v1/firestore.dart';
+```
+
+### 3. Initialize the client
+
+To call the client, you need to create an instance of the service that
+you want to use, e.g., `Firestore`.
+
+There are two ways of creating an instance with the necessary credentials.
+
+#### Option A: Using Application Default Credentials (ADC) (Recommended)
+
+Recommended for production environments, server-side backends, and when
+running on Google Cloud (such as Cloud Run, GCE, GKE).
+
+When running on Google Cloud, Application Default Credentials are automatically
+available.
+
+When running locally, the `gcloud` command must be available (see
+[Install the Google Cloud CLI](https://docs.cloud.google.com/sdk/docs/install-sdk)).
+To obtain Application Default Credentials, run:
+
+```shell
+gcloud auth application-default login
+```
+
+Add `googleapis_auth` to your dependencies:
+
+```shell
+dart pub add googleapis_auth
+```
+
+```dart
+import 'package:googleapis_auth/auth_io.dart';
+import 'package:google_cloud_firestore_v1/firestore.dart';
+
+Future<void> main() async {
+  final authClient = await clientViaApplicationDefaultCredentials(
+    scopes: [
+      'https://www.googleapis.com/auth/cloud-platform',
+    ],
+  );
+
+  final client = Firestore(client: authClient);
+
+  try {
+    // Call a method on the client.
+    final response = await client.getDocument(
+      GetDocumentRequest(),
+    );
+    print('Response: $response');
+  } finally {
+    // Always close the client to release resources.
+    client.close();
+  }
+}
+```
+
+#### Option B: Using an API Key (Simple)
+
+Recommended for quick testing or prototyping because the setup is simple.
+
+If the user does not have an API key, then they can obtain one using the
+[Google Cloud Console](https://console.cloud.google.com/apis/credentials).
+
+Add the API key to one of these environment variables:
+- `GOOGLE_API_KEY`
+
+
+```dart
+import 'package:google_cloud_firestore_v1/firestore.dart';
+
+Future<void> main() async {
+  final client = Firestore.fromApiKey();
+
+  try {
+    // Call a method on the client.
+    final response = await client.getDocument(
+      GetDocumentRequest(),
+    );
+    print('Response: $response');
+  } finally {
+    // Always close the client to release resources.
+    client.close();
+  }
+}
+```
+

--- a/generated/google_cloud_firestore_v1/skills/google_cloud_firestore_v1-tests/SKILL.md
+++ b/generated/google_cloud_firestore_v1/skills/google_cloud_firestore_v1-tests/SKILL.md
@@ -78,8 +78,8 @@ void main() {
           return Document();
       },
     );
-    // Instead of verifying that `functionUnderTest`, you should verify the
-    // relevant properties of the result.
+    // Instead of verifying that `functionUnderTest` completes, you should verify
+    // the relevant properties of the result.
     await expectLater(functionUnderTest(fake), completes);
   });
 }

--- a/generated/google_cloud_firestore_v1/skills/google_cloud_firestore_v1-tests/SKILL.md
+++ b/generated/google_cloud_firestore_v1/skills/google_cloud_firestore_v1-tests/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: google-cloud-firestore-v1-tests
+description: >-
+  Use this skill when writing tests for code that uses
+  package:google_cloud_firestore_v1
+---
+
+## Testing with Fakes
+
+Most unit tests should use fakes instead of making network requests to Google
+services.
+
+- Code that uses `Firestore` can be tested by injecting the
+  fake `FakeFirestore`.
+
+Import the fakes from the testing library:
+
+```dart
+import 'package:google_cloud_firestore_v1/testing.dart';
+```
+
+### Option A: Using Constructor Closures (Recommended)
+
+You can inject behavior by passing optional function callbacks to the fake's
+constructor. Methods that are not provided will throw an `UnsupportedError`.
+
+```dart
+import 'package:google_cloud_firestore_v1/firestore.dart';
+import 'package:google_cloud_firestore_v1/testing.dart';
+
+final fake = FakeFirestore(
+  getDocument: (request) async {
+    // Assert request contents here if needed.
+    return Document();
+  },
+);
+```
+
+### Option B: Subclassing the Fake
+
+For more complex test setups or shared states, you can subclass the fake and
+override its methods. Methods that are not overridden will throw an
+`UnsupportedError`.
+
+```dart
+import 'package:google_cloud_firestore_v1/firestore.dart';
+import 'package:google_cloud_firestore_v1/testing.dart';
+
+final class MyFakeFirestore extends FakeFirestore {
+  @override
+  Future<Document> getDocument(
+    GetDocumentRequest request,
+  ) async {
+    // Assert request contents here if needed.
+    return Document();
+  }
+}
+```
+
+## A Simple Test
+
+```dart
+import 'package:google_cloud_firestore_v1/firestore.dart';
+import 'package:google_cloud_firestore_v1/testing.dart';
+import 'package:test/test.dart';
+
+Future<void> functionUnderTest(Firestore service) async {
+  // Application logic here.
+  await service.getDocument(GetDocumentRequest());
+  // More application logic here.
+}
+
+void main() {
+  test('test', () async {
+    final fake = FakeFirestore(
+      getDocument: (request) async {
+          // Assert request contents here.
+          return Document();
+      },
+    );
+    // Instead of verifying that `functionUnderTest`, you should verify the
+    // relevant properties of the result.
+    await expectLater(functionUnderTest(fake), completes);
+  });
+}
+```

--- a/generated/google_cloud_functions_v2/README.md
+++ b/generated/google_cloud_functions_v2/README.md
@@ -22,4 +22,17 @@ The Google Cloud client library for the Cloud Functions API.
 
 The Google Cloud client library for the Cloud Functions API.
 
+## Agent Skills
+
+This package supports [Agent Skills](https://agentskills.io/home).
+
+To add this package to your application and install the skills for use by your
+Agent, run:
+
+```shell
+dart pub add google_cloud_functions_v2
+dart pub get
+dart run skills@ get
+```
+
 Manages lightweight user-provided functions executed in response to events.

--- a/generated/google_cloud_functions_v2/lib/cloudfunctions.dart
+++ b/generated/google_cloud_functions_v2/lib/cloudfunctions.dart
@@ -23,4 +23,6 @@ library;
 // ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: unintended_html_in_doc_comment
 
+export 'package:google_cloud_rpc/exceptions.dart';
+
 export 'src/api.g.dart' hide FakeFunctionService;

--- a/generated/google_cloud_functions_v2/lib/src/api.g.dart
+++ b/generated/google_cloud_functions_v2/lib/src/api.g.dart
@@ -17,6 +17,8 @@
 /// The Google Cloud client for the Cloud Functions API.
 ///
 /// Manages lightweight user-provided functions executed in response to events.
+///
+/// @docImport 'package:google_cloud_rpc/exceptions.dart';
 library;
 
 // ignore_for_file: camel_case_types
@@ -32,7 +34,6 @@ import 'package:google_cloud_location/location.dart';
 import 'package:google_cloud_longrunning/longrunning.dart';
 import 'package:google_cloud_protobuf/protobuf.dart';
 import 'package:google_cloud_protobuf/src/encoding.dart';
-import 'package:google_cloud_rpc/exceptions.dart';
 import 'package:google_cloud_rpc/service_client.dart';
 import 'package:google_cloud_type/type.dart';
 import 'package:http/http.dart' as http;

--- a/generated/google_cloud_functions_v2/skills/google_cloud_functions_v2-setup/SKILL.md
+++ b/generated/google_cloud_functions_v2/skills/google_cloud_functions_v2-setup/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: google-cloud-functions-v2-setup
+description: >-
+  Use this skill to help the developer get started with
+  package:google_cloud_functions_v2
+---
+
+## Getting Started with package:google_cloud_functions_v2
+
+### 1. Add the package to your pubspec.yaml
+
+```shell
+dart pub add google_cloud_functions_v2
+```
+
+### 2. Import the library
+
+In your Dart code, import the library:
+
+```dart
+import 'package:google_cloud_functions_v2/cloudfunctions.dart';
+```
+
+### 3. Initialize the client
+
+To call the client, you need to create an instance of the service that
+you want to use, e.g., `FunctionService`.
+
+There are two ways of creating an instance with the necessary credentials.
+
+#### Option A: Using Application Default Credentials (ADC) (Recommended)
+
+Recommended for production environments, server-side backends, and when
+running on Google Cloud (such as Cloud Run, GCE, GKE).
+
+When running on Google Cloud, Application Default Credentials are automatically
+available.
+
+When running locally, the `gcloud` command must be available (see
+[Install the Google Cloud CLI](https://docs.cloud.google.com/sdk/docs/install-sdk)).
+To obtain Application Default Credentials, run:
+
+```shell
+gcloud auth application-default login
+```
+
+Add `googleapis_auth` to your dependencies:
+
+```shell
+dart pub add googleapis_auth
+```
+
+```dart
+import 'package:googleapis_auth/auth_io.dart';
+import 'package:google_cloud_functions_v2/cloudfunctions.dart';
+
+Future<void> main() async {
+  final authClient = await clientViaApplicationDefaultCredentials(
+    scopes: [
+      'https://www.googleapis.com/auth/cloud-platform',
+    ],
+  );
+
+  final client = FunctionService(client: authClient);
+
+  try {
+    // Call a method on the client.
+    final response = await client.getFunction(
+      GetFunctionRequest(),
+    );
+    print('Response: $response');
+  } finally {
+    // Always close the client to release resources.
+    client.close();
+  }
+}
+```
+
+#### Option B: Using an API Key (Simple)
+
+Recommended for quick testing or prototyping because the setup is simple.
+
+If the user does not have an API key, then they can obtain one using the
+[Google Cloud Console](https://console.cloud.google.com/apis/credentials).
+
+Add the API key to one of these environment variables:
+- `GOOGLE_API_KEY`
+
+
+```dart
+import 'package:google_cloud_functions_v2/cloudfunctions.dart';
+
+Future<void> main() async {
+  final client = FunctionService.fromApiKey();
+
+  try {
+    // Call a method on the client.
+    final response = await client.getFunction(
+      GetFunctionRequest(),
+    );
+    print('Response: $response');
+  } finally {
+    // Always close the client to release resources.
+    client.close();
+  }
+}
+```
+

--- a/generated/google_cloud_functions_v2/skills/google_cloud_functions_v2-tests/SKILL.md
+++ b/generated/google_cloud_functions_v2/skills/google_cloud_functions_v2-tests/SKILL.md
@@ -78,8 +78,8 @@ void main() {
           return Function$();
       },
     );
-    // Instead of verifying that `functionUnderTest`, you should verify the
-    // relevant properties of the result.
+    // Instead of verifying that `functionUnderTest` completes, you should verify
+    // the relevant properties of the result.
     await expectLater(functionUnderTest(fake), completes);
   });
 }

--- a/generated/google_cloud_functions_v2/skills/google_cloud_functions_v2-tests/SKILL.md
+++ b/generated/google_cloud_functions_v2/skills/google_cloud_functions_v2-tests/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: google-cloud-functions-v2-tests
+description: >-
+  Use this skill when writing tests for code that uses
+  package:google_cloud_functions_v2
+---
+
+## Testing with Fakes
+
+Most unit tests should use fakes instead of making network requests to Google
+services.
+
+- Code that uses `FunctionService` can be tested by injecting the
+  fake `FakeFunctionService`.
+
+Import the fakes from the testing library:
+
+```dart
+import 'package:google_cloud_functions_v2/testing.dart';
+```
+
+### Option A: Using Constructor Closures (Recommended)
+
+You can inject behavior by passing optional function callbacks to the fake's
+constructor. Methods that are not provided will throw an `UnsupportedError`.
+
+```dart
+import 'package:google_cloud_functions_v2/cloudfunctions.dart';
+import 'package:google_cloud_functions_v2/testing.dart';
+
+final fake = FakeFunctionService(
+  getFunction: (request) async {
+    // Assert request contents here if needed.
+    return Function$();
+  },
+);
+```
+
+### Option B: Subclassing the Fake
+
+For more complex test setups or shared states, you can subclass the fake and
+override its methods. Methods that are not overridden will throw an
+`UnsupportedError`.
+
+```dart
+import 'package:google_cloud_functions_v2/cloudfunctions.dart';
+import 'package:google_cloud_functions_v2/testing.dart';
+
+final class MyFakeFunctionService extends FakeFunctionService {
+  @override
+  Future<Function$> getFunction(
+    GetFunctionRequest request,
+  ) async {
+    // Assert request contents here if needed.
+    return Function$();
+  }
+}
+```
+
+## A Simple Test
+
+```dart
+import 'package:google_cloud_functions_v2/cloudfunctions.dart';
+import 'package:google_cloud_functions_v2/testing.dart';
+import 'package:test/test.dart';
+
+Future<void> functionUnderTest(FunctionService service) async {
+  // Application logic here.
+  await service.getFunction(GetFunctionRequest());
+  // More application logic here.
+}
+
+void main() {
+  test('test', () async {
+    final fake = FakeFunctionService(
+      getFunction: (request) async {
+          // Assert request contents here.
+          return Function$();
+      },
+    );
+    // Instead of verifying that `functionUnderTest`, you should verify the
+    // relevant properties of the result.
+    await expectLater(functionUnderTest(fake), completes);
+  });
+}
+```

--- a/generated/google_cloud_iam_v1/README.md
+++ b/generated/google_cloud_iam_v1/README.md
@@ -22,4 +22,17 @@ The Google Cloud client library for the IAM Meta API.
 
 The Google Cloud client library for the IAM Meta API.
 
+## Agent Skills
+
+This package supports [Agent Skills](https://agentskills.io/home).
+
+To add this package to your application and install the skills for use by your
+Agent, run:
+
+```shell
+dart pub add google_cloud_iam_v1
+dart pub get
+dart run skills@ get
+```
+
 Manages access control for Google Cloud Platform resources.

--- a/generated/google_cloud_iam_v1/lib/iam.dart
+++ b/generated/google_cloud_iam_v1/lib/iam.dart
@@ -23,4 +23,6 @@ library;
 // ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: unintended_html_in_doc_comment
 
+export 'package:google_cloud_rpc/exceptions.dart';
+
 export 'src/api.g.dart' hide FakeIAMPolicy;

--- a/generated/google_cloud_iam_v1/lib/src/api.g.dart
+++ b/generated/google_cloud_iam_v1/lib/src/api.g.dart
@@ -17,6 +17,8 @@
 /// The Google Cloud client for the IAM Meta API.
 ///
 /// Manages access control for Google Cloud Platform resources.
+///
+/// @docImport 'package:google_cloud_rpc/exceptions.dart';
 library;
 
 // ignore_for_file: camel_case_types
@@ -29,7 +31,6 @@ library;
 
 import 'package:google_cloud_protobuf/protobuf.dart';
 import 'package:google_cloud_protobuf/src/encoding.dart';
-import 'package:google_cloud_rpc/exceptions.dart';
 import 'package:google_cloud_rpc/service_client.dart';
 import 'package:google_cloud_type/type.dart';
 import 'package:http/http.dart' as http;

--- a/generated/google_cloud_iam_v1/skills/google_cloud_iam_v1-setup/SKILL.md
+++ b/generated/google_cloud_iam_v1/skills/google_cloud_iam_v1-setup/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: google-cloud-iam-v1-setup
+description: >-
+  Use this skill to help the developer get started with
+  package:google_cloud_iam_v1
+---
+
+## Getting Started with package:google_cloud_iam_v1
+
+### 1. Add the package to your pubspec.yaml
+
+```shell
+dart pub add google_cloud_iam_v1
+```
+
+### 2. Import the library
+
+In your Dart code, import the library:
+
+```dart
+import 'package:google_cloud_iam_v1/iam.dart';
+```
+
+### 3. Initialize the client
+
+To call the client, you need to create an instance of the service that
+you want to use, e.g., `IAMPolicy`.
+
+There are two ways of creating an instance with the necessary credentials.
+
+#### Option A: Using Application Default Credentials (ADC) (Recommended)
+
+Recommended for production environments, server-side backends, and when
+running on Google Cloud (such as Cloud Run, GCE, GKE).
+
+When running on Google Cloud, Application Default Credentials are automatically
+available.
+
+When running locally, the `gcloud` command must be available (see
+[Install the Google Cloud CLI](https://docs.cloud.google.com/sdk/docs/install-sdk)).
+To obtain Application Default Credentials, run:
+
+```shell
+gcloud auth application-default login
+```
+
+Add `googleapis_auth` to your dependencies:
+
+```shell
+dart pub add googleapis_auth
+```
+
+```dart
+import 'package:googleapis_auth/auth_io.dart';
+import 'package:google_cloud_iam_v1/iam.dart';
+
+Future<void> main() async {
+  final authClient = await clientViaApplicationDefaultCredentials(
+    scopes: [
+      'https://www.googleapis.com/auth/cloud-platform',
+    ],
+  );
+
+  final client = IAMPolicy(client: authClient);
+
+  try {
+    // Call a method on the client.
+    final response = await client.setIamPolicy(
+      SetIamPolicyRequest(),
+    );
+    print('Response: $response');
+  } finally {
+    // Always close the client to release resources.
+    client.close();
+  }
+}
+```
+
+#### Option B: Using an API Key (Simple)
+
+Recommended for quick testing or prototyping because the setup is simple.
+
+If the user does not have an API key, then they can obtain one using the
+[Google Cloud Console](https://console.cloud.google.com/apis/credentials).
+
+Add the API key to one of these environment variables:
+- `GOOGLE_API_KEY`
+
+
+```dart
+import 'package:google_cloud_iam_v1/iam.dart';
+
+Future<void> main() async {
+  final client = IAMPolicy.fromApiKey();
+
+  try {
+    // Call a method on the client.
+    final response = await client.setIamPolicy(
+      SetIamPolicyRequest(),
+    );
+    print('Response: $response');
+  } finally {
+    // Always close the client to release resources.
+    client.close();
+  }
+}
+```
+

--- a/generated/google_cloud_iam_v1/skills/google_cloud_iam_v1-tests/SKILL.md
+++ b/generated/google_cloud_iam_v1/skills/google_cloud_iam_v1-tests/SKILL.md
@@ -78,8 +78,8 @@ void main() {
           return Policy();
       },
     );
-    // Instead of verifying that `functionUnderTest`, you should verify the
-    // relevant properties of the result.
+    // Instead of verifying that `functionUnderTest` completes, you should verify
+    // the relevant properties of the result.
     await expectLater(functionUnderTest(fake), completes);
   });
 }

--- a/generated/google_cloud_iam_v1/skills/google_cloud_iam_v1-tests/SKILL.md
+++ b/generated/google_cloud_iam_v1/skills/google_cloud_iam_v1-tests/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: google-cloud-iam-v1-tests
+description: >-
+  Use this skill when writing tests for code that uses
+  package:google_cloud_iam_v1
+---
+
+## Testing with Fakes
+
+Most unit tests should use fakes instead of making network requests to Google
+services.
+
+- Code that uses `IAMPolicy` can be tested by injecting the
+  fake `FakeIAMPolicy`.
+
+Import the fakes from the testing library:
+
+```dart
+import 'package:google_cloud_iam_v1/testing.dart';
+```
+
+### Option A: Using Constructor Closures (Recommended)
+
+You can inject behavior by passing optional function callbacks to the fake's
+constructor. Methods that are not provided will throw an `UnsupportedError`.
+
+```dart
+import 'package:google_cloud_iam_v1/iam.dart';
+import 'package:google_cloud_iam_v1/testing.dart';
+
+final fake = FakeIAMPolicy(
+  setIamPolicy: (request) async {
+    // Assert request contents here if needed.
+    return Policy();
+  },
+);
+```
+
+### Option B: Subclassing the Fake
+
+For more complex test setups or shared states, you can subclass the fake and
+override its methods. Methods that are not overridden will throw an
+`UnsupportedError`.
+
+```dart
+import 'package:google_cloud_iam_v1/iam.dart';
+import 'package:google_cloud_iam_v1/testing.dart';
+
+final class MyFakeIAMPolicy extends FakeIAMPolicy {
+  @override
+  Future<Policy> setIamPolicy(
+    SetIamPolicyRequest request,
+  ) async {
+    // Assert request contents here if needed.
+    return Policy();
+  }
+}
+```
+
+## A Simple Test
+
+```dart
+import 'package:google_cloud_iam_v1/iam.dart';
+import 'package:google_cloud_iam_v1/testing.dart';
+import 'package:test/test.dart';
+
+Future<void> functionUnderTest(IAMPolicy service) async {
+  // Application logic here.
+  await service.setIamPolicy(SetIamPolicyRequest());
+  // More application logic here.
+}
+
+void main() {
+  test('test', () async {
+    final fake = FakeIAMPolicy(
+      setIamPolicy: (request) async {
+          // Assert request contents here.
+          return Policy();
+      },
+    );
+    // Instead of verifying that `functionUnderTest`, you should verify the
+    // relevant properties of the result.
+    await expectLater(functionUnderTest(fake), completes);
+  });
+}
+```

--- a/generated/google_cloud_language_v2/README.md
+++ b/generated/google_cloud_language_v2/README.md
@@ -22,6 +22,19 @@ The Google Cloud client library for the Cloud Natural Language API.
 
 The Google Cloud client library for the Cloud Natural Language API.
 
+## Agent Skills
+
+This package supports [Agent Skills](https://agentskills.io/home).
+
+To add this package to your application and install the skills for use by your
+Agent, run:
+
+```shell
+dart pub add google_cloud_language_v2
+dart pub get
+dart run skills@ get
+```
+
 Provides natural language understanding technologies, such as sentiment
 analysis, entity recognition, entity sentiment analysis, and other text
 annotations, to developers.

--- a/generated/google_cloud_language_v2/lib/language.dart
+++ b/generated/google_cloud_language_v2/lib/language.dart
@@ -25,4 +25,6 @@ library;
 // ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: unintended_html_in_doc_comment
 
+export 'package:google_cloud_rpc/exceptions.dart';
+
 export 'src/api.g.dart' hide FakeLanguageService;

--- a/generated/google_cloud_language_v2/lib/src/api.g.dart
+++ b/generated/google_cloud_language_v2/lib/src/api.g.dart
@@ -19,6 +19,8 @@
 /// Provides natural language understanding technologies, such as sentiment
 /// analysis, entity recognition, entity sentiment analysis, and other text
 /// annotations, to developers.
+///
+/// @docImport 'package:google_cloud_rpc/exceptions.dart';
 library;
 
 // ignore_for_file: camel_case_types
@@ -31,7 +33,6 @@ library;
 
 import 'package:google_cloud_protobuf/protobuf.dart';
 import 'package:google_cloud_protobuf/src/encoding.dart';
-import 'package:google_cloud_rpc/exceptions.dart';
 import 'package:google_cloud_rpc/service_client.dart';
 import 'package:http/http.dart' as http;
 

--- a/generated/google_cloud_language_v2/skills/google_cloud_language_v2-setup/SKILL.md
+++ b/generated/google_cloud_language_v2/skills/google_cloud_language_v2-setup/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: google-cloud-language-v2-setup
+description: >-
+  Use this skill to help the developer get started with
+  package:google_cloud_language_v2
+---
+
+## Getting Started with package:google_cloud_language_v2
+
+### 1. Add the package to your pubspec.yaml
+
+```shell
+dart pub add google_cloud_language_v2
+```
+
+### 2. Import the library
+
+In your Dart code, import the library:
+
+```dart
+import 'package:google_cloud_language_v2/language.dart';
+```
+
+### 3. Initialize the client
+
+To call the client, you need to create an instance of the service that
+you want to use, e.g., `LanguageService`.
+
+There are two ways of creating an instance with the necessary credentials.
+
+#### Option A: Using Application Default Credentials (ADC) (Recommended)
+
+Recommended for production environments, server-side backends, and when
+running on Google Cloud (such as Cloud Run, GCE, GKE).
+
+When running on Google Cloud, Application Default Credentials are automatically
+available.
+
+When running locally, the `gcloud` command must be available (see
+[Install the Google Cloud CLI](https://docs.cloud.google.com/sdk/docs/install-sdk)).
+To obtain Application Default Credentials, run:
+
+```shell
+gcloud auth application-default login
+```
+
+Add `googleapis_auth` to your dependencies:
+
+```shell
+dart pub add googleapis_auth
+```
+
+```dart
+import 'package:googleapis_auth/auth_io.dart';
+import 'package:google_cloud_language_v2/language.dart';
+
+Future<void> main() async {
+  final authClient = await clientViaApplicationDefaultCredentials(
+    scopes: [
+      'https://www.googleapis.com/auth/cloud-platform',
+    ],
+  );
+
+  final client = LanguageService(client: authClient);
+
+  try {
+    // Call a method on the client.
+    final response = await client.analyzeSentiment(
+      AnalyzeSentimentRequest(),
+    );
+    print('Response: $response');
+  } finally {
+    // Always close the client to release resources.
+    client.close();
+  }
+}
+```
+
+#### Option B: Using an API Key (Simple)
+
+Recommended for quick testing or prototyping because the setup is simple.
+
+If the user does not have an API key, then they can obtain one using the
+[Google Cloud Console](https://console.cloud.google.com/apis/credentials).
+
+Add the API key to one of these environment variables:
+- `GOOGLE_API_KEY`
+
+
+```dart
+import 'package:google_cloud_language_v2/language.dart';
+
+Future<void> main() async {
+  final client = LanguageService.fromApiKey();
+
+  try {
+    // Call a method on the client.
+    final response = await client.analyzeSentiment(
+      AnalyzeSentimentRequest(),
+    );
+    print('Response: $response');
+  } finally {
+    // Always close the client to release resources.
+    client.close();
+  }
+}
+```
+

--- a/generated/google_cloud_language_v2/skills/google_cloud_language_v2-tests/SKILL.md
+++ b/generated/google_cloud_language_v2/skills/google_cloud_language_v2-tests/SKILL.md
@@ -78,8 +78,8 @@ void main() {
           return AnalyzeSentimentResponse();
       },
     );
-    // Instead of verifying that `functionUnderTest`, you should verify the
-    // relevant properties of the result.
+    // Instead of verifying that `functionUnderTest` completes, you should verify
+    // the relevant properties of the result.
     await expectLater(functionUnderTest(fake), completes);
   });
 }

--- a/generated/google_cloud_language_v2/skills/google_cloud_language_v2-tests/SKILL.md
+++ b/generated/google_cloud_language_v2/skills/google_cloud_language_v2-tests/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: google-cloud-language-v2-tests
+description: >-
+  Use this skill when writing tests for code that uses
+  package:google_cloud_language_v2
+---
+
+## Testing with Fakes
+
+Most unit tests should use fakes instead of making network requests to Google
+services.
+
+- Code that uses `LanguageService` can be tested by injecting the
+  fake `FakeLanguageService`.
+
+Import the fakes from the testing library:
+
+```dart
+import 'package:google_cloud_language_v2/testing.dart';
+```
+
+### Option A: Using Constructor Closures (Recommended)
+
+You can inject behavior by passing optional function callbacks to the fake's
+constructor. Methods that are not provided will throw an `UnsupportedError`.
+
+```dart
+import 'package:google_cloud_language_v2/language.dart';
+import 'package:google_cloud_language_v2/testing.dart';
+
+final fake = FakeLanguageService(
+  analyzeSentiment: (request) async {
+    // Assert request contents here if needed.
+    return AnalyzeSentimentResponse();
+  },
+);
+```
+
+### Option B: Subclassing the Fake
+
+For more complex test setups or shared states, you can subclass the fake and
+override its methods. Methods that are not overridden will throw an
+`UnsupportedError`.
+
+```dart
+import 'package:google_cloud_language_v2/language.dart';
+import 'package:google_cloud_language_v2/testing.dart';
+
+final class MyFakeLanguageService extends FakeLanguageService {
+  @override
+  Future<AnalyzeSentimentResponse> analyzeSentiment(
+    AnalyzeSentimentRequest request,
+  ) async {
+    // Assert request contents here if needed.
+    return AnalyzeSentimentResponse();
+  }
+}
+```
+
+## A Simple Test
+
+```dart
+import 'package:google_cloud_language_v2/language.dart';
+import 'package:google_cloud_language_v2/testing.dart';
+import 'package:test/test.dart';
+
+Future<void> functionUnderTest(LanguageService service) async {
+  // Application logic here.
+  await service.analyzeSentiment(AnalyzeSentimentRequest());
+  // More application logic here.
+}
+
+void main() {
+  test('test', () async {
+    final fake = FakeLanguageService(
+      analyzeSentiment: (request) async {
+          // Assert request contents here.
+          return AnalyzeSentimentResponse();
+      },
+    );
+    // Instead of verifying that `functionUnderTest`, you should verify the
+    // relevant properties of the result.
+    await expectLater(functionUnderTest(fake), completes);
+  });
+}
+```

--- a/generated/google_cloud_location/README.md
+++ b/generated/google_cloud_location/README.md
@@ -22,6 +22,19 @@ The Google Cloud client library for the Cloud Metadata API.
 
 The Google Cloud client library for the Cloud Metadata API.
 
+## Agent Skills
+
+This package supports [Agent Skills](https://agentskills.io/home).
+
+To add this package to your application and install the skills for use by your
+Agent, run:
+
+```shell
+dart pub add google_cloud_location
+dart pub get
+dart run skills@ get
+```
+
 This API provides static metadata about Google Cloud Platform. Currently,
 it only provides basic information about Google Cloud locations, such as
 zones, regions, and countries.

--- a/generated/google_cloud_location/lib/location.dart
+++ b/generated/google_cloud_location/lib/location.dart
@@ -25,4 +25,6 @@ library;
 // ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: unintended_html_in_doc_comment
 
+export 'package:google_cloud_rpc/exceptions.dart';
+
 export 'src/api.g.dart' hide FakeLocations;

--- a/generated/google_cloud_location/lib/src/api.g.dart
+++ b/generated/google_cloud_location/lib/src/api.g.dart
@@ -19,6 +19,8 @@
 /// This API provides static metadata about Google Cloud Platform. Currently,
 /// it only provides basic information about Google Cloud locations, such as
 /// zones, regions, and countries.
+///
+/// @docImport 'package:google_cloud_rpc/exceptions.dart';
 library;
 
 // ignore_for_file: camel_case_types
@@ -31,7 +33,6 @@ library;
 
 import 'package:google_cloud_protobuf/protobuf.dart';
 import 'package:google_cloud_protobuf/src/encoding.dart';
-import 'package:google_cloud_rpc/exceptions.dart';
 import 'package:google_cloud_rpc/service_client.dart';
 import 'package:http/http.dart' as http;
 

--- a/generated/google_cloud_location/skills/google_cloud_location-setup/SKILL.md
+++ b/generated/google_cloud_location/skills/google_cloud_location-setup/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: google-cloud-location-setup
+description: >-
+  Use this skill to help the developer get started with
+  package:google_cloud_location
+---
+
+## Getting Started with package:google_cloud_location
+
+### 1. Add the package to your pubspec.yaml
+
+```shell
+dart pub add google_cloud_location
+```
+
+### 2. Import the library
+
+In your Dart code, import the library:
+
+```dart
+import 'package:google_cloud_location/location.dart';
+```
+
+### 3. Initialize the client
+
+To call the client, you need to create an instance of the service that
+you want to use, e.g., `Locations`.
+
+There are two ways of creating an instance with the necessary credentials.
+
+#### Option A: Using Application Default Credentials (ADC) (Recommended)
+
+Recommended for production environments, server-side backends, and when
+running on Google Cloud (such as Cloud Run, GCE, GKE).
+
+When running on Google Cloud, Application Default Credentials are automatically
+available.
+
+When running locally, the `gcloud` command must be available (see
+[Install the Google Cloud CLI](https://docs.cloud.google.com/sdk/docs/install-sdk)).
+To obtain Application Default Credentials, run:
+
+```shell
+gcloud auth application-default login
+```
+
+Add `googleapis_auth` to your dependencies:
+
+```shell
+dart pub add googleapis_auth
+```
+
+```dart
+import 'package:googleapis_auth/auth_io.dart';
+import 'package:google_cloud_location/location.dart';
+
+Future<void> main() async {
+  final authClient = await clientViaApplicationDefaultCredentials(
+    scopes: [
+      'https://www.googleapis.com/auth/cloud-platform',
+    ],
+  );
+
+  final client = Locations(client: authClient);
+
+  try {
+    // Call a method on the client.
+    final response = await client.getLocation(
+      GetLocationRequest(),
+    );
+    print('Response: $response');
+  } finally {
+    // Always close the client to release resources.
+    client.close();
+  }
+}
+```
+
+#### Option B: Using an API Key (Simple)
+
+Recommended for quick testing or prototyping because the setup is simple.
+
+If the user does not have an API key, then they can obtain one using the
+[Google Cloud Console](https://console.cloud.google.com/apis/credentials).
+
+Add the API key to one of these environment variables:
+- `GOOGLE_API_KEY`
+
+
+```dart
+import 'package:google_cloud_location/location.dart';
+
+Future<void> main() async {
+  final client = Locations.fromApiKey();
+
+  try {
+    // Call a method on the client.
+    final response = await client.getLocation(
+      GetLocationRequest(),
+    );
+    print('Response: $response');
+  } finally {
+    // Always close the client to release resources.
+    client.close();
+  }
+}
+```
+

--- a/generated/google_cloud_location/skills/google_cloud_location-tests/SKILL.md
+++ b/generated/google_cloud_location/skills/google_cloud_location-tests/SKILL.md
@@ -78,8 +78,8 @@ void main() {
           return Location();
       },
     );
-    // Instead of verifying that `functionUnderTest`, you should verify the
-    // relevant properties of the result.
+    // Instead of verifying that `functionUnderTest` completes, you should verify
+    // the relevant properties of the result.
     await expectLater(functionUnderTest(fake), completes);
   });
 }

--- a/generated/google_cloud_location/skills/google_cloud_location-tests/SKILL.md
+++ b/generated/google_cloud_location/skills/google_cloud_location-tests/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: google-cloud-location-tests
+description: >-
+  Use this skill when writing tests for code that uses
+  package:google_cloud_location
+---
+
+## Testing with Fakes
+
+Most unit tests should use fakes instead of making network requests to Google
+services.
+
+- Code that uses `Locations` can be tested by injecting the
+  fake `FakeLocations`.
+
+Import the fakes from the testing library:
+
+```dart
+import 'package:google_cloud_location/testing.dart';
+```
+
+### Option A: Using Constructor Closures (Recommended)
+
+You can inject behavior by passing optional function callbacks to the fake's
+constructor. Methods that are not provided will throw an `UnsupportedError`.
+
+```dart
+import 'package:google_cloud_location/location.dart';
+import 'package:google_cloud_location/testing.dart';
+
+final fake = FakeLocations(
+  getLocation: (request) async {
+    // Assert request contents here if needed.
+    return Location();
+  },
+);
+```
+
+### Option B: Subclassing the Fake
+
+For more complex test setups or shared states, you can subclass the fake and
+override its methods. Methods that are not overridden will throw an
+`UnsupportedError`.
+
+```dart
+import 'package:google_cloud_location/location.dart';
+import 'package:google_cloud_location/testing.dart';
+
+final class MyFakeLocations extends FakeLocations {
+  @override
+  Future<Location> getLocation(
+    GetLocationRequest request,
+  ) async {
+    // Assert request contents here if needed.
+    return Location();
+  }
+}
+```
+
+## A Simple Test
+
+```dart
+import 'package:google_cloud_location/location.dart';
+import 'package:google_cloud_location/testing.dart';
+import 'package:test/test.dart';
+
+Future<void> functionUnderTest(Locations service) async {
+  // Application logic here.
+  await service.getLocation(GetLocationRequest());
+  // More application logic here.
+}
+
+void main() {
+  test('test', () async {
+    final fake = FakeLocations(
+      getLocation: (request) async {
+          // Assert request contents here.
+          return Location();
+      },
+    );
+    // Instead of verifying that `functionUnderTest`, you should verify the
+    // relevant properties of the result.
+    await expectLater(functionUnderTest(fake), completes);
+  });
+}
+```

--- a/generated/google_cloud_logging_v2/README.md
+++ b/generated/google_cloud_logging_v2/README.md
@@ -22,4 +22,17 @@ The Google Cloud client library for the Cloud Logging API.
 
 The Google Cloud client library for the Cloud Logging API.
 
+## Agent Skills
+
+This package supports [Agent Skills](https://agentskills.io/home).
+
+To add this package to your application and install the skills for use by your
+Agent, run:
+
+```shell
+dart pub add google_cloud_logging_v2
+dart pub get
+dart run skills@ get
+```
+
 Writes log entries and manages your Cloud Logging configuration.

--- a/generated/google_cloud_logging_v2/lib/logging.dart
+++ b/generated/google_cloud_logging_v2/lib/logging.dart
@@ -23,5 +23,7 @@ library;
 // ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: unintended_html_in_doc_comment
 
+export 'package:google_cloud_rpc/exceptions.dart';
+
 export 'src/api.g.dart'
     hide FakeConfigServiceV2, FakeLoggingServiceV2, FakeMetricsServiceV2;

--- a/generated/google_cloud_logging_v2/lib/src/api.g.dart
+++ b/generated/google_cloud_logging_v2/lib/src/api.g.dart
@@ -17,6 +17,8 @@
 /// The Google Cloud client for the Cloud Logging API.
 ///
 /// Writes log entries and manages your Cloud Logging configuration.
+///
+/// @docImport 'package:google_cloud_rpc/exceptions.dart';
 library;
 
 // ignore_for_file: camel_case_types
@@ -32,7 +34,6 @@ import 'package:google_cloud_logging_type/logging_type.dart' as logging_type;
 import 'package:google_cloud_longrunning/longrunning.dart';
 import 'package:google_cloud_protobuf/protobuf.dart';
 import 'package:google_cloud_protobuf/src/encoding.dart';
-import 'package:google_cloud_rpc/exceptions.dart';
 import 'package:google_cloud_rpc/rpc.dart';
 import 'package:google_cloud_rpc/service_client.dart';
 import 'package:http/http.dart' as http;

--- a/generated/google_cloud_logging_v2/skills/google_cloud_logging_v2-setup/SKILL.md
+++ b/generated/google_cloud_logging_v2/skills/google_cloud_logging_v2-setup/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: google-cloud-logging-v2-setup
+description: >-
+  Use this skill to help the developer get started with
+  package:google_cloud_logging_v2
+---
+
+## Getting Started with package:google_cloud_logging_v2
+
+### 1. Add the package to your pubspec.yaml
+
+```shell
+dart pub add google_cloud_logging_v2
+```
+
+### 2. Import the library
+
+In your Dart code, import the library:
+
+```dart
+import 'package:google_cloud_logging_v2/logging.dart';
+```
+
+### 3. Initialize the client
+
+To call the client, you need to create an instance of the service that
+you want to use, e.g., `ConfigServiceV2`.
+
+There are two ways of creating an instance with the necessary credentials.
+
+#### Option A: Using Application Default Credentials (ADC) (Recommended)
+
+Recommended for production environments, server-side backends, and when
+running on Google Cloud (such as Cloud Run, GCE, GKE).
+
+When running on Google Cloud, Application Default Credentials are automatically
+available.
+
+When running locally, the `gcloud` command must be available (see
+[Install the Google Cloud CLI](https://docs.cloud.google.com/sdk/docs/install-sdk)).
+To obtain Application Default Credentials, run:
+
+```shell
+gcloud auth application-default login
+```
+
+Add `googleapis_auth` to your dependencies:
+
+```shell
+dart pub add googleapis_auth
+```
+
+```dart
+import 'package:googleapis_auth/auth_io.dart';
+import 'package:google_cloud_logging_v2/logging.dart';
+
+Future<void> main() async {
+  final authClient = await clientViaApplicationDefaultCredentials(
+    scopes: [
+      'https://www.googleapis.com/auth/cloud-platform',
+    ],
+  );
+
+  final client = ConfigServiceV2(client: authClient);
+
+  try {
+    // Call a method on the client.
+    final response = await client.createView(
+      CreateViewRequest(),
+    );
+    print('Response: $response');
+  } finally {
+    // Always close the client to release resources.
+    client.close();
+  }
+}
+```
+
+#### Option B: Using an API Key (Simple)
+
+Recommended for quick testing or prototyping because the setup is simple.
+
+If the user does not have an API key, then they can obtain one using the
+[Google Cloud Console](https://console.cloud.google.com/apis/credentials).
+
+Add the API key to one of these environment variables:
+- `GOOGLE_API_KEY`
+
+
+```dart
+import 'package:google_cloud_logging_v2/logging.dart';
+
+Future<void> main() async {
+  final client = ConfigServiceV2.fromApiKey();
+
+  try {
+    // Call a method on the client.
+    final response = await client.createView(
+      CreateViewRequest(),
+    );
+    print('Response: $response');
+  } finally {
+    // Always close the client to release resources.
+    client.close();
+  }
+}
+```
+

--- a/generated/google_cloud_logging_v2/skills/google_cloud_logging_v2-tests/SKILL.md
+++ b/generated/google_cloud_logging_v2/skills/google_cloud_logging_v2-tests/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: google-cloud-logging-v2-tests
+description: >-
+  Use this skill when writing tests for code that uses
+  package:google_cloud_logging_v2
+---
+
+## Testing with Fakes
+
+Most unit tests should use fakes instead of making network requests to Google
+services.
+
+- Code that uses `LoggingServiceV2` can be tested by injecting the
+  fake `FakeLoggingServiceV2`.
+- Code that uses `ConfigServiceV2` can be tested by injecting the
+  fake `FakeConfigServiceV2`.
+- Code that uses `MetricsServiceV2` can be tested by injecting the
+  fake `FakeMetricsServiceV2`.
+
+Import the fakes from the testing library:
+
+```dart
+import 'package:google_cloud_logging_v2/testing.dart';
+```
+
+### Option A: Using Constructor Closures (Recommended)
+
+You can inject behavior by passing optional function callbacks to the fake's
+constructor. Methods that are not provided will throw an `UnsupportedError`.
+
+```dart
+import 'package:google_cloud_logging_v2/logging.dart';
+import 'package:google_cloud_logging_v2/testing.dart';
+
+final fake = FakeConfigServiceV2(
+  createView: (request) async {
+    // Assert request contents here if needed.
+    return LogView();
+  },
+);
+```
+
+### Option B: Subclassing the Fake
+
+For more complex test setups or shared states, you can subclass the fake and
+override its methods. Methods that are not overridden will throw an
+`UnsupportedError`.
+
+```dart
+import 'package:google_cloud_logging_v2/logging.dart';
+import 'package:google_cloud_logging_v2/testing.dart';
+
+final class MyFakeConfigServiceV2 extends FakeConfigServiceV2 {
+  @override
+  Future<LogView> createView(
+    CreateViewRequest request,
+  ) async {
+    // Assert request contents here if needed.
+    return LogView();
+  }
+}
+```
+
+## A Simple Test
+
+```dart
+import 'package:google_cloud_logging_v2/logging.dart';
+import 'package:google_cloud_logging_v2/testing.dart';
+import 'package:test/test.dart';
+
+Future<void> functionUnderTest(ConfigServiceV2 service) async {
+  // Application logic here.
+  await service.createView(CreateViewRequest());
+  // More application logic here.
+}
+
+void main() {
+  test('test', () async {
+    final fake = FakeConfigServiceV2(
+      createView: (request) async {
+          // Assert request contents here.
+          return LogView();
+      },
+    );
+    // Instead of verifying that `functionUnderTest`, you should verify the
+    // relevant properties of the result.
+    await expectLater(functionUnderTest(fake), completes);
+  });
+}
+```

--- a/generated/google_cloud_logging_v2/skills/google_cloud_logging_v2-tests/SKILL.md
+++ b/generated/google_cloud_logging_v2/skills/google_cloud_logging_v2-tests/SKILL.md
@@ -82,8 +82,8 @@ void main() {
           return LogView();
       },
     );
-    // Instead of verifying that `functionUnderTest`, you should verify the
-    // relevant properties of the result.
+    // Instead of verifying that `functionUnderTest` completes, you should verify
+    // the relevant properties of the result.
     await expectLater(functionUnderTest(fake), completes);
   });
 }

--- a/generated/google_cloud_logging_v2/test/write_log_test.dart
+++ b/generated/google_cloud_logging_v2/test/write_log_test.dart
@@ -21,7 +21,6 @@ import 'package:google_cloud_api/api.dart';
 import 'package:google_cloud_logging_type/logging_type.dart';
 import 'package:google_cloud_logging_v2/logging.dart';
 import 'package:google_cloud_protobuf/protobuf.dart' as protobuf;
-import 'package:google_cloud_rpc/exceptions.dart';
 import 'package:google_cloud_rpc/rpc.dart';
 import 'package:googleapis_auth/auth_io.dart' as auth;
 import 'package:http/http.dart' as http;

--- a/generated/google_cloud_longrunning/README.md
+++ b/generated/google_cloud_longrunning/README.md
@@ -22,6 +22,19 @@ The Google Cloud client library for the Long Running Operations API.
 
 The Google Cloud client library for the Long Running Operations API.
 
+## Agent Skills
+
+This package supports [Agent Skills](https://agentskills.io/home).
+
+To add this package to your application and install the skills for use by your
+Agent, run:
+
+```shell
+dart pub add google_cloud_longrunning
+dart pub get
+dart run skills@ get
+```
+
 Defines types and an abstract service to handle long-running operations.
 
 [Long-running operations] are a common pattern to handle methods that may take

--- a/generated/google_cloud_longrunning/lib/longrunning.dart
+++ b/generated/google_cloud_longrunning/lib/longrunning.dart
@@ -32,4 +32,6 @@ library;
 // ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: unintended_html_in_doc_comment
 
+export 'package:google_cloud_rpc/exceptions.dart';
+
 export 'src/api.g.dart' hide FakeOperations;

--- a/generated/google_cloud_longrunning/lib/src/api.g.dart
+++ b/generated/google_cloud_longrunning/lib/src/api.g.dart
@@ -26,6 +26,8 @@
 /// operations.
 ///
 /// [Long-running operations]: https://google.aip.dev/151
+///
+/// @docImport 'package:google_cloud_rpc/exceptions.dart';
 library;
 
 // ignore_for_file: camel_case_types
@@ -38,7 +40,6 @@ library;
 
 import 'package:google_cloud_protobuf/protobuf.dart';
 import 'package:google_cloud_protobuf/src/encoding.dart';
-import 'package:google_cloud_rpc/exceptions.dart';
 import 'package:google_cloud_rpc/rpc.dart';
 import 'package:google_cloud_rpc/service_client.dart';
 import 'package:http/http.dart' as http;

--- a/generated/google_cloud_longrunning/skills/google_cloud_longrunning-setup/SKILL.md
+++ b/generated/google_cloud_longrunning/skills/google_cloud_longrunning-setup/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: google-cloud-longrunning-setup
+description: >-
+  Use this skill to help the developer get started with
+  package:google_cloud_longrunning
+---
+
+## Getting Started with package:google_cloud_longrunning
+
+### 1. Add the package to your pubspec.yaml
+
+```shell
+dart pub add google_cloud_longrunning
+```
+
+### 2. Import the library
+
+In your Dart code, import the library:
+
+```dart
+import 'package:google_cloud_longrunning/longrunning.dart';
+```
+
+### 3. Initialize the client
+
+To call the client, you need to create an instance of the service that
+you want to use, e.g., `Operations`.
+
+There are two ways of creating an instance with the necessary credentials.
+
+#### Option A: Using Application Default Credentials (ADC) (Recommended)
+
+Recommended for production environments, server-side backends, and when
+running on Google Cloud (such as Cloud Run, GCE, GKE).
+
+When running on Google Cloud, Application Default Credentials are automatically
+available.
+
+When running locally, the `gcloud` command must be available (see
+[Install the Google Cloud CLI](https://docs.cloud.google.com/sdk/docs/install-sdk)).
+To obtain Application Default Credentials, run:
+
+```shell
+gcloud auth application-default login
+```
+
+Add `googleapis_auth` to your dependencies:
+
+```shell
+dart pub add googleapis_auth
+```
+
+```dart
+import 'package:googleapis_auth/auth_io.dart';
+import 'package:google_cloud_longrunning/longrunning.dart';
+
+Future<void> main() async {
+  final authClient = await clientViaApplicationDefaultCredentials(
+    scopes: [
+      'https://www.googleapis.com/auth/cloud-platform',
+    ],
+  );
+
+  final client = Operations(client: authClient);
+
+  try {
+    // Call a method on the client.
+    await client.deleteOperation(
+      DeleteOperationRequest(),
+    );
+    print('Method completed successfully.');
+  } finally {
+    // Always close the client to release resources.
+    client.close();
+  }
+}
+```
+
+#### Option B: Using an API Key (Simple)
+
+Recommended for quick testing or prototyping because the setup is simple.
+
+If the user does not have an API key, then they can obtain one using the
+[Google Cloud Console](https://console.cloud.google.com/apis/credentials).
+
+Add the API key to one of these environment variables:
+- `GOOGLE_API_KEY`
+
+
+```dart
+import 'package:google_cloud_longrunning/longrunning.dart';
+
+Future<void> main() async {
+  final client = Operations.fromApiKey();
+
+  try {
+    // Call a method on the client.
+    await client.deleteOperation(
+      DeleteOperationRequest(),
+    );
+    print('Method completed successfully.');
+  } finally {
+    // Always close the client to release resources.
+    client.close();
+  }
+}
+```
+

--- a/generated/google_cloud_longrunning/skills/google_cloud_longrunning-tests/SKILL.md
+++ b/generated/google_cloud_longrunning/skills/google_cloud_longrunning-tests/SKILL.md
@@ -75,8 +75,8 @@ void main() {
           // Assert request contents here.
       },
     );
-    // Instead of verifying that `functionUnderTest`, you should verify the
-    // relevant properties of the result.
+    // Instead of verifying that `functionUnderTest` completes, you should verify
+    // the relevant properties of the result.
     await expectLater(functionUnderTest(fake), completes);
   });
 }

--- a/generated/google_cloud_longrunning/skills/google_cloud_longrunning-tests/SKILL.md
+++ b/generated/google_cloud_longrunning/skills/google_cloud_longrunning-tests/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: google-cloud-longrunning-tests
+description: >-
+  Use this skill when writing tests for code that uses
+  package:google_cloud_longrunning
+---
+
+## Testing with Fakes
+
+Most unit tests should use fakes instead of making network requests to Google
+services.
+
+- Code that uses `Operations` can be tested by injecting the
+  fake `FakeOperations`.
+
+Import the fakes from the testing library:
+
+```dart
+import 'package:google_cloud_longrunning/testing.dart';
+```
+
+### Option A: Using Constructor Closures (Recommended)
+
+You can inject behavior by passing optional function callbacks to the fake's
+constructor. Methods that are not provided will throw an `UnsupportedError`.
+
+```dart
+import 'package:google_cloud_longrunning/longrunning.dart';
+import 'package:google_cloud_longrunning/testing.dart';
+
+final fake = FakeOperations(
+  deleteOperation: (request) async {
+    // Assert request contents here if needed.
+  },
+);
+```
+
+### Option B: Subclassing the Fake
+
+For more complex test setups or shared states, you can subclass the fake and
+override its methods. Methods that are not overridden will throw an
+`UnsupportedError`.
+
+```dart
+import 'package:google_cloud_longrunning/longrunning.dart';
+import 'package:google_cloud_longrunning/testing.dart';
+
+final class MyFakeOperations extends FakeOperations {
+  @override
+  Future<void> deleteOperation(
+    DeleteOperationRequest request,
+  ) async {
+    // Assert request contents here if needed.
+  }
+}
+```
+
+## A Simple Test
+
+```dart
+import 'package:google_cloud_longrunning/longrunning.dart';
+import 'package:google_cloud_longrunning/testing.dart';
+import 'package:test/test.dart';
+
+Future<void> functionUnderTest(Operations service) async {
+  // Application logic here.
+  await service.deleteOperation(DeleteOperationRequest());
+  // More application logic here.
+}
+
+void main() {
+  test('test', () async {
+    final fake = FakeOperations(
+      deleteOperation: (request) async {
+          // Assert request contents here.
+      },
+    );
+    // Instead of verifying that `functionUnderTest`, you should verify the
+    // relevant properties of the result.
+    await expectLater(functionUnderTest(fake), completes);
+  });
+}
+```

--- a/generated/google_cloud_rpc/lib/exceptions.dart
+++ b/generated/google_cloud_rpc/lib/exceptions.dart
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// @docImport 'package:google_cloud_rpc/exceptions.dart';
+/// {@canonicalFor exceptions.ServiceException}
+/// {@canonicalFor exceptions.BadRequestException}
 /// Exceptions raised by Google API clients.
 library;
 

--- a/generated/google_cloud_secretmanager_v1/README.md
+++ b/generated/google_cloud_secretmanager_v1/README.md
@@ -22,5 +22,18 @@ The Google Cloud client library for the Secret Manager API.
 
 The Google Cloud client library for the Secret Manager API.
 
+## Agent Skills
+
+This package supports [Agent Skills](https://agentskills.io/home).
+
+To add this package to your application and install the skills for use by your
+Agent, run:
+
+```shell
+dart pub add google_cloud_secretmanager_v1
+dart pub get
+dart run skills@ get
+```
+
 Stores sensitive data such as API keys, passwords, and certificates.
 Provides convenience while improving security.

--- a/generated/google_cloud_secretmanager_v1/lib/secretmanager.dart
+++ b/generated/google_cloud_secretmanager_v1/lib/secretmanager.dart
@@ -24,4 +24,6 @@ library;
 // ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: unintended_html_in_doc_comment
 
+export 'package:google_cloud_rpc/exceptions.dart';
+
 export 'src/api.g.dart' hide FakeSecretManagerService;

--- a/generated/google_cloud_secretmanager_v1/lib/src/api.g.dart
+++ b/generated/google_cloud_secretmanager_v1/lib/src/api.g.dart
@@ -18,6 +18,8 @@
 ///
 /// Stores sensitive data such as API keys, passwords, and certificates.
 /// Provides convenience while improving security.
+///
+/// @docImport 'package:google_cloud_rpc/exceptions.dart';
 library;
 
 // ignore_for_file: camel_case_types
@@ -32,7 +34,6 @@ import 'package:google_cloud_iam_v1/iam.dart';
 import 'package:google_cloud_location/location.dart';
 import 'package:google_cloud_protobuf/protobuf.dart';
 import 'package:google_cloud_protobuf/src/encoding.dart';
-import 'package:google_cloud_rpc/exceptions.dart';
 import 'package:google_cloud_rpc/rpc.dart';
 import 'package:google_cloud_rpc/service_client.dart';
 import 'package:http/http.dart' as http;

--- a/generated/google_cloud_secretmanager_v1/skills/google_cloud_secretmanager_v1-setup/SKILL.md
+++ b/generated/google_cloud_secretmanager_v1/skills/google_cloud_secretmanager_v1-setup/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: google-cloud-secretmanager-v1-setup
+description: >-
+  Use this skill to help the developer get started with
+  package:google_cloud_secretmanager_v1
+---
+
+## Getting Started with package:google_cloud_secretmanager_v1
+
+### 1. Add the package to your pubspec.yaml
+
+```shell
+dart pub add google_cloud_secretmanager_v1
+```
+
+### 2. Import the library
+
+In your Dart code, import the library:
+
+```dart
+import 'package:google_cloud_secretmanager_v1/secretmanager.dart';
+```
+
+### 3. Initialize the client
+
+To call the client, you need to create an instance of the service that
+you want to use, e.g., `SecretManagerService`.
+
+There are two ways of creating an instance with the necessary credentials.
+
+#### Option A: Using Application Default Credentials (ADC) (Recommended)
+
+Recommended for production environments, server-side backends, and when
+running on Google Cloud (such as Cloud Run, GCE, GKE).
+
+When running on Google Cloud, Application Default Credentials are automatically
+available.
+
+When running locally, the `gcloud` command must be available (see
+[Install the Google Cloud CLI](https://docs.cloud.google.com/sdk/docs/install-sdk)).
+To obtain Application Default Credentials, run:
+
+```shell
+gcloud auth application-default login
+```
+
+Add `googleapis_auth` to your dependencies:
+
+```shell
+dart pub add googleapis_auth
+```
+
+```dart
+import 'package:googleapis_auth/auth_io.dart';
+import 'package:google_cloud_secretmanager_v1/secretmanager.dart';
+
+Future<void> main() async {
+  final authClient = await clientViaApplicationDefaultCredentials(
+    scopes: [
+      'https://www.googleapis.com/auth/cloud-platform',
+    ],
+  );
+
+  final client = SecretManagerService(client: authClient);
+
+  try {
+    // Call a method on the client.
+    final response = await client.enableManagedRotation(
+      EnableManagedRotationRequest(),
+    );
+    print('Response: $response');
+  } finally {
+    // Always close the client to release resources.
+    client.close();
+  }
+}
+```
+
+#### Option B: Using an API Key (Simple)
+
+Recommended for quick testing or prototyping because the setup is simple.
+
+If the user does not have an API key, then they can obtain one using the
+[Google Cloud Console](https://console.cloud.google.com/apis/credentials).
+
+Add the API key to one of these environment variables:
+- `GOOGLE_API_KEY`
+
+
+```dart
+import 'package:google_cloud_secretmanager_v1/secretmanager.dart';
+
+Future<void> main() async {
+  final client = SecretManagerService.fromApiKey();
+
+  try {
+    // Call a method on the client.
+    final response = await client.enableManagedRotation(
+      EnableManagedRotationRequest(),
+    );
+    print('Response: $response');
+  } finally {
+    // Always close the client to release resources.
+    client.close();
+  }
+}
+```
+

--- a/generated/google_cloud_secretmanager_v1/skills/google_cloud_secretmanager_v1-tests/SKILL.md
+++ b/generated/google_cloud_secretmanager_v1/skills/google_cloud_secretmanager_v1-tests/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: google-cloud-secretmanager-v1-tests
+description: >-
+  Use this skill when writing tests for code that uses
+  package:google_cloud_secretmanager_v1
+---
+
+## Testing with Fakes
+
+Most unit tests should use fakes instead of making network requests to Google
+services.
+
+- Code that uses `SecretManagerService` can be tested by injecting the
+  fake `FakeSecretManagerService`.
+
+Import the fakes from the testing library:
+
+```dart
+import 'package:google_cloud_secretmanager_v1/testing.dart';
+```
+
+### Option A: Using Constructor Closures (Recommended)
+
+You can inject behavior by passing optional function callbacks to the fake's
+constructor. Methods that are not provided will throw an `UnsupportedError`.
+
+```dart
+import 'package:google_cloud_secretmanager_v1/secretmanager.dart';
+import 'package:google_cloud_secretmanager_v1/testing.dart';
+
+final fake = FakeSecretManagerService(
+  enableManagedRotation: (request) async {
+    // Assert request contents here if needed.
+    return SecretVersion();
+  },
+);
+```
+
+### Option B: Subclassing the Fake
+
+For more complex test setups or shared states, you can subclass the fake and
+override its methods. Methods that are not overridden will throw an
+`UnsupportedError`.
+
+```dart
+import 'package:google_cloud_secretmanager_v1/secretmanager.dart';
+import 'package:google_cloud_secretmanager_v1/testing.dart';
+
+final class MyFakeSecretManagerService extends FakeSecretManagerService {
+  @override
+  Future<SecretVersion> enableManagedRotation(
+    EnableManagedRotationRequest request,
+  ) async {
+    // Assert request contents here if needed.
+    return SecretVersion();
+  }
+}
+```
+
+## A Simple Test
+
+```dart
+import 'package:google_cloud_secretmanager_v1/secretmanager.dart';
+import 'package:google_cloud_secretmanager_v1/testing.dart';
+import 'package:test/test.dart';
+
+Future<void> functionUnderTest(SecretManagerService service) async {
+  // Application logic here.
+  await service.enableManagedRotation(EnableManagedRotationRequest());
+  // More application logic here.
+}
+
+void main() {
+  test('test', () async {
+    final fake = FakeSecretManagerService(
+      enableManagedRotation: (request) async {
+          // Assert request contents here.
+          return SecretVersion();
+      },
+    );
+    // Instead of verifying that `functionUnderTest`, you should verify the
+    // relevant properties of the result.
+    await expectLater(functionUnderTest(fake), completes);
+  });
+}
+```

--- a/generated/google_cloud_secretmanager_v1/skills/google_cloud_secretmanager_v1-tests/SKILL.md
+++ b/generated/google_cloud_secretmanager_v1/skills/google_cloud_secretmanager_v1-tests/SKILL.md
@@ -78,8 +78,8 @@ void main() {
           return SecretVersion();
       },
     );
-    // Instead of verifying that `functionUnderTest`, you should verify the
-    // relevant properties of the result.
+    // Instead of verifying that `functionUnderTest` completes, you should verify
+    // the relevant properties of the result.
     await expectLater(functionUnderTest(fake), completes);
   });
 }

--- a/generated/google_cloud_showcase_v1beta1/README.md
+++ b/generated/google_cloud_showcase_v1beta1/README.md
@@ -22,5 +22,18 @@ The Google Cloud client library for the Client Libraries Showcase API.
 
 The Google Cloud client library for the Client Libraries Showcase API.
 
+## Agent Skills
+
+This package supports [Agent Skills](https://agentskills.io/home).
+
+To add this package to your application and install the skills for use by your
+Agent, run:
+
+```shell
+dart pub add google_cloud_showcase_v1beta1
+dart pub get
+dart run skills@ get
+```
+
 Showcase represents both a model API and an integration testing surface for
 client library generator consumption.

--- a/generated/google_cloud_showcase_v1beta1/lib/showcase.dart
+++ b/generated/google_cloud_showcase_v1beta1/lib/showcase.dart
@@ -24,11 +24,14 @@ library;
 // ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: unintended_html_in_doc_comment
 
+export 'package:google_cloud_rpc/exceptions.dart';
+
 export 'src/api.g.dart'
     hide
         FakeCompliance,
         FakeEcho,
         FakeIdentity,
         FakeMessaging,
+        FakeResumableUploadService,
         FakeSequenceService,
         FakeTesting;

--- a/generated/google_cloud_showcase_v1beta1/lib/src/api.g.dart
+++ b/generated/google_cloud_showcase_v1beta1/lib/src/api.g.dart
@@ -3518,6 +3518,433 @@ base class FakeMessaging implements Messaging {
   }
 }
 
+/// A service showcasing universal resumable upload protocol support.
+final class ResumableUploadService {
+  static const _defaultHost = 'localhost:7469';
+  final Uri _endPoint;
+
+  final ServiceClient _client;
+
+  /// Creates a `ResumableUploadService` using [client] for transport.
+  ///
+  /// The provided [http.Client] must be configured to provide whatever
+  /// authentication is required by `ResumableUploadService`. You can do that using
+  /// [`package:googleapis_auth`](https://pub.dev/packages/googleapis_auth).
+  ///
+  /// If [endPoint] is provided then its `scheme`, `host`, and `port` are
+  /// used for all API requests. For example, `Uri.http('127.0.0.1:8080')`
+  /// could be used to force the `Firestore` service to communicate with the
+  /// local emulator.
+  ResumableUploadService({required http.Client client, Uri? endPoint})
+    : _client = ServiceClient(client: client),
+      _endPoint = endPoint == null
+          ? Uri.https(_defaultHost, '')
+          : Uri(
+              scheme: endPoint.scheme,
+              host: endPoint.host,
+              port: endPoint.port,
+            );
+
+  /// Creates a `ResumableUploadService` that does authentication through an API key.
+  ///
+  /// If called without arguments, the API key is taken from these environment
+  /// variables:
+  ///
+  /// - `GOOGLE_API_KEY`
+  ///
+  /// Throws [ConfigurationException] if called without arguments and none of
+  /// the above environment variables are set. On the web,
+  /// always throws [ConfigurationException] if called without arguments.
+  ///
+  /// See [API Keys Overview](https://cloud.google.com/api-keys/docs/overview).
+  factory ResumableUploadService.fromApiKey([String? apiKey]) =>
+      ResumableUploadService(client: httpClientFromApiKey(apiKey, _apiKeys));
+
+  /// A method with media_upload annotation enabled.
+  ///
+  /// Throws a [http.ClientException] if there were problems communicating with
+  /// the API service. Throws a [ServiceException] if the API method failed for
+  /// any reason.
+  Future<UploadMediaResponse> uploadMedia(UploadMediaRequest request) async {
+    final url = _endPoint.replace(path: '/v1beta1/files:upload');
+    final response = await _client.post(url, body: request);
+    return UploadMediaResponse.fromJson(response);
+  }
+
+  /// Provides the `Locations` service functionality in this service.
+  ///
+  /// Throws a [http.ClientException] if there were problems communicating with
+  /// the API service. Throws a [ServiceException] if the API method failed for
+  /// any reason.
+  Future<ListLocationsResponse> listLocations(
+    ListLocationsRequest request,
+  ) async {
+    final url = _endPoint.replace(
+      path: '/v1beta1/${request.name}/locations',
+      queryParameters: {
+        if (request.filter case final $1 when $1.isNotDefault) 'filter': $1,
+        if (request.pageSize case final $1 when $1.isNotDefault)
+          'pageSize': '${$1}',
+        if (request.pageToken case final $1 when $1.isNotDefault)
+          'pageToken': $1,
+      },
+    );
+    final response = await _client.get(url);
+    return ListLocationsResponse.fromJson(response);
+  }
+
+  /// Provides the `Locations` service functionality in this service.
+  ///
+  /// Throws a [http.ClientException] if there were problems communicating with
+  /// the API service. Throws a [ServiceException] if the API method failed for
+  /// any reason.
+  Future<Location> getLocation(GetLocationRequest request) async {
+    final url = _endPoint.replace(path: '/v1beta1/${request.name}');
+    final response = await _client.get(url);
+    return Location.fromJson(response);
+  }
+
+  /// Provides the `IAMPolicy` service functionality in this service.
+  ///
+  /// Throws a [http.ClientException] if there were problems communicating with
+  /// the API service. Throws a [ServiceException] if the API method failed for
+  /// any reason.
+  Future<Policy> setIamPolicy(SetIamPolicyRequest request) async {
+    final url = _endPoint.replace(
+      path: '/v1beta1/${request.resource}:setIamPolicy',
+    );
+    final response = await _client.post(url, body: request);
+    return Policy.fromJson(response);
+  }
+
+  /// Provides the `IAMPolicy` service functionality in this service.
+  ///
+  /// Throws a [http.ClientException] if there were problems communicating with
+  /// the API service. Throws a [ServiceException] if the API method failed for
+  /// any reason.
+  Future<Policy> getIamPolicy(GetIamPolicyRequest request) async {
+    final url = _endPoint.replace(
+      path: '/v1beta1/${request.resource}:getIamPolicy',
+      queryParameters: {
+        if (request.options?.requestedPolicyVersion case final $1?
+            when $1.isNotDefault)
+          'options.requestedPolicyVersion': '${$1}',
+      },
+    );
+    final response = await _client.get(url);
+    return Policy.fromJson(response);
+  }
+
+  /// Provides the `IAMPolicy` service functionality in this service.
+  ///
+  /// Throws a [http.ClientException] if there were problems communicating with
+  /// the API service. Throws a [ServiceException] if the API method failed for
+  /// any reason.
+  Future<TestIamPermissionsResponse> testIamPermissions(
+    TestIamPermissionsRequest request,
+  ) async {
+    final url = _endPoint.replace(
+      path: '/v1beta1/${request.resource}:testIamPermissions',
+    );
+    final response = await _client.post(url, body: request);
+    return TestIamPermissionsResponse.fromJson(response);
+  }
+
+  /// Provides the `Operations` service functionality in this service.
+  ///
+  /// Throws a [http.ClientException] if there were problems communicating with
+  /// the API service. Throws a [ServiceException] if the API method failed for
+  /// any reason.
+  Future<ListOperationsResponse> listOperations(
+    ListOperationsRequest request,
+  ) async {
+    final url = _endPoint.replace(
+      path: '/v1beta1/operations',
+      queryParameters: {
+        if (request.name case final $1 when $1.isNotDefault) 'name': $1,
+        if (request.filter case final $1 when $1.isNotDefault) 'filter': $1,
+        if (request.pageSize case final $1 when $1.isNotDefault)
+          'pageSize': '${$1}',
+        if (request.pageToken case final $1 when $1.isNotDefault)
+          'pageToken': $1,
+        if (request.returnPartialSuccess case final $1 when $1.isNotDefault)
+          'returnPartialSuccess': '${$1}',
+      },
+    );
+    final response = await _client.get(url);
+    return ListOperationsResponse.fromJson(response);
+  }
+
+  /// Provides the `Operations` service functionality in this service.
+  ///
+  /// Throws a [http.ClientException] if there were problems communicating with
+  /// the API service. Throws a [ServiceException] if the API method failed for
+  /// any reason.
+  ///
+  /// This method can be used to get the current status of a long-running
+  /// operation.
+  Future<Operation<T, S>> getOperation<
+    T extends ProtoMessage,
+    S extends ProtoMessage
+  >(Operation<T, S> request) async {
+    final url = _endPoint.replace(path: '/v1beta1/${request.name}');
+    final response = await _client.get(url);
+    return Operation.fromJson(response, request.operationHelper);
+  }
+
+  /// Provides the `Operations` service functionality in this service.
+  ///
+  /// Throws a [http.ClientException] if there were problems communicating with
+  /// the API service. Throws a [ServiceException] if the API method failed for
+  /// any reason.
+  Future<void> deleteOperation(DeleteOperationRequest request) async {
+    final url = _endPoint.replace(path: '/v1beta1/${request.name}');
+    await _client.delete(url);
+  }
+
+  /// Provides the `Operations` service functionality in this service.
+  ///
+  /// Throws a [http.ClientException] if there were problems communicating with
+  /// the API service. Throws a [ServiceException] if the API method failed for
+  /// any reason.
+  Future<void> cancelOperation(CancelOperationRequest request) async {
+    final url = _endPoint.replace(path: '/v1beta1/${request.name}:cancel');
+    await _client.post(url);
+  }
+
+  /// Closes the client and cleans up any resources associated with it.
+  ///
+  /// Once [close] is called, no other methods should be called.
+  void close() => _client.close();
+}
+
+/// Testing fake for [ResumableUploadService].
+base class FakeResumableUploadService implements ResumableUploadService {
+  final Future<UploadMediaResponse> Function(UploadMediaRequest request)?
+  _uploadMedia;
+  final Future<ListLocationsResponse> Function(ListLocationsRequest request)?
+  _listLocations;
+  final Future<Location> Function(GetLocationRequest request)? _getLocation;
+  final Future<Policy> Function(SetIamPolicyRequest request)? _setIamPolicy;
+  final Future<Policy> Function(GetIamPolicyRequest request)? _getIamPolicy;
+  final Future<TestIamPermissionsResponse> Function(
+    TestIamPermissionsRequest request,
+  )?
+  _testIamPermissions;
+  final Future<ListOperationsResponse> Function(ListOperationsRequest request)?
+  _listOperations;
+  final Future<Operation<T, S>> Function<
+    T extends ProtoMessage,
+    S extends ProtoMessage
+  >(Operation<T, S> request)?
+  _getOperation;
+  final Future<void> Function(DeleteOperationRequest request)? _deleteOperation;
+  final Future<void> Function(CancelOperationRequest request)? _cancelOperation;
+
+  @override
+  Uri get _endPoint => throw UnsupportedError('_endPoint');
+  @override
+  ServiceClient get _client => throw UnsupportedError('_client');
+
+  bool isClosed = false;
+
+  FakeResumableUploadService({
+    Future<UploadMediaResponse> Function(UploadMediaRequest request)?
+    uploadMedia,
+    Future<ListLocationsResponse> Function(ListLocationsRequest request)?
+    listLocations,
+    Future<Location> Function(GetLocationRequest request)? getLocation,
+    Future<Policy> Function(SetIamPolicyRequest request)? setIamPolicy,
+    Future<Policy> Function(GetIamPolicyRequest request)? getIamPolicy,
+    Future<TestIamPermissionsResponse> Function(
+      TestIamPermissionsRequest request,
+    )?
+    testIamPermissions,
+    Future<ListOperationsResponse> Function(ListOperationsRequest request)?
+    listOperations,
+    Future<Operation<T, S>> Function<
+      T extends ProtoMessage,
+      S extends ProtoMessage
+    >(Operation<T, S> request)?
+    getOperation,
+    Future<void> Function(DeleteOperationRequest request)? deleteOperation,
+    Future<void> Function(CancelOperationRequest request)? cancelOperation,
+  }) : _uploadMedia = uploadMedia,
+       _listLocations = listLocations,
+       _getLocation = getLocation,
+       _setIamPolicy = setIamPolicy,
+       _getIamPolicy = getIamPolicy,
+       _testIamPermissions = testIamPermissions,
+       _listOperations = listOperations,
+       _getOperation = getOperation,
+       _deleteOperation = deleteOperation,
+       _cancelOperation = cancelOperation;
+
+  /// A method with media_upload annotation enabled.
+  ///
+  /// Throws a [http.ClientException] if there were problems communicating with
+  /// the API service. Throws a [ServiceException] if the API method failed for
+  /// any reason.
+  @override
+  Future<UploadMediaResponse> uploadMedia(UploadMediaRequest request) async {
+    if (isClosed) throw StateError('Service is closed');
+
+    if (_uploadMedia case final uploadMedia?) {
+      return uploadMedia(request);
+    }
+    throw UnsupportedError('uploadMedia');
+  }
+
+  /// Provides the `Locations` service functionality in this service.
+  ///
+  /// Throws a [http.ClientException] if there were problems communicating with
+  /// the API service. Throws a [ServiceException] if the API method failed for
+  /// any reason.
+  @override
+  Future<ListLocationsResponse> listLocations(
+    ListLocationsRequest request,
+  ) async {
+    if (isClosed) throw StateError('Service is closed');
+
+    if (_listLocations case final listLocations?) {
+      return listLocations(request);
+    }
+    throw UnsupportedError('listLocations');
+  }
+
+  /// Provides the `Locations` service functionality in this service.
+  ///
+  /// Throws a [http.ClientException] if there were problems communicating with
+  /// the API service. Throws a [ServiceException] if the API method failed for
+  /// any reason.
+  @override
+  Future<Location> getLocation(GetLocationRequest request) async {
+    if (isClosed) throw StateError('Service is closed');
+
+    if (_getLocation case final getLocation?) {
+      return getLocation(request);
+    }
+    throw UnsupportedError('getLocation');
+  }
+
+  /// Provides the `IAMPolicy` service functionality in this service.
+  ///
+  /// Throws a [http.ClientException] if there were problems communicating with
+  /// the API service. Throws a [ServiceException] if the API method failed for
+  /// any reason.
+  @override
+  Future<Policy> setIamPolicy(SetIamPolicyRequest request) async {
+    if (isClosed) throw StateError('Service is closed');
+
+    if (_setIamPolicy case final setIamPolicy?) {
+      return setIamPolicy(request);
+    }
+    throw UnsupportedError('setIamPolicy');
+  }
+
+  /// Provides the `IAMPolicy` service functionality in this service.
+  ///
+  /// Throws a [http.ClientException] if there were problems communicating with
+  /// the API service. Throws a [ServiceException] if the API method failed for
+  /// any reason.
+  @override
+  Future<Policy> getIamPolicy(GetIamPolicyRequest request) async {
+    if (isClosed) throw StateError('Service is closed');
+
+    if (_getIamPolicy case final getIamPolicy?) {
+      return getIamPolicy(request);
+    }
+    throw UnsupportedError('getIamPolicy');
+  }
+
+  /// Provides the `IAMPolicy` service functionality in this service.
+  ///
+  /// Throws a [http.ClientException] if there were problems communicating with
+  /// the API service. Throws a [ServiceException] if the API method failed for
+  /// any reason.
+  @override
+  Future<TestIamPermissionsResponse> testIamPermissions(
+    TestIamPermissionsRequest request,
+  ) async {
+    if (isClosed) throw StateError('Service is closed');
+
+    if (_testIamPermissions case final testIamPermissions?) {
+      return testIamPermissions(request);
+    }
+    throw UnsupportedError('testIamPermissions');
+  }
+
+  /// Provides the `Operations` service functionality in this service.
+  ///
+  /// Throws a [http.ClientException] if there were problems communicating with
+  /// the API service. Throws a [ServiceException] if the API method failed for
+  /// any reason.
+  @override
+  Future<ListOperationsResponse> listOperations(
+    ListOperationsRequest request,
+  ) async {
+    if (isClosed) throw StateError('Service is closed');
+
+    if (_listOperations case final listOperations?) {
+      return listOperations(request);
+    }
+    throw UnsupportedError('listOperations');
+  }
+
+  /// Provides the `Operations` service functionality in this service.
+  ///
+  /// Throws a [http.ClientException] if there were problems communicating with
+  /// the API service. Throws a [ServiceException] if the API method failed for
+  /// any reason.
+  @override
+  Future<Operation<T, S>> getOperation<
+    T extends ProtoMessage,
+    S extends ProtoMessage
+  >(Operation<T, S> request) async {
+    if (isClosed) throw StateError('Service is closed');
+
+    if (_getOperation case final getOperation?) {
+      return getOperation(request);
+    }
+    throw UnsupportedError('getOperation');
+  }
+
+  /// Provides the `Operations` service functionality in this service.
+  ///
+  /// Throws a [http.ClientException] if there were problems communicating with
+  /// the API service. Throws a [ServiceException] if the API method failed for
+  /// any reason.
+  @override
+  Future<void> deleteOperation(DeleteOperationRequest request) async {
+    if (isClosed) throw StateError('Service is closed');
+
+    if (_deleteOperation case final deleteOperation?) {
+      return deleteOperation(request);
+    }
+    throw UnsupportedError('deleteOperation');
+  }
+
+  /// Provides the `Operations` service functionality in this service.
+  ///
+  /// Throws a [http.ClientException] if there were problems communicating with
+  /// the API service. Throws a [ServiceException] if the API method failed for
+  /// any reason.
+  @override
+  Future<void> cancelOperation(CancelOperationRequest request) async {
+    if (isClosed) throw StateError('Service is closed');
+
+    if (_cancelOperation case final cancelOperation?) {
+      return cancelOperation(request);
+    }
+    throw UnsupportedError('cancelOperation');
+  }
+
+  @override
+  void close() {
+    isClosed = true;
+  }
+}
+
 /// A service that enables testing of unary and server streaming calls
 /// by specifying a specific, predictable sequence of responses from the service
 final class SequenceService {
@@ -8013,6 +8440,72 @@ final class RestError_Status extends ProtoMessage {
       'status=$status',
     ].join(',');
     return 'Status(${$contents})';
+  }
+}
+
+final class UploadMediaRequest extends ProtoMessage {
+  static const String fullyQualifiedName =
+      'google.showcase.v1beta1.UploadMediaRequest';
+
+  final String name;
+
+  UploadMediaRequest({this.name = ''}) : super(fullyQualifiedName);
+
+  factory UploadMediaRequest.fromJson(Object? j) {
+    final json = j as Map<String, Object?>;
+    return UploadMediaRequest(
+      name: switch (json['name']) {
+        null => '',
+        Object $1 => decodeString($1),
+      },
+    );
+  }
+
+  @override
+  Object toJson() => {if (name.isNotDefault) 'name': name};
+
+  @override
+  String toString() {
+    final $contents = ['name=$name'].join(',');
+    return 'UploadMediaRequest(${$contents})';
+  }
+}
+
+final class UploadMediaResponse extends ProtoMessage {
+  static const String fullyQualifiedName =
+      'google.showcase.v1beta1.UploadMediaResponse';
+
+  final String name;
+
+  final int size;
+
+  UploadMediaResponse({this.name = '', this.size = 0})
+    : super(fullyQualifiedName);
+
+  factory UploadMediaResponse.fromJson(Object? j) {
+    final json = j as Map<String, Object?>;
+    return UploadMediaResponse(
+      name: switch (json['name']) {
+        null => '',
+        Object $1 => decodeString($1),
+      },
+      size: switch (json['size']) {
+        null => 0,
+        Object $1 => decodeInt64($1),
+      },
+    );
+  }
+
+  @override
+  Object toJson() => {
+    if (name.isNotDefault) 'name': name,
+    if (size.isNotDefault) 'size': size.toString(),
+  };
+
+  @override
+  String toString() {
+    final $contents = ['name=$name', 'size=$size'].join(',');
+    return 'UploadMediaResponse(${$contents})';
   }
 }
 

--- a/generated/google_cloud_showcase_v1beta1/lib/src/api.g.dart
+++ b/generated/google_cloud_showcase_v1beta1/lib/src/api.g.dart
@@ -18,6 +18,8 @@
 ///
 /// Showcase represents both a model API and an integration testing surface for
 /// client library generator consumption.
+///
+/// @docImport 'package:google_cloud_rpc/exceptions.dart';
 library;
 
 // ignore_for_file: camel_case_types
@@ -33,7 +35,6 @@ import 'package:google_cloud_location/location.dart';
 import 'package:google_cloud_longrunning/longrunning.dart';
 import 'package:google_cloud_protobuf/protobuf.dart';
 import 'package:google_cloud_protobuf/src/encoding.dart';
-import 'package:google_cloud_rpc/exceptions.dart';
 import 'package:google_cloud_rpc/rpc.dart';
 import 'package:google_cloud_rpc/service_client.dart';
 import 'package:http/http.dart' as http;

--- a/generated/google_cloud_showcase_v1beta1/lib/testing.dart
+++ b/generated/google_cloud_showcase_v1beta1/lib/testing.dart
@@ -23,5 +23,6 @@ export 'src/api.g.dart'
         FakeEcho,
         FakeIdentity,
         FakeMessaging,
+        FakeResumableUploadService,
         FakeSequenceService,
         FakeTesting;

--- a/generated/google_cloud_showcase_v1beta1/skills/google_cloud_showcase_v1beta1-setup/SKILL.md
+++ b/generated/google_cloud_showcase_v1beta1/skills/google_cloud_showcase_v1beta1-setup/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: google-cloud-showcase-v1beta1-setup
+description: >-
+  Use this skill to help the developer get started with
+  package:google_cloud_showcase_v1beta1
+---
+
+## Getting Started with package:google_cloud_showcase_v1beta1
+
+### 1. Add the package to your pubspec.yaml
+
+```shell
+dart pub add google_cloud_showcase_v1beta1
+```
+
+### 2. Import the library
+
+In your Dart code, import the library:
+
+```dart
+import 'package:google_cloud_showcase_v1beta1/showcase.dart';
+```
+
+### 3. Initialize the client
+
+To call the client, you need to create an instance of the service that
+you want to use, e.g., `SequenceService`.
+
+There are two ways of creating an instance with the necessary credentials.
+
+#### Option A: Using Application Default Credentials (ADC) (Recommended)
+
+Recommended for production environments, server-side backends, and when
+running on Google Cloud (such as Cloud Run, GCE, GKE).
+
+When running on Google Cloud, Application Default Credentials are automatically
+available.
+
+When running locally, the `gcloud` command must be available (see
+[Install the Google Cloud CLI](https://docs.cloud.google.com/sdk/docs/install-sdk)).
+To obtain Application Default Credentials, run:
+
+```shell
+gcloud auth application-default login
+```
+
+Add `googleapis_auth` to your dependencies:
+
+```shell
+dart pub add googleapis_auth
+```
+
+```dart
+import 'package:googleapis_auth/auth_io.dart';
+import 'package:google_cloud_showcase_v1beta1/showcase.dart';
+
+Future<void> main() async {
+  final authClient = await clientViaApplicationDefaultCredentials(
+    scopes: [
+      'https://www.googleapis.com/auth/cloud-platform',
+    ],
+  );
+
+  final client = SequenceService(client: authClient);
+
+  try {
+    // Call a method on the client.
+    final response = await client.createSequence(
+      CreateSequenceRequest(),
+    );
+    print('Response: $response');
+  } finally {
+    // Always close the client to release resources.
+    client.close();
+  }
+}
+```
+
+#### Option B: Using an API Key (Simple)
+
+Recommended for quick testing or prototyping because the setup is simple.
+
+If the user does not have an API key, then they can obtain one using the
+[Google Cloud Console](https://console.cloud.google.com/apis/credentials).
+
+Add the API key to one of these environment variables:
+- `GOOGLE_API_KEY`
+
+
+```dart
+import 'package:google_cloud_showcase_v1beta1/showcase.dart';
+
+Future<void> main() async {
+  final client = SequenceService.fromApiKey();
+
+  try {
+    // Call a method on the client.
+    final response = await client.createSequence(
+      CreateSequenceRequest(),
+    );
+    print('Response: $response');
+  } finally {
+    // Always close the client to release resources.
+    client.close();
+  }
+}
+```
+

--- a/generated/google_cloud_showcase_v1beta1/skills/google_cloud_showcase_v1beta1-tests/SKILL.md
+++ b/generated/google_cloud_showcase_v1beta1/skills/google_cloud_showcase_v1beta1-tests/SKILL.md
@@ -90,8 +90,8 @@ void main() {
           return Sequence();
       },
     );
-    // Instead of verifying that `functionUnderTest`, you should verify the
-    // relevant properties of the result.
+    // Instead of verifying that `functionUnderTest` completes, you should verify
+    // the relevant properties of the result.
     await expectLater(functionUnderTest(fake), completes);
   });
 }

--- a/generated/google_cloud_showcase_v1beta1/skills/google_cloud_showcase_v1beta1-tests/SKILL.md
+++ b/generated/google_cloud_showcase_v1beta1/skills/google_cloud_showcase_v1beta1-tests/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: google-cloud-showcase-v1beta1-tests
+description: >-
+  Use this skill when writing tests for code that uses
+  package:google_cloud_showcase_v1beta1
+---
+
+## Testing with Fakes
+
+Most unit tests should use fakes instead of making network requests to Google
+services.
+
+- Code that uses `Compliance` can be tested by injecting the
+  fake `FakeCompliance`.
+- Code that uses `Echo` can be tested by injecting the
+  fake `FakeEcho`.
+- Code that uses `Identity` can be tested by injecting the
+  fake `FakeIdentity`.
+- Code that uses `Messaging` can be tested by injecting the
+  fake `FakeMessaging`.
+- Code that uses `ResumableUploadService` can be tested by injecting the
+  fake `FakeResumableUploadService`.
+- Code that uses `SequenceService` can be tested by injecting the
+  fake `FakeSequenceService`.
+- Code that uses `Testing` can be tested by injecting the
+  fake `FakeTesting`.
+
+Import the fakes from the testing library:
+
+```dart
+import 'package:google_cloud_showcase_v1beta1/testing.dart';
+```
+
+### Option A: Using Constructor Closures (Recommended)
+
+You can inject behavior by passing optional function callbacks to the fake's
+constructor. Methods that are not provided will throw an `UnsupportedError`.
+
+```dart
+import 'package:google_cloud_showcase_v1beta1/showcase.dart';
+import 'package:google_cloud_showcase_v1beta1/testing.dart';
+
+final fake = FakeSequenceService(
+  createSequence: (request) async {
+    // Assert request contents here if needed.
+    return Sequence();
+  },
+);
+```
+
+### Option B: Subclassing the Fake
+
+For more complex test setups or shared states, you can subclass the fake and
+override its methods. Methods that are not overridden will throw an
+`UnsupportedError`.
+
+```dart
+import 'package:google_cloud_showcase_v1beta1/showcase.dart';
+import 'package:google_cloud_showcase_v1beta1/testing.dart';
+
+final class MyFakeSequenceService extends FakeSequenceService {
+  @override
+  Future<Sequence> createSequence(
+    CreateSequenceRequest request,
+  ) async {
+    // Assert request contents here if needed.
+    return Sequence();
+  }
+}
+```
+
+## A Simple Test
+
+```dart
+import 'package:google_cloud_showcase_v1beta1/showcase.dart';
+import 'package:google_cloud_showcase_v1beta1/testing.dart';
+import 'package:test/test.dart';
+
+Future<void> functionUnderTest(SequenceService service) async {
+  // Application logic here.
+  await service.createSequence(CreateSequenceRequest());
+  // More application logic here.
+}
+
+void main() {
+  test('test', () async {
+    final fake = FakeSequenceService(
+      createSequence: (request) async {
+          // Assert request contents here.
+          return Sequence();
+      },
+    );
+    // Instead of verifying that `functionUnderTest`, you should verify the
+    // relevant properties of the result.
+    await expectLater(functionUnderTest(fake), completes);
+  });
+}
+```

--- a/generated/google_cloud_showcase_v1beta1/test/echo_test.dart
+++ b/generated/google_cloud_showcase_v1beta1/test/echo_test.dart
@@ -19,7 +19,6 @@
 library;
 
 import 'package:google_cloud_protobuf/protobuf.dart' as protobuf;
-import 'package:google_cloud_rpc/exceptions.dart';
 import 'package:google_cloud_rpc/rpc.dart';
 import 'package:google_cloud_showcase_v1beta1/showcase.dart';
 import 'package:http/http.dart' as http;

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -15,18 +15,18 @@ language: dart
 version: v0.21.0
 sources:
   conformance:
-    commit: 59ab79a8fa063d66283236e2616b82870e07beef
-    sha256: 17d73a1665a67e2e72def80929ba41b68c24bdb848e194d28c5d67a2975c994e
+    commit: 07eec573f37d51c5c08243b1bd04e3c79422351f
+    sha256: f888f61018e0073bc675a5efa3d9e22dec8da725e77e9c18bbaa3f71f71ced14
   googleapis:
-    commit: cd3e7097f1edeb8379c4b26744c9ae9172b491f3
-    sha256: f3e2af994695d848542d9d3c3fafbc4a554a05cd7c0b8609bfa3f6901c9fa249
+    commit: 28ba5d15234eff44241492ca72b135e1171fc537
+    sha256: 7914a988cc0da8792005bf87a7a4277aa15f85d57d1727c2eef93fce743ab4a1
   protobuf:
-    commit: 59ab79a8fa063d66283236e2616b82870e07beef
-    sha256: 17d73a1665a67e2e72def80929ba41b68c24bdb848e194d28c5d67a2975c994e
+    commit: 07eec573f37d51c5c08243b1bd04e3c79422351f
+    sha256: f888f61018e0073bc675a5efa3d9e22dec8da725e77e9c18bbaa3f71f71ced14
     subpath: src
   showcase:
-    commit: e25a96754f46c9ebb7d3db667b9a030434ed4cbf
-    sha256: 52314efb8c2d5eded992be1895f3e3238f17f25fcfeb96df1e478ad361be450d
+    commit: 0c88ce83d259310dd6f6dc8f63a93bf8592723de
+    sha256: a4ee652fc9bbf90d53148e5cb2594906a41f846f4e3518e8fd97f3b2893c7073
 default:
   output: generated/
   tag_format: '{name}-v{version}'

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: dart
-version: v0.21.0
+version: v0.38.1
 sources:
   conformance:
     commit: 07eec573f37d51c5c08243b1bd04e3c79422351f


### PR DESCRIPTION
Adds the new file `generated/RELEASING.md`, which describes the first steps in the generated-code release process. I will add more steps to that process as I complete them.

Restructures `generated/README.md` to avoid duplication with `generated/RELEASING.md`.

Modifies some test file to avoid duplicate imports now that every `google_cloud_*` library exports `package:google_cloud_rpc/exceptions.dart`.

The remaining changes are done through automation by completing steps 1-4 from `generated/RELEASING.md`.
