### PR TITLE
chore: bump generated clients versions for release

### DIFF
--- a/generated/google_cloud_ai_generativelanguage_v1beta/CHANGELOG.md
+++ b/generated/google_cloud_ai_generativelanguage_v1beta/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.5
+
+- feat: track library version usage (#330)
+- fix(dart): remove emptying `testing.dart` files (#327)
+- chore: update cloud dependencies
+
 ## 0.5.4
 
 - feat: add setup and test agentic skills  (#321)

--- a/generated/google_cloud_ai_generativelanguage_v1beta/lib/src/version.dart
+++ b/generated/google_cloud_ai_generativelanguage_v1beta/lib/src/version.dart
@@ -17,4 +17,4 @@
 // ignore_for_file: lines_longer_than_80_chars
 
 /// The version of the google_cloud_ai_generativelanguage_v1beta client library.
-const packageVersion = '0.5.4';
+const packageVersion = '0.5.5';

--- a/generated/google_cloud_ai_generativelanguage_v1beta/pubspec.yaml
+++ b/generated/google_cloud_ai_generativelanguage_v1beta/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: google_cloud_ai_generativelanguage_v1beta
 description: The Google Cloud client library for the Generative Language API.
-version: 0.5.4
+version: 0.5.5
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_ai_generativelanguage_v1beta
 issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 
@@ -26,10 +26,10 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_longrunning: ^0.5.4
-  google_cloud_protobuf: ^0.5.4
-  google_cloud_rpc: ^0.5.4
-  google_cloud_type: ^0.5.4
+  google_cloud_longrunning: ^0.5.5
+  google_cloud_protobuf: ^0.5.5
+  google_cloud_rpc: ^0.5.5
+  google_cloud_type: ^0.5.5
   http: ^1.3.0
 
 dev_dependencies:

--- a/generated/google_cloud_aiplatform_v1beta1/CHANGELOG.md
+++ b/generated/google_cloud_aiplatform_v1beta1/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.5
+
+- feat: track library version usage (#330)
+- fix(dart): remove emptying `testing.dart` files (#327)
+- chore: update cloud dependencies
+
 ## 0.5.4
 
 - feat: add setup and test agentic skills  (#321)

--- a/generated/google_cloud_aiplatform_v1beta1/lib/src/version.dart
+++ b/generated/google_cloud_aiplatform_v1beta1/lib/src/version.dart
@@ -17,4 +17,4 @@
 // ignore_for_file: lines_longer_than_80_chars
 
 /// The version of the google_cloud_aiplatform_v1beta1 client library.
-const packageVersion = '0.5.4';
+const packageVersion = '0.5.5';

--- a/generated/google_cloud_aiplatform_v1beta1/pubspec.yaml
+++ b/generated/google_cloud_aiplatform_v1beta1/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: google_cloud_aiplatform_v1beta1
 description: The Google Cloud client library for the Vertex AI API.
-version: 0.5.4
+version: 0.5.5
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_aiplatform_v1beta1
 issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 
@@ -26,13 +26,13 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_api: ^0.5.4
-  google_cloud_iam_v1: ^0.5.4
-  google_cloud_location: ^0.5.4
-  google_cloud_longrunning: ^0.5.4
-  google_cloud_protobuf: ^0.5.4
-  google_cloud_rpc: ^0.5.4
-  google_cloud_type: ^0.5.4
+  google_cloud_api: ^0.5.5
+  google_cloud_iam_v1: ^0.5.5
+  google_cloud_location: ^0.5.5
+  google_cloud_longrunning: ^0.5.5
+  google_cloud_protobuf: ^0.5.5
+  google_cloud_rpc: ^0.5.5
+  google_cloud_type: ^0.5.5
   http: ^1.3.0
 
 dev_dependencies:

--- a/generated/google_cloud_api/CHANGELOG.md
+++ b/generated/google_cloud_api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.5
+
+- feat: track library version usage (#330)
+- fix(dart): remove emptying `testing.dart` files (#327)
+- chore: update cloud dependencies
+
 ## 0.5.4
 
 - chore: add CHANGELOG.md to existing published packages (#313)

--- a/generated/google_cloud_api/lib/src/version.dart
+++ b/generated/google_cloud_api/lib/src/version.dart
@@ -17,4 +17,4 @@
 // ignore_for_file: lines_longer_than_80_chars
 
 /// The version of the google_cloud_api client library.
-const packageVersion = '0.5.4';
+const packageVersion = '0.5.5';

--- a/generated/google_cloud_api/pubspec.yaml
+++ b/generated/google_cloud_api/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: google_cloud_api
 description: The Google Cloud client library for the Service Config API.
-version: 0.5.4
+version: 0.5.5
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_api
 issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 
@@ -26,4 +26,4 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_protobuf: ^0.5.4
+  google_cloud_protobuf: ^0.5.5

--- a/generated/google_cloud_common/CHANGELOG.md
+++ b/generated/google_cloud_common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.5
+
+- feat: track library version usage (#330)
+- fix(dart): remove emptying `testing.dart` files (#327)
+- chore: update cloud dependencies
+
 ## 0.5.4
 
 - chore: add CHANGELOG.md to existing published packages (#313)

--- a/generated/google_cloud_common/lib/src/version.dart
+++ b/generated/google_cloud_common/lib/src/version.dart
@@ -17,4 +17,4 @@
 // ignore_for_file: lines_longer_than_80_chars
 
 /// The version of the google_cloud_common client library.
-const packageVersion = '0.5.4';
+const packageVersion = '0.5.5';

--- a/generated/google_cloud_common/pubspec.yaml
+++ b/generated/google_cloud_common/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: google_cloud_common
 description: The Google Cloud client library for the Common Operation Metadata type.
-version: 0.5.4
+version: 0.5.5
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_common
 issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 
@@ -26,4 +26,4 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_protobuf: ^0.5.4
+  google_cloud_protobuf: ^0.5.5

--- a/generated/google_cloud_compute_v1/CHANGELOG.md
+++ b/generated/google_cloud_compute_v1/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- initial release
+

--- a/generated/google_cloud_compute_v1/pubspec.yaml
+++ b/generated/google_cloud_compute_v1/pubspec.yaml
@@ -26,8 +26,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_protobuf: ^0.5.4
-  google_cloud_rpc: ^0.5.4
+  google_cloud_protobuf: ^0.5.5
+  google_cloud_rpc: ^0.5.5
   http: ^1.3.0
 
 dev_dependencies:

--- a/generated/google_cloud_firestore_v1/CHANGELOG.md
+++ b/generated/google_cloud_firestore_v1/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.5
+
+- feat: track library version usage (#330)
+- fix(dart): remove emptying `testing.dart` files (#327)
+- chore: update cloud dependencies
+
 ## 0.5.4
 
 - feat: add setup and test agentic skills  (#321)

--- a/generated/google_cloud_firestore_v1/lib/src/version.dart
+++ b/generated/google_cloud_firestore_v1/lib/src/version.dart
@@ -17,4 +17,4 @@
 // ignore_for_file: lines_longer_than_80_chars
 
 /// The version of the google_cloud_firestore_v1 client library.
-const packageVersion = '0.5.4';
+const packageVersion = '0.5.5';

--- a/generated/google_cloud_firestore_v1/pubspec.yaml
+++ b/generated/google_cloud_firestore_v1/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: google_cloud_firestore_v1
 description: The Google Cloud client library for the Cloud Firestore API.
-version: 0.5.4
+version: 0.5.5
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_firestore_v1
 issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 
@@ -26,10 +26,10 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_longrunning: ^0.5.4
-  google_cloud_protobuf: ^0.5.4
-  google_cloud_rpc: ^0.5.4
-  google_cloud_type: ^0.5.4
+  google_cloud_longrunning: ^0.5.5
+  google_cloud_protobuf: ^0.5.5
+  google_cloud_rpc: ^0.5.5
+  google_cloud_type: ^0.5.5
   http: ^1.3.0
 
 dev_dependencies:

--- a/generated/google_cloud_functions_v2/CHANGELOG.md
+++ b/generated/google_cloud_functions_v2/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.5
+
+- feat: track library version usage (#330)
+- fix(dart): remove emptying `testing.dart` files (#327)
+- chore: update cloud dependencies
+
 ## 0.5.4
 
 - feat: add setup and test agentic skills  (#321)

--- a/generated/google_cloud_functions_v2/lib/src/version.dart
+++ b/generated/google_cloud_functions_v2/lib/src/version.dart
@@ -17,4 +17,4 @@
 // ignore_for_file: lines_longer_than_80_chars
 
 /// The version of the google_cloud_functions_v2 client library.
-const packageVersion = '0.5.4';
+const packageVersion = '0.5.5';

--- a/generated/google_cloud_functions_v2/pubspec.yaml
+++ b/generated/google_cloud_functions_v2/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: google_cloud_functions_v2
 description: The Google Cloud client library for the Cloud Functions API.
-version: 0.5.4
+version: 0.5.5
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_functions_v2
 issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 
@@ -26,10 +26,10 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_iam_v1: ^0.5.4
-  google_cloud_location: ^0.5.4
-  google_cloud_longrunning: ^0.5.4
-  google_cloud_protobuf: ^0.5.4
-  google_cloud_rpc: ^0.5.4
-  google_cloud_type: ^0.5.4
+  google_cloud_iam_v1: ^0.5.5
+  google_cloud_location: ^0.5.5
+  google_cloud_longrunning: ^0.5.5
+  google_cloud_protobuf: ^0.5.5
+  google_cloud_rpc: ^0.5.5
+  google_cloud_type: ^0.5.5
   http: ^1.3.0

--- a/generated/google_cloud_iam_v1/CHANGELOG.md
+++ b/generated/google_cloud_iam_v1/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.5
+
+- feat: track library version usage (#330)
+- fix(dart): remove emptying `testing.dart` files (#327)
+- chore: update cloud dependencies
+
 ## 0.5.4
 
 - feat: add setup and test agentic skills  (#321)

--- a/generated/google_cloud_iam_v1/lib/src/version.dart
+++ b/generated/google_cloud_iam_v1/lib/src/version.dart
@@ -17,4 +17,4 @@
 // ignore_for_file: lines_longer_than_80_chars
 
 /// The version of the google_cloud_iam_v1 client library.
-const packageVersion = '0.5.4';
+const packageVersion = '0.5.5';

--- a/generated/google_cloud_iam_v1/pubspec.yaml
+++ b/generated/google_cloud_iam_v1/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: google_cloud_iam_v1
 description: The Google Cloud client library for the IAM Meta API.
-version: 0.5.4
+version: 0.5.5
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_iam_v1
 issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 
@@ -26,7 +26,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_protobuf: ^0.5.4
-  google_cloud_rpc: ^0.5.4
-  google_cloud_type: ^0.5.4
+  google_cloud_protobuf: ^0.5.5
+  google_cloud_rpc: ^0.5.5
+  google_cloud_type: ^0.5.5
   http: ^1.3.0

--- a/generated/google_cloud_language_v2/CHANGELOG.md
+++ b/generated/google_cloud_language_v2/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.5
+
+- feat: track library version usage (#330)
+- fix(dart): remove emptying `testing.dart` files (#327)
+- chore: update cloud dependencies
+
 ## 0.5.4
 
 - feat: add setup and test agentic skills  (#321)

--- a/generated/google_cloud_language_v2/lib/src/version.dart
+++ b/generated/google_cloud_language_v2/lib/src/version.dart
@@ -17,4 +17,4 @@
 // ignore_for_file: lines_longer_than_80_chars
 
 /// The version of the google_cloud_language_v2 client library.
-const packageVersion = '0.5.4';
+const packageVersion = '0.5.5';

--- a/generated/google_cloud_language_v2/pubspec.yaml
+++ b/generated/google_cloud_language_v2/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: google_cloud_language_v2
 description: The Google Cloud client library for the Cloud Natural Language API.
-version: 0.5.4
+version: 0.5.5
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_language_v2
 issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 
@@ -26,6 +26,6 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_protobuf: ^0.5.4
-  google_cloud_rpc: ^0.5.4
+  google_cloud_protobuf: ^0.5.5
+  google_cloud_rpc: ^0.5.5
   http: ^1.3.0

--- a/generated/google_cloud_location/CHANGELOG.md
+++ b/generated/google_cloud_location/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.5
+
+- feat: track library version usage (#330)
+- fix(dart): remove emptying `testing.dart` files (#327)
+- chore: update cloud dependencies
+
 ## 0.5.4
 
 - feat: add setup and test agentic skills  (#321)

--- a/generated/google_cloud_location/lib/src/version.dart
+++ b/generated/google_cloud_location/lib/src/version.dart
@@ -17,4 +17,4 @@
 // ignore_for_file: lines_longer_than_80_chars
 
 /// The version of the google_cloud_location client library.
-const packageVersion = '0.5.4';
+const packageVersion = '0.5.5';

--- a/generated/google_cloud_location/pubspec.yaml
+++ b/generated/google_cloud_location/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: google_cloud_location
 description: The Google Cloud client library for the Cloud Metadata API.
-version: 0.5.4
+version: 0.5.5
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_location
 issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 
@@ -26,6 +26,6 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_protobuf: ^0.5.4
-  google_cloud_rpc: ^0.5.4
+  google_cloud_protobuf: ^0.5.5
+  google_cloud_rpc: ^0.5.5
   http: ^1.3.0

--- a/generated/google_cloud_logging_type/CHANGELOG.md
+++ b/generated/google_cloud_logging_type/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.5
+
+- feat: track library version usage (#330)
+- fix(dart): remove emptying `testing.dart` files (#327)
+- chore: update cloud dependencies
+
 ## 0.5.4
 
 - chore: add CHANGELOG.md to existing published packages (#313)

--- a/generated/google_cloud_logging_type/lib/src/version.dart
+++ b/generated/google_cloud_logging_type/lib/src/version.dart
@@ -17,4 +17,4 @@
 // ignore_for_file: lines_longer_than_80_chars
 
 /// The version of the google_cloud_logging_type client library.
-const packageVersion = '0.5.4';
+const packageVersion = '0.5.5';

--- a/generated/google_cloud_logging_type/pubspec.yaml
+++ b/generated/google_cloud_logging_type/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: google_cloud_logging_type
 description: The Google Cloud client library for the Logging types.
-version: 0.5.4
+version: 0.5.5
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_logging_type
 issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 
@@ -26,4 +26,4 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_protobuf: ^0.5.4
+  google_cloud_protobuf: ^0.5.5

--- a/generated/google_cloud_logging_v2/CHANGELOG.md
+++ b/generated/google_cloud_logging_v2/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.5
+
+- feat: track library version usage (#330)
+- fix(dart): remove emptying `testing.dart` files (#327)
+- chore: update cloud dependencies
+
 ## 0.5.4
 
 - feat: add setup and test agentic skills  (#321)

--- a/generated/google_cloud_logging_v2/lib/src/version.dart
+++ b/generated/google_cloud_logging_v2/lib/src/version.dart
@@ -17,4 +17,4 @@
 // ignore_for_file: lines_longer_than_80_chars
 
 /// The version of the google_cloud_logging_v2 client library.
-const packageVersion = '0.5.4';
+const packageVersion = '0.5.5';

--- a/generated/google_cloud_logging_v2/pubspec.yaml
+++ b/generated/google_cloud_logging_v2/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: google_cloud_logging_v2
 description: The Google Cloud client library for the Cloud Logging API.
-version: 0.5.4
+version: 0.5.5
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_logging_v2
 issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 
@@ -26,11 +26,11 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_api: ^0.5.4
-  google_cloud_logging_type: ^0.5.4
-  google_cloud_longrunning: ^0.5.4
-  google_cloud_protobuf: ^0.5.4
-  google_cloud_rpc: ^0.5.4
+  google_cloud_api: ^0.5.5
+  google_cloud_logging_type: ^0.5.5
+  google_cloud_longrunning: ^0.5.5
+  google_cloud_protobuf: ^0.5.5
+  google_cloud_rpc: ^0.5.5
   http: ^1.3.0
 
 dev_dependencies:

--- a/generated/google_cloud_longrunning/CHANGELOG.md
+++ b/generated/google_cloud_longrunning/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.5
+
+- feat: track library version usage (#330)
+- fix(dart): remove emptying `testing.dart` files (#327)
+- chore: update cloud dependencies
+
 ## 0.5.4
 
 - feat: add setup and test agentic skills  (#321)

--- a/generated/google_cloud_longrunning/lib/src/version.dart
+++ b/generated/google_cloud_longrunning/lib/src/version.dart
@@ -17,4 +17,4 @@
 // ignore_for_file: lines_longer_than_80_chars
 
 /// The version of the google_cloud_longrunning client library.
-const packageVersion = '0.5.4';
+const packageVersion = '0.5.5';

--- a/generated/google_cloud_longrunning/pubspec.yaml
+++ b/generated/google_cloud_longrunning/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: google_cloud_longrunning
 description: The Google Cloud client library for the Long Running Operations API.
-version: 0.5.4
+version: 0.5.5
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_longrunning
 issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 
@@ -26,8 +26,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_protobuf: ^0.5.4
-  google_cloud_rpc: ^0.5.4
+  google_cloud_protobuf: ^0.5.5
+  google_cloud_rpc: ^0.5.5
   http: ^1.3.0
 
 dev_dependencies:

--- a/generated/google_cloud_protobuf/CHANGELOG.md
+++ b/generated/google_cloud_protobuf/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.5.5
+
+- feat: track library version usage (#330)
+- fix(dart): remove emptying `testing.dart` files (#327)
+
 ## 0.5.4
 
 - chore: add CHANGELOG.md to existing published packages (#313)

--- a/generated/google_cloud_protobuf/lib/src/version.dart
+++ b/generated/google_cloud_protobuf/lib/src/version.dart
@@ -17,4 +17,4 @@
 // ignore_for_file: lines_longer_than_80_chars
 
 /// The version of the google_cloud_protobuf client library.
-const packageVersion = '0.5.4';
+const packageVersion = '0.5.5';

--- a/generated/google_cloud_protobuf/pubspec.yaml
+++ b/generated/google_cloud_protobuf/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: google_cloud_protobuf
 description: The Google Cloud client library for the Core Protobuf Types.
-version: 0.5.4
+version: 0.5.5
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_protobuf
 issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 

--- a/generated/google_cloud_protojson_conformance/pubspec.yaml
+++ b/generated/google_cloud_protojson_conformance/pubspec.yaml
@@ -27,7 +27,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_protobuf: ^0.5.4
+  google_cloud_protobuf: ^0.5.5
 
 dev_dependencies:
   path: any

--- a/generated/google_cloud_rpc/CHANGELOG.md
+++ b/generated/google_cloud_rpc/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.5
+
+- feat: track library version usage (#330)
+- fix(dart): remove emptying `testing.dart` files (#327)
+- chore: update cloud dependencies
+
 ## 0.5.4
 
 - feat: add setup and test agentic skills  (#321)

--- a/generated/google_cloud_rpc/lib/src/version.dart
+++ b/generated/google_cloud_rpc/lib/src/version.dart
@@ -17,4 +17,4 @@
 // ignore_for_file: lines_longer_than_80_chars
 
 /// The version of the google_cloud_rpc client library.
-const packageVersion = '0.5.4';
+const packageVersion = '0.5.5';

--- a/generated/google_cloud_rpc/pubspec.yaml
+++ b/generated/google_cloud_rpc/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: google_cloud_rpc
 description: The Google Cloud client library for the Google RPC Types.
-version: 0.5.4
+version: 0.5.5
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_rpc
 issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 
@@ -26,7 +26,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_protobuf: ^0.5.4
+  google_cloud_protobuf: ^0.5.5
   googleapis_auth: ^2.0.0
   http: ^1.3.0
 

--- a/generated/google_cloud_secretmanager_v1/CHANGELOG.md
+++ b/generated/google_cloud_secretmanager_v1/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.5
+
+- feat: track library version usage (#330)
+- fix(dart): remove emptying `testing.dart` files (#327)
+- chore: update cloud dependencies
+
 ## 0.5.4
 
 - feat: add setup and test agentic skills  (#321)

--- a/generated/google_cloud_secretmanager_v1/lib/src/version.dart
+++ b/generated/google_cloud_secretmanager_v1/lib/src/version.dart
@@ -17,4 +17,4 @@
 // ignore_for_file: lines_longer_than_80_chars
 
 /// The version of the google_cloud_secretmanager_v1 client library.
-const packageVersion = '0.5.4';
+const packageVersion = '0.5.5';

--- a/generated/google_cloud_secretmanager_v1/pubspec.yaml
+++ b/generated/google_cloud_secretmanager_v1/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: google_cloud_secretmanager_v1
 description: The Google Cloud client library for the Secret Manager API.
-version: 0.5.4
+version: 0.5.5
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_secretmanager_v1
 issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 
@@ -26,10 +26,10 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_iam_v1: ^0.5.4
-  google_cloud_location: ^0.5.4
-  google_cloud_protobuf: ^0.5.4
-  google_cloud_rpc: ^0.5.4
+  google_cloud_iam_v1: ^0.5.5
+  google_cloud_location: ^0.5.5
+  google_cloud_protobuf: ^0.5.5
+  google_cloud_rpc: ^0.5.5
   http: ^1.3.0
 
 dev_dependencies:

--- a/generated/google_cloud_showcase_v1beta1/pubspec.yaml
+++ b/generated/google_cloud_showcase_v1beta1/pubspec.yaml
@@ -27,11 +27,11 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_iam_v1: ^0.5.4
-  google_cloud_location: ^0.5.4
-  google_cloud_longrunning: ^0.5.4
-  google_cloud_protobuf: ^0.5.4
-  google_cloud_rpc: ^0.5.4
+  google_cloud_iam_v1: ^0.5.5
+  google_cloud_location: ^0.5.5
+  google_cloud_longrunning: ^0.5.5
+  google_cloud_protobuf: ^0.5.5
+  google_cloud_rpc: ^0.5.5
   http: ^1.3.0
 
 dev_dependencies:

--- a/generated/google_cloud_type/CHANGELOG.md
+++ b/generated/google_cloud_type/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.5
+
+- feat: track library version usage (#330)
+- fix(dart): remove emptying `testing.dart` files (#327)
+- chore: update cloud dependencies
+
 ## 0.5.4
 
 - chore: add CHANGELOG.md to existing published packages (#313)

--- a/generated/google_cloud_type/lib/src/version.dart
+++ b/generated/google_cloud_type/lib/src/version.dart
@@ -17,4 +17,4 @@
 // ignore_for_file: lines_longer_than_80_chars
 
 /// The version of the google_cloud_type client library.
-const packageVersion = '0.5.4';
+const packageVersion = '0.5.5';

--- a/generated/google_cloud_type/pubspec.yaml
+++ b/generated/google_cloud_type/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: google_cloud_type
 description: The Google Cloud client library for the Common Types.
-version: 0.5.4
+version: 0.5.5
 repository: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_type
 issue_tracker: https://github.com/googleapis/google-cloud-dart/issues
 
@@ -26,4 +26,4 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_protobuf: ^0.5.4
+  google_cloud_protobuf: ^0.5.5

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -34,14 +34,14 @@ default:
     api_keys_environment_variables: GOOGLE_API_KEY
     issue_tracker_url: https://github.com/googleapis/google-cloud-dart/issues
     packages:
-      package:google_cloud_api: ^0.5.4
-      package:google_cloud_iam_v1: ^0.5.4
-      package:google_cloud_location: ^0.5.4
-      package:google_cloud_logging_type: ^0.5.4
-      package:google_cloud_longrunning: ^0.5.4
-      package:google_cloud_protobuf: ^0.5.4
-      package:google_cloud_rpc: ^0.5.4
-      package:google_cloud_type: ^0.5.4
+      package:google_cloud_api: ^0.5.5
+      package:google_cloud_iam_v1: ^0.5.5
+      package:google_cloud_location: ^0.5.5
+      package:google_cloud_logging_type: ^0.5.5
+      package:google_cloud_longrunning: ^0.5.5
+      package:google_cloud_protobuf: ^0.5.5
+      package:google_cloud_rpc: ^0.5.5
+      package:google_cloud_type: ^0.5.5
       package:googleapis_auth: ^2.0.0
       package:http: ^1.3.0
     prefixes:
@@ -58,7 +58,7 @@ default:
       proto:google.type: package:google_cloud_type/type.dart
 libraries:
   - name: google_cloud_ai_generativelanguage_v1beta
-    version: 0.5.4
+    version: 0.5.5
     apis:
       - path: google/ai/generativelanguage/v1beta
     copyright_year: "2025"
@@ -150,7 +150,7 @@ libraries:
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_ai_generativelanguage_v1beta
       supports_sse: true
   - name: google_cloud_aiplatform_v1beta1
-    version: 0.5.4
+    version: 0.5.5
     copyright_year: "2025"
     keep:
       - CHANGELOG.md
@@ -260,7 +260,7 @@ libraries:
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_aiplatform_v1beta1
       supports_sse: true
   - name: google_cloud_api
-    version: 0.5.4
+    version: 0.5.5
     apis:
       - path: google/api
     copyright_year: "2025"
@@ -270,7 +270,7 @@ libraries:
       name_override: api
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_api
   - name: google_cloud_common
-    version: 0.5.4
+    version: 0.5.5
     copyright_year: "2025"
     keep:
       - CHANGELOG.md
@@ -290,7 +290,7 @@ libraries:
       dev_dependencies: googleapis_auth,test,test_utils
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_compute_v1
   - name: google_cloud_firestore_v1
-    version: 0.5.4
+    version: 0.5.5
     apis:
       - path: google/firestore/v1
     copyright_year: "2026"
@@ -307,14 +307,14 @@ libraries:
         > [`package:google_cloud_firestore`](https://pub.dev/packages/google_cloud_firestore).
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_firestore_v1
   - name: google_cloud_functions_v2
-    version: 0.5.4
+    version: 0.5.5
     copyright_year: "2025"
     keep:
       - CHANGELOG.md
     dart:
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_functions_v2
   - name: google_cloud_iam_v1
-    version: 0.5.4
+    version: 0.5.5
     apis:
       - path: google/iam/v1
     copyright_year: "2025"
@@ -324,14 +324,14 @@ libraries:
       name_override: iam
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_iam_v1
   - name: google_cloud_language_v2
-    version: 0.5.4
+    version: 0.5.5
     copyright_year: "2025"
     keep:
       - CHANGELOG.md
     dart:
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_language_v2
   - name: google_cloud_location
-    version: 0.5.4
+    version: 0.5.5
     copyright_year: "2025"
     keep:
       - CHANGELOG.md
@@ -339,7 +339,7 @@ libraries:
       name_override: location
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_location
   - name: google_cloud_logging_type
-    version: 0.5.4
+    version: 0.5.5
     apis:
       - path: google/logging/type
     copyright_year: "2025"
@@ -350,7 +350,7 @@ libraries:
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_logging_type
       title_override: Logging types
   - name: google_cloud_logging_v2
-    version: 0.5.4
+    version: 0.5.5
     apis:
       - path: google/logging/v2
     copyright_year: "2025"
@@ -362,7 +362,7 @@ libraries:
       dev_dependencies: googleapis_auth,test,test_utils
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_logging_v2
   - name: google_cloud_longrunning
-    version: 0.5.4
+    version: 0.5.5
     apis:
       - path: google/longrunning
     copyright_year: "2025"
@@ -376,7 +376,7 @@ libraries:
       part_file: longrunning.p.dart
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_longrunning
   - name: google_cloud_protobuf
-    version: 0.5.4
+    version: 0.5.5
     apis:
       - path: google/protobuf
     copyright_year: "2025"
@@ -428,7 +428,7 @@ libraries:
       library_path_override: google_cloud_protobuf_test_messages_proto3.dart
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_protojson_conformance
   - name: google_cloud_rpc
-    version: 0.5.4
+    version: 0.5.5
     apis:
       - path: google/rpc
     copyright_year: "2025"
@@ -449,7 +449,7 @@ libraries:
       part_file: rpc.p.dart
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_rpc
   - name: google_cloud_secretmanager_v1
-    version: 0.5.4
+    version: 0.5.5
     copyright_year: "2025"
     keep:
       - CHANGELOG.md
@@ -478,7 +478,7 @@ libraries:
       repository_url: https://github.com/googleapis/google-cloud-dart/tree/main/generated/google_cloud_showcase_v1beta1
       supports_sse: true
   - name: google_cloud_type
-    version: 0.5.4
+    version: 0.5.5
     apis:
       - path: google/type
     copyright_year: "2025"


### PR DESCRIPTION
Ran:

```bash
go run github.com/googleapis/librarian/cmd/librarian@${LIBRARIAN_VERSION} bump --all
go run github.com/googleapis/librarian/cmd/librarian@${LIBRARIAN_VERSION} publish --dry-run
```