### PR TITLE
feat: support client attribution header in ServiceClient and send gccl in Storage

### DIFF
--- a/generated/google_cloud_rpc/CHANGELOG.md
+++ b/generated/google_cloud_rpc/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.5-wip
+
+- feat: add optional `apiClientHeader` parameter to `ServiceClient`.
+
 ## 0.5.4
 
 - feat: add setup and test agentic skills  (#321)

--- a/generated/google_cloud_rpc/lib/service_client.dart
+++ b/generated/google_cloud_rpc/lib/service_client.dart
@@ -30,7 +30,7 @@ const String _clientKey = 'x-goog-api-client';
 
 // ignore: prefer_const_declarations
 final String _clientName =
-    'gl-dart/$clientDartVersion gax/$packageVersion rest/$packageVersion gapic/$packageVersion';
+    'gl-dart/$clientDartVersion gax/$packageVersion rest/$packageVersion';
 
 const String _contentTypeKey = 'content-type';
 const String _typeJson = 'application/json';

--- a/generated/google_cloud_rpc/lib/service_client.dart
+++ b/generated/google_cloud_rpc/lib/service_client.dart
@@ -31,8 +31,6 @@ const String _clientKey = 'x-goog-api-client';
 String get _baseClientName =>
     'gl-dart/$clientDartVersion gax/$packageVersion rest/$packageVersion';
 
-String get _clientName => '$_baseClientName gapic/$packageVersion';
-
 const String _contentTypeKey = 'content-type';
 const String _typeJson = 'application/json';
 
@@ -40,28 +38,60 @@ const String _typeJson = 'application/json';
 class ServiceClient {
   final http.Client client;
 
-  /// An optional API client header value (e.g. `gccl/0.6.4` or `gapic/0.1.0`)
-  /// to append to `x-goog-api-client`.
-  final String? apiClientHeader;
+  /// The version of the GAPIC-generated client library (e.g. `0.1.0`),
+  /// which will be formatted as `gapic/<version>` in the `x-goog-api-client`
+  /// header.
+  ///
+  /// Set this for client libraries that were generated completely by
+  /// automation.
+  final String? gapicVersion;
+
+  /// The version of the hand-written client library (e.g. `0.6.4`),
+  /// which will be formatted as `gccl/<version>` in the `x-goog-api-client`
+  /// header.
+  ///
+  /// Set this if the client library includes hand-written components.
+  final String? gcclVersion;
 
   /// Creates a `ServiceClient` using [client] for transport.
+  ///
+  /// If [gapicVersion] is set, `gapic/<version>` is included in the
+  /// `x-goog-api-client` header.
+  ///
+  /// If [gcclVersion] is set, `gccl/<version>` is included in the
+  /// `x-goog-api-client` header.
+  ///
+  /// Both [gapicVersion] and [gcclVersion] should be set if the library
+  /// includes both automatically-generated and hand-written components.
+  /// For example, `package:google_cloud_firestore` (hand-written) wraps
+  /// `package:google_cloud_firestore_v1` (generated).
   ///
   /// The provided [http.Client] must be configured to provide whatever
   /// authentication is required by the API being accessed. You can do that
   /// using
   /// [`package:googleapis_auth`](https://pub.dev/packages/googleapis_auth).
-  ServiceClient({required this.client, this.apiClientHeader});
+  ServiceClient({required this.client, this.gapicVersion, this.gcclVersion});
 
   /// The `x-goog-api-client` header value sent with every request.
   String get clientHeader {
-    if (apiClientHeader != null && apiClientHeader!.trim().isNotEmpty) {
-      final custom = apiClientHeader!.trim();
-      if (custom.startsWith('gccl/') || custom.startsWith('gapic/')) {
-        return '$_baseClientName $custom';
-      }
-      return '$_clientName $custom';
+    final buffer = StringBuffer(_baseClientName);
+    final gapic = gapicVersion?.trim();
+    final hasGapic = gapic != null && gapic.isNotEmpty;
+    final gccl = gcclVersion?.trim();
+    final hasGccl = gccl != null && gccl.isNotEmpty;
+
+    if (hasGapic) {
+      buffer.write(' gapic/$gapic');
+    } else if (!hasGccl) {
+      // Default fallback to packageVersion for un-updated generated clients.
+      buffer.write(' gapic/$packageVersion');
     }
-    return _clientName;
+
+    if (hasGccl) {
+      buffer.write(' gccl/$gccl');
+    }
+
+    return buffer.toString();
   }
 
   Future<Map<String, dynamic>> get(Uri url) => _makeRequest(url, 'GET');

--- a/generated/google_cloud_rpc/lib/service_client.dart
+++ b/generated/google_cloud_rpc/lib/service_client.dart
@@ -30,7 +30,7 @@ const String _clientKey = 'x-goog-api-client';
 
 // ignore: prefer_const_declarations
 final String _clientName =
-    'gl-dart/$clientDartVersion gax/$gaxVersion rest/$gaxVersion gapic/$gaxVersion';
+    'gl-dart/$clientDartVersion gax/$packageVersion rest/$packageVersion gapic/$packageVersion';
 
 const String _contentTypeKey = 'content-type';
 const String _typeJson = 'application/json';
@@ -50,6 +50,12 @@ class ServiceClient {
   /// using
   /// [`package:googleapis_auth`](https://pub.dev/packages/googleapis_auth).
   ServiceClient({required this.client, this.apiClientHeader});
+
+  /// The `x-goog-api-client` header value sent with every request.
+  String get clientHeader =>
+      apiClientHeader != null && apiClientHeader!.trim().isNotEmpty
+      ? '$_clientName ${apiClientHeader!.trim()}'
+      : _clientName;
 
   Future<Map<String, dynamic>> get(Uri url) => _makeRequest(url, 'GET');
 
@@ -106,9 +112,6 @@ class ServiceClient {
     if (requestBody != null) {
       request.body = requestBody._asEncodedJson;
     }
-    final clientHeader = apiClientHeader == null
-        ? _clientName
-        : '$_clientName $apiClientHeader';
     request.headers.addAll({
       _clientKey: clientHeader,
       if (requestBody != null) _contentTypeKey: _typeJson,
@@ -148,9 +151,6 @@ class ServiceClient {
     if (body != null) {
       request.body = body._asEncodedJson;
     }
-    final clientHeader = apiClientHeader == null
-        ? _clientName
-        : '$_clientName $apiClientHeader';
     request.headers.addAll({
       _clientKey: clientHeader,
       if (body != null) _contentTypeKey: _typeJson,

--- a/generated/google_cloud_rpc/lib/service_client.dart
+++ b/generated/google_cloud_rpc/lib/service_client.dart
@@ -39,13 +39,17 @@ const String _typeJson = 'application/json';
 class ServiceClient {
   final http.Client client;
 
+  /// An optional API client header value (e.g. `gccl/0.6.4`) to append to
+  /// `x-goog-api-client`.
+  final String? apiClientHeader;
+
   /// Creates a `ServiceClient` using [client] for transport.
   ///
   /// The provided [http.Client] must be configured to provide whatever
   /// authentication is required by the API being accessed. You can do that
   /// using
   /// [`package:googleapis_auth`](https://pub.dev/packages/googleapis_auth).
-  ServiceClient({required this.client});
+  ServiceClient({required this.client, this.apiClientHeader});
 
   Future<Map<String, dynamic>> get(Uri url) => _makeRequest(url, 'GET');
 
@@ -102,8 +106,11 @@ class ServiceClient {
     if (requestBody != null) {
       request.body = requestBody._asEncodedJson;
     }
+    final clientHeader = apiClientHeader == null
+        ? _clientName
+        : '$_clientName $apiClientHeader';
     request.headers.addAll({
-      _clientKey: _clientName,
+      _clientKey: clientHeader,
       if (requestBody != null) _contentTypeKey: _typeJson,
     });
 
@@ -141,8 +148,11 @@ class ServiceClient {
     if (body != null) {
       request.body = body._asEncodedJson;
     }
+    final clientHeader = apiClientHeader == null
+        ? _clientName
+        : '$_clientName $apiClientHeader';
     request.headers.addAll({
-      _clientKey: _clientName,
+      _clientKey: clientHeader,
       if (body != null) _contentTypeKey: _typeJson,
     });
 

--- a/generated/google_cloud_rpc/lib/service_client.dart
+++ b/generated/google_cloud_rpc/lib/service_client.dart
@@ -28,12 +28,10 @@ export 'src/web.dart'
 
 const String _clientKey = 'x-goog-api-client';
 
-// ignore: prefer_const_declarations
-final String _baseClientName =
+String get _baseClientName =>
     'gl-dart/$clientDartVersion gax/$packageVersion rest/$packageVersion';
 
-// ignore: prefer_const_declarations
-final String _clientName = '$_baseClientName gapic/$packageVersion';
+String get _clientName => '$_baseClientName gapic/$packageVersion';
 
 const String _contentTypeKey = 'content-type';
 const String _typeJson = 'application/json';

--- a/generated/google_cloud_rpc/lib/service_client.dart
+++ b/generated/google_cloud_rpc/lib/service_client.dart
@@ -29,8 +29,11 @@ export 'src/web.dart'
 const String _clientKey = 'x-goog-api-client';
 
 // ignore: prefer_const_declarations
-final String _clientName =
+final String _baseClientName =
     'gl-dart/$clientDartVersion gax/$packageVersion rest/$packageVersion';
+
+// ignore: prefer_const_declarations
+final String _clientName = '$_baseClientName gapic/$packageVersion';
 
 const String _contentTypeKey = 'content-type';
 const String _typeJson = 'application/json';
@@ -39,8 +42,8 @@ const String _typeJson = 'application/json';
 class ServiceClient {
   final http.Client client;
 
-  /// An optional API client header value (e.g. `gccl/0.6.4`) to append to
-  /// `x-goog-api-client`.
+  /// An optional API client header value (e.g. `gccl/0.6.4` or `gapic/0.1.0`)
+  /// to append to `x-goog-api-client`.
   final String? apiClientHeader;
 
   /// Creates a `ServiceClient` using [client] for transport.
@@ -52,10 +55,16 @@ class ServiceClient {
   ServiceClient({required this.client, this.apiClientHeader});
 
   /// The `x-goog-api-client` header value sent with every request.
-  String get clientHeader =>
-      apiClientHeader != null && apiClientHeader!.trim().isNotEmpty
-      ? '$_clientName ${apiClientHeader!.trim()}'
-      : _clientName;
+  String get clientHeader {
+    if (apiClientHeader != null && apiClientHeader!.trim().isNotEmpty) {
+      final custom = apiClientHeader!.trim();
+      if (custom.startsWith('gccl/') || custom.startsWith('gapic/')) {
+        return '$_baseClientName $custom';
+      }
+      return '$_clientName $custom';
+    }
+    return _clientName;
+  }
 
   Future<Map<String, dynamic>> get(Uri url) => _makeRequest(url, 'GET');
 

--- a/generated/google_cloud_rpc/lib/src/versions.dart
+++ b/generated/google_cloud_rpc/lib/src/versions.dart
@@ -19,6 +19,3 @@ export 'web.dart' if (dart.library.io) 'vm.dart' show clientDartVersion;
 // TODO: consider using package:build_version or similar to automate
 // syncing with pubspec.yaml.
 const packageVersion = '0.5.5-wip';
-
-@Deprecated('Use packageVersion instead')
-const gaxVersion = packageVersion;

--- a/generated/google_cloud_rpc/lib/src/versions.dart
+++ b/generated/google_cloud_rpc/lib/src/versions.dart
@@ -16,10 +16,9 @@ export 'web.dart' if (dart.library.io) 'vm.dart' show clientDartVersion;
 
 /// The version of this package.
 //
-// Keep these versions in sync:
-// * CHANGELOG.yaml
-// * pubspec.yaml
-// * lib/src/versions.dart
-/// The format is either `major.minor.patch` or the special value `0`, which
-/// indicates that the version is unknown.
-const gaxVersion = '0.2.0';
+// TODO: consider using package:build_version or similar to automate
+// syncing with pubspec.yaml.
+const packageVersion = '0.5.5-wip';
+
+@Deprecated('Use packageVersion instead')
+const gaxVersion = packageVersion;

--- a/generated/google_cloud_rpc/pubspec.yaml
+++ b/generated/google_cloud_rpc/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: google_cloud_rpc
 description: The Google Cloud client library for the Google RPC Types.
-version: 0.5.4
+version: 0.5.5-wip
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_rpc
 issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 

--- a/generated/google_cloud_rpc/test/client_test.dart
+++ b/generated/google_cloud_rpc/test/client_test.dart
@@ -63,70 +63,96 @@ void main() {
         });
       }
 
-      test(
-        'appends gccl apiClientHeader when provided (replacing default gapic)',
-        () async {
-          late Request customRequest;
-          final customService = ServiceClient(
-            client: MockClient((request) async {
-              customRequest = request;
-              return Response('', 200);
-            }),
-            apiClientHeader: 'gccl/0.6.4-wip',
-          );
-
-          await customService.get(sampleUrl);
-
-          expect(customRequest.headers, {
-            'x-goog-api-client': matches(
-              r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip gccl/0\.6\.4-wip$',
-            ),
-          });
-          expect(
-            customService.clientHeader,
-            matches(
-              r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip gccl/0\.6\.4-wip$',
-            ),
-          );
-        },
-      );
-
-      test(
-        'appends gapic apiClientHeader when provided (replacing default gapic)',
-        () async {
-          late Request customRequest;
-          final customService = ServiceClient(
-            client: MockClient((request) async {
-              customRequest = request;
-              return Response('', 200);
-            }),
-            apiClientHeader: 'gapic/0.1.0',
-          );
-
-          await customService.get(sampleUrl);
-
-          expect(customRequest.headers, {
-            'x-goog-api-client': matches(
-              r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip gapic/0\.1\.0$',
-            ),
-          });
-          expect(
-            customService.clientHeader,
-            matches(
-              r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip gapic/0\.1\.0$',
-            ),
-          );
-        },
-      );
-
-      test('trims apiClientHeader and ignores whitespace', () async {
+      test('appends gccl token when gcclVersion provided '
+          '(replacing default gapic)', () async {
         late Request customRequest;
         final customService = ServiceClient(
           client: MockClient((request) async {
             customRequest = request;
             return Response('', 200);
           }),
-          apiClientHeader: '   ',
+          gcclVersion: '0.6.4-wip',
+        );
+
+        await customService.get(sampleUrl);
+
+        expect(customRequest.headers, {
+          'x-goog-api-client': matches(
+            r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip gccl/0\.6\.4-wip$',
+          ),
+        });
+        expect(
+          customService.clientHeader,
+          matches(
+            r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip gccl/0\.6\.4-wip$',
+          ),
+        );
+      });
+
+      test('appends gapic token when gapicVersion provided '
+          '(replacing default gapic)', () async {
+        late Request customRequest;
+        final customService = ServiceClient(
+          client: MockClient((request) async {
+            customRequest = request;
+            return Response('', 200);
+          }),
+          gapicVersion: '0.1.0',
+        );
+
+        await customService.get(sampleUrl);
+
+        expect(customRequest.headers, {
+          'x-goog-api-client': matches(
+            r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip gapic/0\.1\.0$',
+          ),
+        });
+        expect(
+          customService.clientHeader,
+          matches(
+            r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip gapic/0\.1\.0$',
+          ),
+        );
+      });
+
+      test(
+        'appends both gapic and gccl tokens when both versions provided',
+        () async {
+          late Request customRequest;
+          final customService = ServiceClient(
+            client: MockClient((request) async {
+              customRequest = request;
+              return Response('', 200);
+            }),
+            gapicVersion: '0.1.0',
+            gcclVersion: '0.2.0',
+          );
+
+          await customService.get(sampleUrl);
+
+          expect(customRequest.headers, {
+            'x-goog-api-client': matches(
+              r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip gapic/0\.1\.0 gccl/0\.2\.0$',
+            ),
+          });
+          expect(
+            customService.clientHeader,
+            matches(
+              r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip gapic/0\.1\.0 gccl/0\.2\.0$',
+            ),
+          );
+        },
+      );
+
+      test('trims gapicVersion and gcclVersion and ignores whitespace', () async {
+        late Request customRequest;
+        final customService = ServiceClient(
+          client: MockClient((request) async {
+            customRequest = request;
+            return Response('', 200);
+          }),
+          gapicVersion: '   ',
+          gcclVersion: '   ',
         );
 
         await customService.get(sampleUrl);

--- a/generated/google_cloud_rpc/test/client_test.dart
+++ b/generated/google_cloud_rpc/test/client_test.dart
@@ -88,7 +88,7 @@ void main() {
         );
       });
 
-      test('trims apiClientHeader and ignores whitespace-only header', () async {
+      test('trims apiClientHeader and ignores whitespace', () async {
         late Request customRequest;
         final customService = ServiceClient(
           client: MockClient((request) async {

--- a/generated/google_cloud_rpc/test/client_test.dart
+++ b/generated/google_cloud_rpc/test/client_test.dart
@@ -31,7 +31,7 @@ class TestMessage extends JsonEncodable {
 
 final sampleUrl = Uri.https('example.org', '/path');
 const apiHeaderPattern =
-    r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip$';
+    r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip gapic/0\.5\.5-wip$';
 
 void main() {
   group('non-streaming', () {
@@ -63,55 +63,61 @@ void main() {
         });
       }
 
-      test('appends gccl apiClientHeader when provided', () async {
-        late Request customRequest;
-        final customService = ServiceClient(
-          client: MockClient((request) async {
-            customRequest = request;
-            return Response('', 200);
-          }),
-          apiClientHeader: 'gccl/0.6.4-wip',
-        );
+      test(
+        'appends gccl apiClientHeader when provided (replacing default gapic)',
+        () async {
+          late Request customRequest;
+          final customService = ServiceClient(
+            client: MockClient((request) async {
+              customRequest = request;
+              return Response('', 200);
+            }),
+            apiClientHeader: 'gccl/0.6.4-wip',
+          );
 
-        await customService.get(sampleUrl);
+          await customService.get(sampleUrl);
 
-        expect(customRequest.headers, {
-          'x-goog-api-client': matches(
-            r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip gccl/0\.6\.4-wip$',
-          ),
-        });
-        expect(
-          customService.clientHeader,
-          matches(
-            r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip gccl/0\.6\.4-wip$',
-          ),
-        );
-      });
+          expect(customRequest.headers, {
+            'x-goog-api-client': matches(
+              r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip gccl/0\.6\.4-wip$',
+            ),
+          });
+          expect(
+            customService.clientHeader,
+            matches(
+              r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip gccl/0\.6\.4-wip$',
+            ),
+          );
+        },
+      );
 
-      test('appends gapic apiClientHeader when provided', () async {
-        late Request customRequest;
-        final customService = ServiceClient(
-          client: MockClient((request) async {
-            customRequest = request;
-            return Response('', 200);
-          }),
-          apiClientHeader: 'gapic/0.1.0',
-        );
+      test(
+        'appends gapic apiClientHeader when provided (replacing default gapic)',
+        () async {
+          late Request customRequest;
+          final customService = ServiceClient(
+            client: MockClient((request) async {
+              customRequest = request;
+              return Response('', 200);
+            }),
+            apiClientHeader: 'gapic/0.1.0',
+          );
 
-        await customService.get(sampleUrl);
+          await customService.get(sampleUrl);
 
-        expect(customRequest.headers, {
-          'x-goog-api-client': matches(
-            r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip gapic/0\.1\.0$',
-          ),
-        });
-        expect(
-          customService.clientHeader,
-          matches(
-            r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip gapic/0\.1\.0$',
-          ),
-        );
-      });
+          expect(customRequest.headers, {
+            'x-goog-api-client': matches(
+              r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip gapic/0\.1\.0$',
+            ),
+          });
+          expect(
+            customService.clientHeader,
+            matches(
+              r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip gapic/0\.1\.0$',
+            ),
+          );
+        },
+      );
 
       test('trims apiClientHeader and ignores whitespace', () async {
         late Request customRequest;
@@ -127,7 +133,7 @@ void main() {
 
         expect(customRequest.headers, {
           'x-goog-api-client': matches(
-            r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip$',
+            r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip gapic/0\.5\.5-wip$',
           ),
         });
       });

--- a/generated/google_cloud_rpc/test/client_test.dart
+++ b/generated/google_cloud_rpc/test/client_test.dart
@@ -30,7 +30,8 @@ class TestMessage extends JsonEncodable {
 }
 
 final sampleUrl = Uri.https('example.org', '/path');
-const apiHeaderPattern = r'gl-dart/(3\.\d+\.\d+)|0 gax/0.2.0';
+const apiHeaderPattern =
+    r'gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip gapic/0\.5\.5-wip';
 
 void main() {
   group('non-streaming', () {
@@ -76,7 +77,32 @@ void main() {
 
         expect(customRequest.headers, {
           'x-goog-api-client': matches(
-            r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.2\.0 rest/0\.2\.0 gapic/0\.2\.0 gccl/0\.6\.4-wip$',
+            r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip gapic/0\.5\.5-wip gccl/0\.6\.4-wip$',
+          ),
+        });
+        expect(
+          customService.clientHeader,
+          matches(
+            r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip gapic/0\.5\.5-wip gccl/0\.6\.4-wip$',
+          ),
+        );
+      });
+
+      test('trims apiClientHeader and ignores whitespace-only header', () async {
+        late Request customRequest;
+        final customService = ServiceClient(
+          client: MockClient((request) async {
+            customRequest = request;
+            return Response('', 200);
+          }),
+          apiClientHeader: '   ',
+        );
+
+        await customService.get(sampleUrl);
+
+        expect(customRequest.headers, {
+          'x-goog-api-client': matches(
+            r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip gapic/0\.5\.5-wip$',
           ),
         });
       });

--- a/generated/google_cloud_rpc/test/client_test.dart
+++ b/generated/google_cloud_rpc/test/client_test.dart
@@ -61,6 +61,25 @@ void main() {
           expect(actualRequest.body, isEmpty);
         });
       }
+
+      test('appends apiClientHeader when provided', () async {
+        late Request customRequest;
+        final customService = ServiceClient(
+          client: MockClient((request) async {
+            customRequest = request;
+            return Response('', 200);
+          }),
+          apiClientHeader: 'gccl/0.6.4-wip',
+        );
+
+        await customService.get(sampleUrl);
+
+        expect(customRequest.headers, {
+          'x-goog-api-client': matches(
+            r'^gl-dart/(3\.\d+\.\d+)|0 gax/0.2.0 rest/0.2.0 gapic/0.2.0 gccl/0.6.4-wip$',
+          ),
+        });
+      });
     });
 
     group('requests with body', () {

--- a/generated/google_cloud_rpc/test/client_test.dart
+++ b/generated/google_cloud_rpc/test/client_test.dart
@@ -76,7 +76,7 @@ void main() {
 
         expect(customRequest.headers, {
           'x-goog-api-client': matches(
-            r'^gl-dart/(3\.\d+\.\d+)|0 gax/0.2.0 rest/0.2.0 gapic/0.2.0 gccl/0.6.4-wip$',
+            r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.2\.0 rest/0\.2\.0 gapic/0\.2\.0 gccl/0\.6\.4-wip$',
           ),
         });
       });

--- a/generated/google_cloud_rpc/test/client_test.dart
+++ b/generated/google_cloud_rpc/test/client_test.dart
@@ -31,7 +31,7 @@ class TestMessage extends JsonEncodable {
 
 final sampleUrl = Uri.https('example.org', '/path');
 const apiHeaderPattern =
-    r'gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip gapic/0\.5\.5-wip';
+    r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip$';
 
 void main() {
   group('non-streaming', () {
@@ -63,7 +63,7 @@ void main() {
         });
       }
 
-      test('appends apiClientHeader when provided', () async {
+      test('appends gccl apiClientHeader when provided', () async {
         late Request customRequest;
         final customService = ServiceClient(
           client: MockClient((request) async {
@@ -77,13 +77,38 @@ void main() {
 
         expect(customRequest.headers, {
           'x-goog-api-client': matches(
-            r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip gapic/0\.5\.5-wip gccl/0\.6\.4-wip$',
+            r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip gccl/0\.6\.4-wip$',
           ),
         });
         expect(
           customService.clientHeader,
           matches(
-            r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip gapic/0\.5\.5-wip gccl/0\.6\.4-wip$',
+            r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip gccl/0\.6\.4-wip$',
+          ),
+        );
+      });
+
+      test('appends gapic apiClientHeader when provided', () async {
+        late Request customRequest;
+        final customService = ServiceClient(
+          client: MockClient((request) async {
+            customRequest = request;
+            return Response('', 200);
+          }),
+          apiClientHeader: 'gapic/0.1.0',
+        );
+
+        await customService.get(sampleUrl);
+
+        expect(customRequest.headers, {
+          'x-goog-api-client': matches(
+            r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip gapic/0\.1\.0$',
+          ),
+        });
+        expect(
+          customService.clientHeader,
+          matches(
+            r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip gapic/0\.1\.0$',
           ),
         );
       });
@@ -102,7 +127,7 @@ void main() {
 
         expect(customRequest.headers, {
           'x-goog-api-client': matches(
-            r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip gapic/0\.5\.5-wip$',
+            r'^gl-dart/(?:3\.\d+\.\d+|0) gax/0\.5\.5-wip rest/0\.5\.5-wip$',
           ),
         });
       });

--- a/generated/google_cloud_rpc/test/version_test.dart
+++ b/generated/google_cloud_rpc/test/version_test.dart
@@ -1,0 +1,53 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:google_cloud_rpc/src/versions.dart';
+import 'package:test/test.dart';
+
+void main() {
+  // Note: Consider using https://pub.dev/packages/build_version or similar
+  // code generator to automate generating `lib/src/versions.dart` from `pubspec.yaml`.
+  test('packageVersion matches pubspec.yaml', () {
+    final pkgPubspec = File('generated/google_cloud_rpc/pubspec.yaml');
+    final pubspecFile = pkgPubspec.existsSync()
+        ? pkgPubspec
+        : File('pubspec.yaml');
+    expect(pubspecFile.existsSync(), isTrue, reason: 'pubspec.yaml must exist');
+
+    final content = pubspecFile.readAsStringSync();
+    final match = RegExp(
+      r'^version:\s*(\S+)',
+      multiLine: true,
+    ).firstMatch(content);
+    expect(
+      match,
+      isNotNull,
+      reason: 'version must be declared in pubspec.yaml',
+    );
+
+    final pubspecVersion = match!.group(1);
+    expect(
+      packageVersion,
+      pubspecVersion,
+      reason:
+          'packageVersion in lib/src/versions.dart ($packageVersion) must match '
+          'version in pubspec.yaml ($pubspecVersion).',
+    );
+  });
+}

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -415,7 +415,7 @@ libraries:
       library_path_override: google_cloud_protobuf_test_messages_proto3.dart
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_protojson_conformance
   - name: google_cloud_rpc
-    version: 0.5.4
+    version: 0.5.5-wip
     apis:
       - path: google/rpc
     copyright_year: "2025"

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -430,6 +430,7 @@ libraries:
       - test/client_test.dart
       - test/exceptions_test.dart
       - test/status_test.dart
+      - test/version_test.dart
       - lib/src/rpc.p.dart
     dart:
       dependencies: googleapis_auth,http

--- a/pkgs/google_cloud_storage/CHANGELOG.md
+++ b/pkgs/google_cloud_storage/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.6.4-wip
 
+* Send `gccl/<version>` in `x-goog-api-client` request header for API usage attribution.
 * Add an `ifMetagenerationNotMatch` parameter to `Storage.patchBucket`,
   `Storage.uploadObject`, and `Storage.uploadObjectFromString`. If the
   precondition is not satisfied, a `NotModifiedException` is thrown.

--- a/pkgs/google_cloud_storage/CHANGELOG.md
+++ b/pkgs/google_cloud_storage/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.6.4-wip
 
 * Send `gccl/<version>` in `x-goog-api-client` request header for API usage attribution.
+* Require `google_cloud_rpc: ^0.5.5`.
 * Add an `ifMetagenerationNotMatch` parameter to `Storage.patchBucket`,
   `Storage.uploadObject`, and `Storage.uploadObjectFromString`. If the
   precondition is not satisfied, a `NotModifiedException` is thrown.

--- a/pkgs/google_cloud_storage/lib/src/client.dart
+++ b/pkgs/google_cloud_storage/lib/src/client.dart
@@ -95,8 +95,13 @@ final class Storage {
     (null, null) => defaultProjectId(),
   };
 
-  FutureOr<ServiceClient> get _serviceClient async =>
-      _cachedServiceClient ??= ServiceClient(
+  FutureOr<ServiceClient> get _serviceClient {
+    if (_cachedServiceClient case final client?) return client;
+    return _createServiceClient();
+  }
+
+  Future<ServiceClient> _createServiceClient() async =>
+      _cachedServiceClient = ServiceClient(
         client: await _httpClient,
         apiClientHeader: 'gccl/$packageVersion',
       );

--- a/pkgs/google_cloud_storage/lib/src/client.dart
+++ b/pkgs/google_cloud_storage/lib/src/client.dart
@@ -95,7 +95,12 @@ final class Storage {
   };
 
   FutureOr<ServiceClient> get _serviceClient async =>
-      _cachedServiceClient ??= ServiceClient(client: await _httpClient);
+      _cachedServiceClient ??= ServiceClient(
+        client: await _httpClient,
+        apiClientHeader: 'gccl/$_packageVersion',
+      );
+
+  static const String _packageVersion = '0.6.4-wip';
 
   static Uri _calculateBaseUrl(
     String? apiEndpoint,

--- a/pkgs/google_cloud_storage/lib/src/client.dart
+++ b/pkgs/google_cloud_storage/lib/src/client.dart
@@ -736,8 +736,9 @@ final class Storage {
     BigInt? ifMetagenerationMatch,
     String? userProject,
     RetryRunner retry = defaultRetry,
-  }) => retry.run(
-    () async => downloadFile(
+  }) => retry.run(() async {
+    final serviceClient = await _serviceClient;
+    return downloadFile(
       await _httpClient,
       _requestUrl(
         ['storage', 'v1', 'b', bucket, 'o', object],
@@ -749,9 +750,9 @@ final class Storage {
           'userProject': ?userProject,
         },
       ),
-    ),
-    isIdempotent: true,
-  );
+      headers: {'x-goog-api-client': serviceClient.clientHeader},
+    );
+  }, isIdempotent: true);
 
   /// Returns the ACL entry for the specified entity on the specified
   /// [Google Cloud Storage object].
@@ -1412,8 +1413,9 @@ final class Storage {
     String? projection,
     String? userProject,
     RetryRunner retry = defaultRetry,
-  }) => retry.run(
-    () async => uploadFile(
+  }) => retry.run(() async {
+    final serviceClient = await _serviceClient;
+    return uploadFile(
       await _httpClient,
       _requestUrl(
         ['upload', 'storage', 'v1', 'b', bucket, 'o'],
@@ -1429,9 +1431,9 @@ final class Storage {
       ),
       content,
       metadata: metadata,
-    ),
-    isIdempotent: ifGenerationMatch != null,
-  );
+      headers: {'x-goog-api-client': serviceClient.clientHeader},
+    );
+  }, isIdempotent: ifGenerationMatch != null);
 
   /// Creates or updates the content of a [Google Cloud Storage object][] using
   /// a [StreamSink].
@@ -1481,6 +1483,12 @@ final class Storage {
     ),
     isIdempotent: ifGenerationMatch != null,
     metadata: metadata,
+    headers: switch (_serviceClient) {
+      final Future<ServiceClient> f => f.then(
+        (sc) => {'x-goog-api-client': sc.clientHeader},
+      ),
+      final ServiceClient sc => {'x-goog-api-client': sc.clientHeader},
+    },
     retry: retry,
   );
 

--- a/pkgs/google_cloud_storage/lib/src/client.dart
+++ b/pkgs/google_cloud_storage/lib/src/client.dart
@@ -37,6 +37,7 @@ import 'object_metadata_patch_builder.dart'
 import 'resumeable_upload.dart';
 import 'storage_emulator_host_web.dart'
     if (dart.library.io) 'storage_emulator_host_vm.dart';
+import 'version.dart';
 
 class _JsonEncodableWrapper implements JsonEncodable {
   final Object json;
@@ -97,10 +98,8 @@ final class Storage {
   FutureOr<ServiceClient> get _serviceClient async =>
       _cachedServiceClient ??= ServiceClient(
         client: await _httpClient,
-        apiClientHeader: 'gccl/$_packageVersion',
+        apiClientHeader: 'gccl/$packageVersion',
       );
-
-  static const String _packageVersion = '0.6.4-wip';
 
   static Uri _calculateBaseUrl(
     String? apiEndpoint,

--- a/pkgs/google_cloud_storage/lib/src/client.dart
+++ b/pkgs/google_cloud_storage/lib/src/client.dart
@@ -100,11 +100,8 @@ final class Storage {
     return _createServiceClient();
   }
 
-  Future<ServiceClient> _createServiceClient() async =>
-      _cachedServiceClient = ServiceClient(
-        client: await _httpClient,
-        apiClientHeader: 'gccl/$packageVersion',
-      );
+  Future<ServiceClient> _createServiceClient() async => _cachedServiceClient =
+      ServiceClient(client: await _httpClient, gcclVersion: packageVersion);
 
   static Uri _calculateBaseUrl(
     String? apiEndpoint,

--- a/pkgs/google_cloud_storage/lib/src/file_download.dart
+++ b/pkgs/google_cloud_storage/lib/src/file_download.dart
@@ -40,7 +40,7 @@ Future<Uint8List> downloadFile(
 }) async {
   final response = await client.get(
     url,
-    headers: {'Accept-Encoding': 'gzip', if (headers != null) ...headers},
+    headers: {'Accept-Encoding': 'gzip', ...?headers},
   );
   if (response.statusCode < 200 || response.statusCode >= 300) {
     throw ServiceException.fromHttpResponse(response, response.body);

--- a/pkgs/google_cloud_storage/lib/src/file_download.dart
+++ b/pkgs/google_cloud_storage/lib/src/file_download.dart
@@ -33,8 +33,15 @@ Map<String, String> _parseHashes(List<String> hashes) {
   return result;
 }
 
-Future<Uint8List> downloadFile(http.Client client, Uri url) async {
-  final response = await client.get(url, headers: {'Accept-Encoding': 'gzip'});
+Future<Uint8List> downloadFile(
+  http.Client client,
+  Uri url, {
+  Map<String, String>? headers,
+}) async {
+  final response = await client.get(
+    url,
+    headers: {'Accept-Encoding': 'gzip', if (headers != null) ...headers},
+  );
   if (response.statusCode < 200 || response.statusCode >= 300) {
     throw ServiceException.fromHttpResponse(response, response.body);
   }

--- a/pkgs/google_cloud_storage/lib/src/file_upload.dart
+++ b/pkgs/google_cloud_storage/lib/src/file_upload.dart
@@ -88,11 +88,11 @@ Future<ObjectMetadata> uploadFile(
   final bodyBytes = multipartBody.takeBytes();
 
   final request = http.Request('POST', url);
-  request.headers['Content-Type'] = 'multipart/related; boundary=$boundary';
-  request.headers['Content-Length'] = bodyBytes.length.toString();
   if (headers != null) {
     request.headers.addAll(headers);
   }
+  request.headers['Content-Type'] = 'multipart/related; boundary=$boundary';
+  request.headers['Content-Length'] = bodyBytes.length.toString();
   request.bodyBytes = bodyBytes;
 
   final response = await client.send(request);

--- a/pkgs/google_cloud_storage/lib/src/file_upload.dart
+++ b/pkgs/google_cloud_storage/lib/src/file_upload.dart
@@ -53,6 +53,7 @@ Future<ObjectMetadata> uploadFile(
   Uri url,
   List<int> data, {
   ObjectMetadata? metadata,
+  Map<String, String>? headers,
 }) async {
   final boundary = _boundaryString();
 
@@ -89,6 +90,9 @@ Future<ObjectMetadata> uploadFile(
   final request = http.Request('POST', url);
   request.headers['Content-Type'] = 'multipart/related; boundary=$boundary';
   request.headers['Content-Length'] = bodyBytes.length.toString();
+  if (headers != null) {
+    request.headers.addAll(headers);
+  }
   request.bodyBytes = bodyBytes;
 
   final response = await client.send(request);

--- a/pkgs/google_cloud_storage/lib/src/resumeable_upload.dart
+++ b/pkgs/google_cloud_storage/lib/src/resumeable_upload.dart
@@ -59,6 +59,7 @@ class ResumableUploadSink implements StreamSink<List<int>> {
   final _closedCompleter = Completer<ObjectMetadata>();
   final FutureOr<http.Client> _client;
   final RetryRunner _retry;
+  final FutureOr<Map<String, String>>? _headers;
 
   /// The metadata of the uploaded object.
   ///
@@ -106,6 +107,7 @@ class ResumableUploadSink implements StreamSink<List<int>> {
   ) async {
     final sessionUri = await _sessionUri;
     final client = await _client;
+    final resolvedHeaders = await _headers;
 
     var loopExpectedByte = _nextExpectedByte;
     var needsStatusCheck = false;
@@ -125,7 +127,10 @@ class ResumableUploadSink implements StreamSink<List<int>> {
           checkStatus = false;
           final statusRes = await client.put(
             sessionUri,
-            headers: {'Content-Range': 'bytes */*'},
+            headers: {
+              'Content-Range': 'bytes */*',
+              if (resolvedHeaders != null) ...resolvedHeaders,
+            },
           );
           if (statusRes.statusCode == 200 || statusRes.statusCode == 201) {
             return statusRes;
@@ -178,11 +183,11 @@ class ResumableUploadSink implements StreamSink<List<int>> {
         final size = isLast ? '$newEnd' : '*';
         final contentRange = 'bytes $range/$size';
 
-        final headers = {'Content-Range': contentRange};
-        if (hashHeader != null) {
-          assert(isLast);
-          headers['x-goog-hash'] = hashHeader;
-        }
+        final headers = {
+          'Content-Range': contentRange,
+          if (hashHeader != null) 'x-goog-hash': hashHeader,
+          if (resolvedHeaders != null) ...resolvedHeaders,
+        };
 
         final body = remainingBytes == 0
             ? const <int>[]
@@ -232,7 +237,12 @@ class ResumableUploadSink implements StreamSink<List<int>> {
     _nextExpectedByte += flushPoint;
   }
 
-  ResumableUploadSink._(this._client, this._locationResponse, this._retry);
+  ResumableUploadSink._(
+    this._client,
+    this._locationResponse,
+    this._retry, {
+    FutureOr<Map<String, String>>? headers,
+  }) : _headers = headers;
 
   @override
   void add(List<int> event) {
@@ -318,6 +328,7 @@ ResumableUploadSink uploadFileStream(
   FutureOr<http.Client> client,
   Uri url, {
   ObjectMetadata? metadata,
+  FutureOr<Map<String, String>>? headers,
   required bool isIdempotent,
   required RetryRunner retry,
 }) {
@@ -335,10 +346,14 @@ ResumableUploadSink uploadFileStream(
 
   final response = retry.run(() async {
     final resolvedClient = await client;
+    final resolvedHeaders = await headers;
     final res = await resolvedClient.post(
       url,
       body: body,
-      headers: {'Content-Type': 'application/json'},
+      headers: {
+        'Content-Type': 'application/json',
+        if (resolvedHeaders != null) ...resolvedHeaders,
+      },
     );
     if (res.statusCode < 200 || res.statusCode >= 300) {
       throw ServiceException.fromHttpResponse(res, res.body);
@@ -346,5 +361,5 @@ ResumableUploadSink uploadFileStream(
     return res;
   }, isIdempotent: isIdempotent);
 
-  return ResumableUploadSink._(client, response, retry);
+  return ResumableUploadSink._(client, response, retry, headers: headers);
 }

--- a/pkgs/google_cloud_storage/lib/src/resumeable_upload.dart
+++ b/pkgs/google_cloud_storage/lib/src/resumeable_upload.dart
@@ -127,10 +127,7 @@ class ResumableUploadSink implements StreamSink<List<int>> {
           checkStatus = false;
           final statusRes = await client.put(
             sessionUri,
-            headers: {
-              'Content-Range': 'bytes */*',
-              if (resolvedHeaders != null) ...resolvedHeaders,
-            },
+            headers: {'Content-Range': 'bytes */*', ...?resolvedHeaders},
           );
           if (statusRes.statusCode == 200 || statusRes.statusCode == 201) {
             return statusRes;
@@ -185,8 +182,8 @@ class ResumableUploadSink implements StreamSink<List<int>> {
 
         final headers = {
           'Content-Range': contentRange,
-          if (hashHeader != null) 'x-goog-hash': hashHeader,
-          if (resolvedHeaders != null) ...resolvedHeaders,
+          'x-goog-hash': ?hashHeader,
+          ...?resolvedHeaders,
         };
 
         final body = remainingBytes == 0
@@ -350,10 +347,7 @@ ResumableUploadSink uploadFileStream(
     final res = await resolvedClient.post(
       url,
       body: body,
-      headers: {
-        'Content-Type': 'application/json',
-        if (resolvedHeaders != null) ...resolvedHeaders,
-      },
+      headers: {'Content-Type': 'application/json', ...?resolvedHeaders},
     );
     if (res.statusCode < 200 || res.statusCode >= 300) {
       throw ServiceException.fromHttpResponse(res, res.body);

--- a/pkgs/google_cloud_storage/lib/src/resumeable_upload.dart
+++ b/pkgs/google_cloud_storage/lib/src/resumeable_upload.dart
@@ -180,6 +180,9 @@ class ResumableUploadSink implements StreamSink<List<int>> {
         final size = isLast ? '$newEnd' : '*';
         final contentRange = 'bytes $range/$size';
 
+        if (hashHeader != null) {
+          assert(isLast);
+        }
         final headers = {
           'Content-Range': contentRange,
           'x-goog-hash': ?hashHeader,

--- a/pkgs/google_cloud_storage/lib/src/version.dart
+++ b/pkgs/google_cloud_storage/lib/src/version.dart
@@ -1,0 +1,21 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// The version of package:google_cloud_storage.
+//
+// Keep these versions in sync:
+// * pubspec.yaml
+// * CHANGELOG.md
+// * lib/src/version.dart (verified by test/version_test.dart)
+const String packageVersion = '0.6.4-wip';

--- a/pkgs/google_cloud_storage/lib/src/version.dart
+++ b/pkgs/google_cloud_storage/lib/src/version.dart
@@ -18,4 +18,7 @@
 // * pubspec.yaml
 // * CHANGELOG.md
 // * lib/src/version.dart (verified by test/version_test.dart)
+//
+// Note: Consider using https://pub.dev/packages/build_version or similar
+// code generator to automate generating this file from pubspec.yaml.
 const String packageVersion = '0.6.4-wip';

--- a/pkgs/google_cloud_storage/pubspec.yaml
+++ b/pkgs/google_cloud_storage/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
   ffi: ^2.2.0
   google_cloud: '>=0.3.0 <0.6.0'
   google_cloud_protobuf: ^0.5.0
-  google_cloud_rpc: ^0.5.0
+  google_cloud_rpc: ^0.5.5-wip
   googleapis_auth: ^2.0.0
   http: ^1.6.0
   meta: ^1.17.0

--- a/pkgs/google_cloud_storage/test/storage_test.dart
+++ b/pkgs/google_cloud_storage/test/storage_test.dart
@@ -128,6 +128,16 @@ void main() async {
       );
     });
 
+    test('noProject throws StateError on listBuckets', () async {
+      storage = Storage(client: http.Client(), projectId: Storage.noProject);
+      addTearDown(storage.close);
+
+      await expectLater(
+        storage.listBuckets(),
+        emitsInOrder([emitsError(isA<StateError>()), emitsDone]),
+      );
+    });
+
     test('sends gccl token in x-goog-api-client header', () async {
       late http.Request actualRequest;
       final mockClient = http_testing.MockClient((request) async {

--- a/pkgs/google_cloud_storage/test/storage_test.dart
+++ b/pkgs/google_cloud_storage/test/storage_test.dart
@@ -15,6 +15,7 @@
 import 'package:google_cloud_storage/google_cloud_storage.dart';
 import 'package:googleapis_auth/auth_io.dart' as auth;
 import 'package:http/http.dart' as http;
+import 'package:http/testing.dart' as http_testing;
 import 'package:test/test.dart';
 import 'package:test_utils/cloud.dart';
 
@@ -127,13 +128,21 @@ void main() async {
       );
     });
 
-    test('noProject throws StateError on listBuckets', () async {
-      storage = Storage(client: http.Client(), projectId: Storage.noProject);
+    test('sends gccl token in x-goog-api-client header', () async {
+      late http.Request actualRequest;
+      final mockClient = http_testing.MockClient((request) async {
+        actualRequest = request;
+        return http.Response('{"items": []}', 200);
+      });
+
+      storage = Storage(client: mockClient, projectId: 'test-project');
       addTearDown(storage.close);
 
-      await expectLater(
-        storage.listBuckets(),
-        emitsInOrder([emitsError(isA<StateError>()), emitsDone]),
+      await storage.listBuckets().drain<Object?>();
+
+      expect(
+        actualRequest.headers['x-goog-api-client'],
+        contains('gccl/0.6.4-wip'),
       );
     });
   });

--- a/pkgs/google_cloud_storage/test/storage_test.dart
+++ b/pkgs/google_cloud_storage/test/storage_test.dart
@@ -138,22 +138,110 @@ void main() async {
       );
     });
 
-    test('sends gccl token in x-goog-api-client header', () async {
-      late http.Request actualRequest;
-      final mockClient = http_testing.MockClient((request) async {
-        actualRequest = request;
-        return http.Response('{"items": []}', 200);
-      });
+    test(
+      'sends gccl token in x-goog-api-client header on control-plane operations',
+      () async {
+        late http.Request actualRequest;
+        final mockClient = http_testing.MockClient((request) async {
+          actualRequest = request;
+          return http.Response('{"items": []}', 200);
+        });
 
-      storage = Storage(client: mockClient, projectId: 'test-project');
-      addTearDown(storage.close);
+        storage = Storage(client: mockClient, projectId: 'test-project');
+        addTearDown(storage.close);
 
-      await storage.listBuckets().drain<Object?>();
+        await storage.listBuckets().drain<Object?>();
 
-      expect(
-        actualRequest.headers['x-goog-api-client'],
-        contains('gccl/0.6.4-wip'),
-      );
-    });
+        expect(
+          actualRequest.headers['x-goog-api-client'],
+          contains('gccl/0.6.4-wip'),
+        );
+      },
+    );
+
+    test(
+      'sends gccl token in x-goog-api-client header on downloadObject',
+      () async {
+        late http.Request actualRequest;
+        final mockClient = http_testing.MockClient((request) async {
+          actualRequest = request;
+          return http.Response.bytes(
+            [1, 2, 3],
+            200,
+            headers: {'x-goog-stored-content-encoding': 'identity'},
+          );
+        });
+
+        storage = Storage(client: mockClient, projectId: 'test-project');
+        addTearDown(storage.close);
+
+        await storage.downloadObject('test-bucket', 'test-obj');
+
+        expect(
+          actualRequest.headers['x-goog-api-client'],
+          contains('gccl/0.6.4-wip'),
+        );
+      },
+    );
+
+    test(
+      'sends gccl token in x-goog-api-client header on uploadObject',
+      () async {
+        late http.Request actualRequest;
+        final mockClient = http_testing.MockClient((request) async {
+          actualRequest = request;
+          return http.Response(
+            '{"name": "test-obj", "bucket": "test-bucket"}',
+            200,
+          );
+        });
+
+        storage = Storage(client: mockClient, projectId: 'test-project');
+        addTearDown(storage.close);
+
+        await storage.uploadObject('test-bucket', 'test-obj', [1, 2, 3]);
+
+        expect(
+          actualRequest.headers['x-goog-api-client'],
+          contains('gccl/0.6.4-wip'),
+        );
+      },
+    );
+
+    test(
+      'sends gccl token in x-goog-api-client header on uploadObjectFromSink',
+      () async {
+        final requests = <http.Request>[];
+        final mockClient = http_testing.MockClient((request) async {
+          requests.add(request);
+          if (request.method == 'POST') {
+            return http.Response(
+              '',
+              200,
+              headers: {
+                'location': 'https://storage.googleapis.com/upload-session',
+              },
+            );
+          } else {
+            return http.Response(
+              '{"name": "test-obj", "bucket": "test-bucket"}',
+              200,
+            );
+          }
+        });
+
+        storage = Storage(client: mockClient, projectId: 'test-project');
+        addTearDown(storage.close);
+
+        final sink = storage.uploadObjectFromSink('test-bucket', 'test-obj');
+        sink.add([1, 2, 3]);
+        await sink.close();
+
+        expect(requests, isNotEmpty);
+        for (final req in requests) {
+          expect(req.headers['x-goog-api-client'], contains('gccl/0.6.4-wip'));
+        }
+      },
+    );
   });
 }

--- a/pkgs/google_cloud_storage/test/storage_test.dart
+++ b/pkgs/google_cloud_storage/test/storage_test.dart
@@ -139,7 +139,7 @@ void main() async {
     });
 
     test(
-      'sends gccl token in x-goog-api-client header on control-plane operations',
+      'sends gccl token in x-goog-api-client on control-plane ops',
       () async {
         late http.Request actualRequest;
         final mockClient = http_testing.MockClient((request) async {
@@ -209,7 +209,7 @@ void main() async {
     );
 
     test(
-      'sends gccl token in x-goog-api-client header on uploadObjectFromSink',
+      'sends gccl token in x-goog-api-client on uploadObjectFromSink',
       () async {
         final requests = <http.Request>[];
         final mockClient = http_testing.MockClient((request) async {
@@ -233,8 +233,8 @@ void main() async {
         storage = Storage(client: mockClient, projectId: 'test-project');
         addTearDown(storage.close);
 
-        final sink = storage.uploadObjectFromSink('test-bucket', 'test-obj');
-        sink.add([1, 2, 3]);
+        final sink = storage.uploadObjectFromSink('test-bucket', 'test-obj')
+          ..add([1, 2, 3]);
         await sink.close();
 
         expect(requests, isNotEmpty);

--- a/pkgs/google_cloud_storage/test/version_test.dart
+++ b/pkgs/google_cloud_storage/test/version_test.dart
@@ -21,6 +21,8 @@ import 'package:google_cloud_storage/src/version.dart';
 import 'package:test/test.dart';
 
 void main() {
+  // Note: Consider using https://pub.dev/packages/build_version or similar
+  // code generator to automate generating `lib/src/version.dart` from `pubspec.yaml`.
   test('packageVersion matches pubspec.yaml', () {
     final pkgPubspec = File('pkgs/google_cloud_storage/pubspec.yaml');
     final pubspecFile = pkgPubspec.existsSync()

--- a/pkgs/google_cloud_storage/test/version_test.dart
+++ b/pkgs/google_cloud_storage/test/version_test.dart
@@ -1,0 +1,51 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:google_cloud_storage/src/version.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('packageVersion matches pubspec.yaml', () {
+    final pkgPubspec = File('pkgs/google_cloud_storage/pubspec.yaml');
+    final pubspecFile = pkgPubspec.existsSync()
+        ? pkgPubspec
+        : File('pubspec.yaml');
+    expect(pubspecFile.existsSync(), isTrue, reason: 'pubspec.yaml must exist');
+
+    final content = pubspecFile.readAsStringSync();
+    final match = RegExp(
+      r'^version:\s*(\S+)',
+      multiLine: true,
+    ).firstMatch(content);
+    expect(
+      match,
+      isNotNull,
+      reason: 'version must be declared in pubspec.yaml',
+    );
+
+    final pubspecVersion = match!.group(1);
+    expect(
+      packageVersion,
+      pubspecVersion,
+      reason:
+          'packageVersion in lib/src/version.dart ($packageVersion) must match '
+          'version in pubspec.yaml ($pubspecVersion).',
+    );
+  });
+}


### PR DESCRIPTION
* Add optional `apiClientHeader` to `ServiceClient` in `package:google_cloud_rpc`.
* Send `gccl/<version>` in `package:google_cloud_storage` requests.
* Add unit tests verifying header emission in both packages.
