### PR TITLE
feat(pubsub): add message and acknowledgment batching

### DIFF
--- a/pkgs/google_cloud_pubsub/CHANGELOG.md
+++ b/pkgs/google_cloud_pubsub/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## 0.1.0-wip
 
+- Added `BatchingSettings`, `PublishSettings`, and `AckSettings`.
+- Added background message batching for `Topic.publish`.
+- Added background acknowledgment and deadline modification batching for
+  `Subscription.acknowledge` and `Subscription.modifyAckDeadline`.
+- Added `close()` lifecycle methods on `Topic` and `Subscription`.
+- Added `publishMessages` on `PubSub` for publishing multiple messages in a
+  single RPC.
 - Added `RetrySettings` to configure exponential backoff retry parameters
   (delays, multiplier, jitter, and total timeout).
 - Initial release of the experimental Google Cloud Pub/Sub client.

--- a/pkgs/google_cloud_pubsub/CHANGELOG.md
+++ b/pkgs/google_cloud_pubsub/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.1.0-wip
 
+- Added `RetrySettings` to configure exponential backoff retry parameters
+  (delays, multiplier, jitter, and total timeout).
 - Initial release of the experimental Google Cloud Pub/Sub client.
 - Supports basic topic and subscription management.
 - Supports publishing and pulling messages (including streaming pull).

--- a/pkgs/google_cloud_pubsub/lib/google_cloud_pubsub.dart
+++ b/pkgs/google_cloud_pubsub/lib/google_cloud_pubsub.dart
@@ -22,5 +22,6 @@ export 'package:grpc/grpc.dart'
 
 export 'src/client.dart' show PubSub;
 export 'src/message.dart' show Message, ReceivedMessage;
+export 'src/retry.dart' show RetrySettings;
 export 'src/subscription.dart' show Subscription;
 export 'src/topic.dart' show Topic;

--- a/pkgs/google_cloud_pubsub/lib/google_cloud_pubsub.dart
+++ b/pkgs/google_cloud_pubsub/lib/google_cloud_pubsub.dart
@@ -20,8 +20,9 @@ export 'package:grpc/grpc.dart'
         ServiceAccountAuthenticator,
         applicationDefaultCredentialsAuthenticator;
 
+export 'src/batching.dart' show BatchingSettings;
 export 'src/client.dart' show PubSub;
 export 'src/message.dart' show Message, ReceivedMessage;
 export 'src/retry.dart' show RetrySettings;
-export 'src/subscription.dart' show Subscription;
-export 'src/topic.dart' show Topic;
+export 'src/subscription.dart' show AckSettings, Subscription;
+export 'src/topic.dart' show PublishSettings, Topic;

--- a/pkgs/google_cloud_pubsub/lib/src/batching.dart
+++ b/pkgs/google_cloud_pubsub/lib/src/batching.dart
@@ -1,0 +1,140 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:async';
+
+import 'package:meta/meta.dart';
+
+/// Settings for batching operations.
+final class BatchingSettings {
+  /// The maximum number of items in a batch.
+  final int maxMessages;
+
+  /// The maximum size in bytes for a batch.
+  final int maxBytes;
+
+  /// The maximum time to wait before sending a batch.
+  final Duration maxDelay;
+
+  /// Creates a new [BatchingSettings] instance.
+  ///
+  /// It is an error if:
+  /// - [maxMessages] is not greater than 0.
+  /// - [maxBytes] is not greater than 0.
+  /// - [maxDelay] is not greater than [Duration.zero].
+  BatchingSettings({
+    this.maxMessages = 100,
+    this.maxBytes = 1024 * 1024, // 1 MB
+    this.maxDelay = const Duration(milliseconds: 10),
+  }) {
+    if (maxMessages <= 0) {
+      throw ArgumentError.value(
+        maxMessages,
+        'maxMessages',
+        'Must be greater than zero',
+      );
+    }
+    if (maxBytes <= 0) {
+      throw ArgumentError.value(
+        maxBytes,
+        'maxBytes',
+        'Must be greater than zero',
+      );
+    }
+    if (maxDelay <= Duration.zero) {
+      throw ArgumentError.value(
+        maxDelay,
+        'maxDelay',
+        'Must be greater than zero',
+      );
+    }
+  }
+}
+
+/// Generic batcher that accumulates items of type [T] and fires batches of [T]
+/// according to [BatchingSettings].
+@internal
+final class Batcher<T> {
+  final BatchingSettings settings;
+  final int Function(T) itemSize;
+  final Future<void> Function(List<T>) onBatch;
+
+  final List<T> _buffer = [];
+  final Set<Future<void>> _inFlight = {};
+  int _currentSizeBytes = 0;
+  Timer? _timer;
+  bool _isClosed = false;
+  Future<void>? _closeFuture;
+
+  Batcher({
+    required this.settings,
+    required this.itemSize,
+    required this.onBatch,
+  });
+
+  /// Whether this batcher is closed.
+  bool get isClosed => _isClosed;
+
+  /// Adds an item to the batch.
+  ///
+  /// It is an error if called on a closed [Batcher].
+  void add(T item) {
+    if (_isClosed) {
+      throw StateError('Cannot add items to a closed Batcher.');
+    }
+    _buffer.add(item);
+    _currentSizeBytes += itemSize(item);
+
+    if (_buffer.length >= settings.maxMessages ||
+        _currentSizeBytes >= settings.maxBytes) {
+      _flush();
+    } else {
+      _timer ??= Timer(settings.maxDelay, _flush);
+    }
+  }
+
+  void _flush() {
+    _timer?.cancel();
+    _timer = null;
+
+    if (_buffer.isEmpty) return;
+
+    final batch = List<T>.from(_buffer);
+    _buffer.clear();
+    _currentSizeBytes = 0;
+
+    final future = Future.sync(() => onBatch(batch));
+    _inFlight.add(future);
+    future
+        .whenComplete(() {
+          _inFlight.remove(future);
+        })
+        .catchError((_) {
+          // Errors should be handled by onBatch (e.g. failing the
+          // completers for the items).
+        });
+  }
+
+  /// Closes the batcher, flushing any remaining items immediately and waiting
+  /// for in-flight batches to complete.
+  Future<void> close() => _closeFuture ??= _doClose();
+
+  Future<void> _doClose() async {
+    _isClosed = true;
+    _flush();
+    while (_inFlight.isNotEmpty) {
+      await Future.wait(_inFlight.map((f) => f.catchError((_) {})));
+    }
+  }
+}

--- a/pkgs/google_cloud_pubsub/lib/src/client.dart
+++ b/pkgs/google_cloud_pubsub/lib/src/client.dart
@@ -14,6 +14,7 @@
 
 import 'dart:async';
 
+import 'package:google_cloud_rpc/rpc.dart';
 import 'package:grpc/grpc.dart';
 import 'package:meta/meta.dart';
 import '../google_cloud_pubsub.dart';
@@ -176,26 +177,35 @@ final class PubSub {
   // Topic-related methods
 
   /// A [Topic] object with the given [unqualifiedName] in the client's project.
-  Topic topic(String unqualifiedName) =>
-      Topic.unqualified(this, unqualifiedName);
+  Topic topic(String unqualifiedName, {PublishSettings? publishSettings}) =>
+      Topic.unqualified(
+        this,
+        unqualifiedName,
+        publishSettings: publishSettings,
+      );
 
   /// A [Topic] object with the given [name].
   ///
   /// The [name] must be in the format `projects/<project-id>/topics/<topic-id>`.
   /// Useful for cross-project access.
-  Topic topicName(String name) => Topic(this, name);
+  Topic topicName(String name, {PublishSettings? publishSettings}) =>
+      Topic(this, name, publishSettings: publishSettings);
 
   /// A [Subscription] object with the given [unqualifiedName] in the client's
   /// project.
-  Subscription subscription(String unqualifiedName) =>
-      Subscription.unqualified(this, unqualifiedName);
+  Subscription subscription(
+    String unqualifiedName, {
+    AckSettings? ackSettings,
+  }) =>
+      Subscription.unqualified(this, unqualifiedName, ackSettings: ackSettings);
 
   /// A [Subscription] object with the given [name].
   ///
   /// The [name] must be in the format
   /// `projects/<project-id>/subscriptions/<subscription-id>`.
   /// Useful for cross-project access.
-  Subscription subscriptionName(String name) => Subscription(this, name);
+  Subscription subscriptionName(String name, {AckSettings? ackSettings}) =>
+      Subscription(this, name, ackSettings: ackSettings);
 
   /// Creates the given topic with the given [topic].
   ///
@@ -246,21 +256,40 @@ final class PubSub {
     List<int> data, {
     Map<String, String>? attributes,
   }) async {
-    final message = grpc.PubsubMessage()..data = data;
-    if (attributes != null) {
-      message.attributes.addAll(attributes);
-    }
+    final messageIds = await publishMessages(topic, [
+      Message(data: data, attributes: attributes),
+    ]);
+    return messageIds.first;
+  }
 
-    final request = grpc.PublishRequest()
-      ..topic = topic
-      ..messages.add(message);
+  /// Adds multiple messages to the topic in a single RPC.
+  ///
+  /// The [topic] must be in the format `projects/<project-id>/topics/<topic-id>`.
+  ///
+  /// Throws a [NotFoundException] if the topic does not exist.
+  ///
+  /// See the [official documentation](https://cloud.google.com/pubsub/docs/reference/rpc/google.pubsub.v1#google.pubsub.v1.Publisher.Publish).
+  Future<List<String>> publishMessages(
+    String topic,
+    List<Message> messages,
+  ) async {
+    if (messages.isEmpty) return <String>[];
+    final request = grpc.PublishRequest()..topic = topic;
+
+    for (final message in messages) {
+      final pbMessage = grpc.PubsubMessage()..data = message.data;
+      if (message.attributes.isNotEmpty) {
+        pbMessage.attributes.addAll(message.attributes);
+      }
+      request.messages.add(pbMessage);
+    }
 
     try {
       final response = await _publisher.publish(
         request,
         options: await _callOptions,
       );
-      return response.messageIds.first;
+      return response.messageIds;
     } on GrpcError catch (e) {
       throw _mapGrpcError(e);
     }
@@ -331,6 +360,8 @@ final class PubSub {
   /// The [subscription] must be in the format
   /// `projects/<project-id>/subscriptions/<subscription-id>`.
   ///
+  /// It is an error if [maxMessages] is not greater than 0.
+  ///
   /// Throws a [NotFoundException] if the subscription does not exist.
   ///
   /// See the [official documentation](https://cloud.google.com/pubsub/docs/reference/rpc/google.pubsub.v1#google.pubsub.v1.Subscriber.Pull).
@@ -338,6 +369,13 @@ final class PubSub {
     String subscription, {
     int maxMessages = 1,
   }) async {
+    if (maxMessages <= 0) {
+      throw ArgumentError.value(
+        maxMessages,
+        'maxMessages',
+        'Must be greater than 0',
+      );
+    }
     final request = grpc.PullRequest()
       ..subscription = subscription
       ..maxMessages = maxMessages;
@@ -378,11 +416,30 @@ final class PubSub {
   ///
   /// Throws a [ServiceException] if the stream is broken by the server or
   /// network.
+  /// It is an error if [streamAckDeadlineSeconds] is not between 10 and 600
+  /// seconds.
   ///
   /// See the [official documentation](https://cloud.google.com/pubsub/docs/reference/rpc/google.pubsub.v1#google.pubsub.v1.Subscriber.StreamingPull).
   Stream<ReceivedMessage> streamingPull(
     String subscription, {
     int streamAckDeadlineSeconds = 10,
+  }) {
+    if (streamAckDeadlineSeconds < 10 || streamAckDeadlineSeconds > 600) {
+      throw ArgumentError.value(
+        streamAckDeadlineSeconds,
+        'streamAckDeadlineSeconds',
+        'Must be between 10 and 600 seconds',
+      );
+    }
+    return _streamingPull(
+      subscription,
+      streamAckDeadlineSeconds: streamAckDeadlineSeconds,
+    );
+  }
+
+  Stream<ReceivedMessage> _streamingPull(
+    String subscription, {
+    required int streamAckDeadlineSeconds,
   }) async* {
     final requestController = StreamController<grpc.StreamingPullRequest>();
     try {
@@ -448,6 +505,7 @@ final class PubSub {
   ///
   /// See the [official documentation](https://cloud.google.com/pubsub/docs/reference/rpc/google.pubsub.v1#google.pubsub.v1.Subscriber.Acknowledge).
   Future<void> acknowledge(String subscription, List<String> ackIds) async {
+    if (ackIds.isEmpty) return;
     final request = grpc.AcknowledgeRequest()
       ..subscription = subscription
       ..ackIds.addAll(ackIds);
@@ -473,6 +531,8 @@ final class PubSub {
   /// may succeed, but those messages may have already been redelivered or
   /// made available for redelivery.
   ///
+  /// It is an error if [ackDeadlineSeconds] is negative.
+  ///
   /// Throws a [NotFoundException] if the subscription does not exist.
   ///
   /// See the [official documentation](https://cloud.google.com/pubsub/docs/reference/rpc/google.pubsub.v1#google.pubsub.v1.Subscriber.ModifyAckDeadline).
@@ -481,6 +541,14 @@ final class PubSub {
     List<String> ackIds,
     int ackDeadlineSeconds,
   ) async {
+    if (ackDeadlineSeconds < 0) {
+      throw ArgumentError.value(
+        ackDeadlineSeconds,
+        'ackDeadlineSeconds',
+        'Must be non-negative',
+      );
+    }
+    if (ackIds.isEmpty) return;
     final request = grpc.ModifyAckDeadlineRequest()
       ..subscription = subscription
       ..ackIds.addAll(ackIds)
@@ -524,7 +592,10 @@ final class PubSub {
       StatusCode.permissionDenied => ForbiddenException(message),
       StatusCode.notFound => NotFoundException(message),
       StatusCode.alreadyExists => ConflictException(message),
-      StatusCode.aborted => ConflictException(message),
+      StatusCode.aborted => ConflictException(
+        message,
+        status: Status(code: StatusCode.aborted, message: message),
+      ),
       StatusCode.failedPrecondition => PreconditionFailedException(message),
       StatusCode.outOfRange => RequestRangeNotSatisfiableException(message),
       StatusCode.resourceExhausted => TooManyRequestsException(message),

--- a/pkgs/google_cloud_pubsub/lib/src/message.dart
+++ b/pkgs/google_cloud_pubsub/lib/src/message.dart
@@ -15,6 +15,8 @@
 import 'dart:async';
 import 'dart:typed_data';
 
+import 'subscription.dart';
+
 /// A Pub/Sub message.
 final class Message {
   /// The payload of this message.
@@ -26,6 +28,10 @@ final class Message {
   Message({required List<int> data, Map<String, String>? attributes})
     : data = data is Uint8List ? data : Uint8List.fromList(data),
       attributes = attributes ?? const {};
+
+  @override
+  String toString() =>
+      'Message(data: ${data.length} bytes, attributes: $attributes)';
 }
 
 /// A message received from a subscription.
@@ -67,12 +73,17 @@ final class ReceivedMessage {
   /// If this message was received via `pull`, it will call the unary
   /// acknowledge endpoint.
   /// If it was received via `streamingPull`, it will send an acknowledgment
-  /// request over the existing stream.
+  /// request over the stream or route it through the subscription batcher.
+  ///
+  /// It is an error if no acknowledge handler is configured for this message
+  /// (e.g. if the message was constructed manually without a handler, or if the
+  /// underlying [Subscription] is closed).
   Future<void> acknowledge() async {
     final handler = _ackHandler;
-    if (handler != null) {
-      await handler([ackId]);
+    if (handler == null) {
+      throw StateError('No acknowledge handler configured for this message.');
     }
+    await handler([ackId]);
   }
 
   /// Modifies the ack deadline for this message.
@@ -81,10 +92,29 @@ final class ReceivedMessage {
   /// time this method is called. For example, if [seconds] is 10, the new ack
   /// deadline is 10 seconds from now. Specifying 0 makes the message
   /// immediately available for redelivery.
+  ///
+  /// It is an error if [seconds] is negative.
+  ///
+  /// It is an error if no modify-ack-deadline handler is configured for this
+  /// message, or if the underlying [Subscription] is closed.
   Future<void> modifyAckDeadline(int seconds) async {
-    final handler = _modifyDeadlineHandler;
-    if (handler != null) {
-      await handler([ackId], seconds);
+    if (seconds < 0) {
+      throw ArgumentError.value(seconds, 'seconds', 'Must be non-negative');
     }
+    final handler = _modifyDeadlineHandler;
+    if (handler == null) {
+      throw StateError(
+        'No modify-ack-deadline handler configured for this message.',
+      );
+    }
+    await handler([ackId], seconds);
   }
+
+  @override
+  String toString() =>
+      'ReceivedMessage('
+      'messageId: $messageId, '
+      'ackId: $ackId, '
+      'publishTime: $publishTime, '
+      'message: $message)';
 }

--- a/pkgs/google_cloud_pubsub/lib/src/retry.dart
+++ b/pkgs/google_cloud_pubsub/lib/src/retry.dart
@@ -1,0 +1,251 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:math';
+
+import 'package:clock/clock.dart';
+import 'package:google_cloud_rpc/exceptions.dart';
+import 'package:grpc/grpc.dart';
+import 'package:meta/meta.dart';
+
+const _sentinel = Object();
+
+/// Settings for configuring retry logic with exponential backoff.
+final class RetrySettings {
+  /// The maximum number of times to retry before failing.
+  ///
+  /// A `null` value indicates that the number of retries is unlimited.
+  final int? maxRetries;
+
+  /// The maximum amount of total time to retry before failing.
+  ///
+  /// A `null` value indicates that the total retry time is unlimited.
+  final Duration? totalTimeout;
+
+  /// The minimum amount of time to wait before retrying.
+  final Duration initialDelay;
+
+  /// The multiplier for the wait time between retries.
+  final double delayMultiplier;
+
+  /// The maximum amount of time to wait between retries.
+  ///
+  /// If the calculated exponential wait time between retries exceeds this
+  /// value, the wait time will be clamped to this value.
+  final Duration maxDelay;
+
+  /// Creates a new [RetrySettings] instance.
+  ///
+  /// It is an error if:
+  /// - [maxRetries] is negative.
+  /// - [initialDelay] is not greater than [Duration.zero].
+  /// - [delayMultiplier] is less than 1.0 or not finite.
+  /// - [maxDelay] is not greater than [Duration.zero].
+  /// - [totalTimeout] is not greater than [Duration.zero].
+  RetrySettings({
+    int? maxRetries,
+    Duration? totalTimeout = const Duration(minutes: 1),
+    Duration initialDelay = const Duration(milliseconds: 100),
+    double delayMultiplier = 1.3,
+    Duration maxDelay = const Duration(seconds: 60),
+  }) : this._internal(
+         maxRetries: maxRetries,
+         totalTimeout: totalTimeout,
+         initialDelay: initialDelay,
+         delayMultiplier: delayMultiplier,
+         maxDelay: maxDelay,
+       );
+
+  RetrySettings._internal({
+    required this.maxRetries,
+    required this.totalTimeout,
+    required this.initialDelay,
+    required this.delayMultiplier,
+    required this.maxDelay,
+  }) {
+    if (maxRetries != null && maxRetries! < 0) {
+      throw ArgumentError.value(
+        maxRetries,
+        'maxRetries',
+        'Must be non-negative',
+      );
+    }
+    if (initialDelay <= Duration.zero) {
+      throw ArgumentError.value(
+        initialDelay,
+        'initialDelay',
+        'Must be greater than zero',
+      );
+    }
+    if (delayMultiplier < 1.0 || !delayMultiplier.isFinite) {
+      throw ArgumentError.value(
+        delayMultiplier,
+        'delayMultiplier',
+        'Must be at least 1.0',
+      );
+    }
+    if (maxDelay <= Duration.zero) {
+      throw ArgumentError.value(
+        maxDelay,
+        'maxDelay',
+        'Must be greater than zero',
+      );
+    }
+    if (totalTimeout != null && totalTimeout! <= Duration.zero) {
+      throw ArgumentError.value(
+        totalTimeout,
+        'totalTimeout',
+        'Must be greater than zero',
+      );
+    }
+  }
+
+  /// Creates a copy of this [RetrySettings] with the given fields replaced.
+  ///
+  /// It is an error if any replaced parameter violates its constraints.
+  RetrySettings copyWith({
+    Object? maxRetries = _sentinel,
+    Object? totalTimeout = _sentinel,
+    Duration? initialDelay,
+    double? delayMultiplier,
+    Duration? maxDelay,
+  }) {
+    if (maxRetries != _sentinel && maxRetries != null && maxRetries is! int) {
+      throw ArgumentError.value(
+        maxRetries,
+        'maxRetries',
+        'Must be an int or null',
+      );
+    }
+    if (totalTimeout != _sentinel &&
+        totalTimeout != null &&
+        totalTimeout is! Duration) {
+      throw ArgumentError.value(
+        totalTimeout,
+        'totalTimeout',
+        'Must be a Duration or null',
+      );
+    }
+    return RetrySettings._internal(
+      maxRetries: identical(maxRetries, _sentinel)
+          ? this.maxRetries
+          : maxRetries as int?,
+      totalTimeout: identical(totalTimeout, _sentinel)
+          ? this.totalTimeout
+          : totalTimeout as Duration?,
+      initialDelay: initialDelay ?? this.initialDelay,
+      delayMultiplier: delayMultiplier ?? this.delayMultiplier,
+      maxDelay: maxDelay ?? this.maxDelay,
+    );
+  }
+}
+
+/// Generates wait durations for exponential backoff according to
+/// [RetrySettings].
+///
+/// Uses [clock] to enforce [totalTimeout].
+@internal
+Iterable<Duration> delaySequence({
+  int? maxRetries,
+  Duration? totalTimeout = const Duration(minutes: 1),
+  required Duration initialDelay,
+  required Duration maxDelay,
+  required double delayMultiplier,
+  Clock clock = const Clock(),
+  Random? random,
+}) sync* {
+  final noRetriesAfter = totalTimeout == null
+      ? null
+      : clock.fromNowBy(totalTimeout);
+  final rng = random ?? Random();
+  var reachedMax = false;
+  for (var i = 0; (maxRetries == null) || (i < maxRetries); i++) {
+    if (noRetriesAfter != null && clock.now().isAfter(noRetriesAfter)) {
+      break;
+    }
+    final baseDelay = reachedMax
+        ? maxDelay
+        : initialDelay * pow(delayMultiplier, i);
+    if (!reachedMax && baseDelay >= maxDelay) {
+      reachedMax = true;
+    }
+    final effectiveBase = reachedMax ? maxDelay : baseDelay;
+    final jitterFactor = 0.8 + 0.4 * rng.nextDouble();
+    yield Duration(
+      microseconds: (effectiveBase.inMicroseconds * jitterFactor).round(),
+    );
+  }
+}
+
+/// Returns whether [e] is considered a retryable error.
+@internal
+bool isRetryable(Object e) {
+  if (e is! Exception) return false;
+  return switch (e) {
+    GrpcError(:final code) => switch (code) {
+      StatusCode.aborted ||
+      StatusCode.deadlineExceeded ||
+      StatusCode.internal ||
+      StatusCode.resourceExhausted ||
+      StatusCode.unavailable ||
+      StatusCode.unknown => true,
+      _ => false,
+    },
+    ConflictException(:final status) when status?.code == StatusCode.aborted =>
+      true,
+    ServiceException(:final status) when status?.code == StatusCode.aborted =>
+      true,
+    BadGatewayException() ||
+    RequestTimeoutException() ||
+    ServiceUnavailableException() ||
+    GatewayTimeoutException() ||
+    TooManyRequestsException() => true,
+    InternalServerErrorException(:final status) =>
+      status?.code != StatusCode.dataLoss,
+    _ => false,
+  };
+}
+
+/// Runs [body] with exponential backoff retries.
+///
+/// Only transient gRPC errors and retryable [ServiceException]s are retried.
+/// If [isIdempotent] is `false`, the operation is never retried and the first
+/// error is rethrown.
+Future<T> runWithRetry<T>(
+  Future<T> Function() body, {
+  required RetrySettings settings,
+  required bool isIdempotent,
+}) async {
+  final delays = delaySequence(
+    maxRetries: settings.maxRetries,
+    totalTimeout: settings.totalTimeout,
+    initialDelay: settings.initialDelay,
+    maxDelay: settings.maxDelay,
+    delayMultiplier: settings.delayMultiplier,
+  ).iterator;
+
+  while (true) {
+    try {
+      return await body();
+    } on Exception catch (e) {
+      if (!isIdempotent || !isRetryable(e)) rethrow;
+
+      if (delays.moveNext()) {
+        await Future<void>.delayed(delays.current);
+      } else {
+        rethrow;
+      }
+    }
+  }
+}

--- a/pkgs/google_cloud_pubsub/lib/src/subscription.dart
+++ b/pkgs/google_cloud_pubsub/lib/src/subscription.dart
@@ -15,6 +15,35 @@
 import 'dart:async';
 
 import '../google_cloud_pubsub.dart';
+import 'batching.dart';
+import 'retry.dart';
+
+/// Settings for background batching and retrying of acknowledgements and
+/// deadline modifications.
+final class AckSettings {
+  /// Settings controlling how requests are accumulated and flushed.
+  final BatchingSettings batching;
+
+  /// Settings controlling retries when flushing a batch over a unary RPC.
+  final RetrySettings retry;
+
+  AckSettings({BatchingSettings? batching, RetrySettings? retry})
+    : batching = batching ?? BatchingSettings(),
+      retry = retry ?? RetrySettings();
+}
+
+final class _AckRequest {
+  final String ackId;
+
+  _AckRequest(this.ackId);
+}
+
+final class _ModifyAckDeadlineRequest {
+  final String ackId;
+  final int ackDeadlineSeconds;
+
+  _ModifyAckDeadlineRequest(this.ackId, this.ackDeadlineSeconds);
+}
 
 /// A [Google Cloud Pub/Sub subscription](https://cloud.google.com/pubsub/docs/overview#subscriptions).
 final class Subscription {
@@ -30,13 +59,31 @@ final class Subscription {
   /// It has the format `projects/<project-id>/subscriptions/<subscription-id>`.
   final String name;
 
+  /// Settings controlling background acknowledgment and deadline modification
+  /// batching and retries.
+  final AckSettings ackSettings;
+
+  late final Batcher<_AckRequest> _ackBatcher;
+  late final Batcher<_ModifyAckDeadlineRequest> _modifyAckBatcher;
+
+  bool _isClosed = false;
+  Future<void>? _closeFuture;
+
+  /// Whether this subscription has been closed via [close].
+  bool get isClosed => _isClosed;
+
   /// A subscription with the given [subscriptionId] in the client's project.
   ///
   /// It is an error if the constructed subscription name is invalid (e.g. if
   /// [subscriptionId] contains slashes).
-  Subscription.unqualified(this.pubsub, String subscriptionId)
-    : name = 'projects/${pubsub.projectId}/subscriptions/$subscriptionId' {
+  Subscription.unqualified(
+    this.pubsub,
+    String subscriptionId, {
+    AckSettings? ackSettings,
+  }) : name = 'projects/${pubsub.projectId}/subscriptions/$subscriptionId',
+       ackSettings = ackSettings ?? AckSettings() {
     _validateName(name);
+    _initBatchers();
   }
 
   /// A subscription with the given [name].
@@ -45,8 +92,23 @@ final class Subscription {
   ///
   /// It is an error if [name] is not in the format
   /// `projects/<project-id>/subscriptions/<subscription-id>`.
-  Subscription(this.pubsub, this.name) {
+  Subscription(this.pubsub, this.name, {AckSettings? ackSettings})
+    : ackSettings = ackSettings ?? AckSettings() {
     _validateName(name);
+    _initBatchers();
+  }
+
+  void _initBatchers() {
+    _ackBatcher = Batcher<_AckRequest>(
+      settings: ackSettings.batching,
+      itemSize: (req) => req.ackId.length,
+      onBatch: _onAckBatch,
+    );
+    _modifyAckBatcher = Batcher<_ModifyAckDeadlineRequest>(
+      settings: ackSettings.batching,
+      itemSize: (req) => req.ackId.length,
+      onBatch: _onModifyAckBatch,
+    );
   }
 
   static void _validateName(String name) {
@@ -73,8 +135,10 @@ final class Subscription {
   /// Returns a [Subscription] instance representing the created subscription.
   ///
   /// See the [official documentation](https://cloud.google.com/pubsub/docs/reference/rpc/google.pubsub.v1#google.pubsub.v1.Subscriber.CreateSubscription).
-  Future<Subscription> create({required String topic}) =>
-      pubsub.createSubscription(name, topic: topic);
+  Future<Subscription> create({required String topic}) async {
+    await pubsub.createSubscription(name, topic: topic);
+    return this;
+  }
 
   /// Deletes this subscription on the server.
   ///
@@ -87,12 +151,15 @@ final class Subscription {
 
   /// Pulls messages from the server.
   ///
+  /// It is an error if [maxMessages] is not greater than 0.
+  /// It is an error if called on a closed [Subscription].
   /// Throws a [NotFoundException] if the subscription does not exist.
-  ///
-  /// It is an error if [maxMessages] is less than or equal to 0.
   ///
   /// See the [official documentation](https://cloud.google.com/pubsub/docs/reference/rpc/google.pubsub.v1#google.pubsub.v1.Subscriber.Pull).
   Future<List<ReceivedMessage>> pull({int maxMessages = 1}) {
+    if (_isClosed) {
+      throw StateError('Cannot pull messages on a closed Subscription.');
+    }
     if (maxMessages <= 0) {
       throw ArgumentError.value(
         maxMessages,
@@ -106,18 +173,18 @@ final class Subscription {
   /// Establishes a stream with the server, which sends messages down to the
   /// client.
   ///
-  /// The client streams acknowledgments and ack deadline modifications
-  /// back to the server. If an error occurs (including when the server closes
-  /// the stream with status `UNAVAILABLE` to reassign resources), the stream
-  /// will throw a [ServiceException]. In this case, the caller should
-  /// re-establish the stream. Flow control can be achieved by configuring the
-  /// underlying RPC channel.
-  ///
   /// Throws a [ServiceException] if the stream is broken by the server or
   /// network.
   ///
+  /// It is an error if called on a closed [Subscription].
+  /// It is an error if [streamAckDeadlineSeconds] is not between 10 and 600
+  /// seconds.
+  ///
   /// See the [official documentation](https://cloud.google.com/pubsub/docs/reference/rpc/google.pubsub.v1#google.pubsub.v1.Subscriber.StreamingPull).
   Stream<ReceivedMessage> streamingPull({int streamAckDeadlineSeconds = 10}) {
+    if (_isClosed) {
+      throw StateError('Cannot stream messages on a closed Subscription.');
+    }
     if (streamAckDeadlineSeconds < 10 || streamAckDeadlineSeconds > 600) {
       throw ArgumentError.value(
         streamAckDeadlineSeconds,
@@ -131,43 +198,83 @@ final class Subscription {
     );
   }
 
-  /// Acknowledges the messages associated with the [messages] immediately.
-  ///
-  /// The Pub/Sub system can remove the relevant messages from the subscription.
-  ///
-  /// Acknowledging a message whose ack deadline has expired may succeed,
-  /// but such a message may be redelivered later. Acknowledging a message more
-  /// than once will not result in an error.
-  ///
-  /// Throws a [NotFoundException] if the subscription does not exist.
-  ///
-  /// See the [official documentation](https://cloud.google.com/pubsub/docs/reference/rpc/google.pubsub.v1#google.pubsub.v1.Subscriber.Acknowledge).
-  Future<void> acknowledgeNow(List<ReceivedMessage> messages) =>
-      pubsub.acknowledge(name, messages.map((m) => m.ackId).toList());
-
-  /// Acknowledges a single message in the background.
-  ///
-  /// This operation is "fire-and-forget" and does not wait for server
-  /// confirmation. If you require explicit confirmation of acknowledgment,
-  /// use [acknowledgeNow].
-  void acknowledge(ReceivedMessage message) {
-    unawaited(acknowledgeNow([message]));
+  Future<void> _onAckBatch(List<_AckRequest> batch) async {
+    final ackIds = batch.map((e) => e.ackId).toList();
+    await runWithRetry(
+      () => pubsub.acknowledge(name, ackIds),
+      settings: ackSettings.retry,
+      isIdempotent: true,
+    );
   }
 
-  /// Modifies the ack deadline for a list of specific messages immediately.
+  Future<void> _onModifyAckBatch(List<_ModifyAckDeadlineRequest> batch) async {
+    final byDeadline = <int, List<String>>{};
+    for (final req in batch) {
+      byDeadline.putIfAbsent(req.ackDeadlineSeconds, () => []).add(req.ackId);
+    }
+    for (final entry in byDeadline.entries) {
+      final deadline = entry.key;
+      final ackIds = entry.value;
+      try {
+        await runWithRetry(
+          () => pubsub.modifyAckDeadline(name, ackIds, deadline),
+          settings: ackSettings.retry,
+          isIdempotent: true,
+        );
+      } catch (_) {
+        // Best effort.
+      }
+    }
+  }
+
+  /// Acknowledges the [messages] synchronously.
   ///
-  /// This method is useful to indicate that more time is needed to process a
-  /// message by the subscriber, or to make the message available for redelivery
-  /// if the processing was interrupted. Note that this does not modify the
-  /// subscription-level `ackDeadlineSeconds` used for subsequent messages.
+  /// Bypasses background batching and immediately executes a unary RPC.
   ///
-  /// Modifying the ack deadline for messages whose deadline has already expired
-  /// may succeed, but those messages may have already been redelivered or
-  /// made available for redelivery.
-  ///
+  /// It is an error if called on a closed [Subscription].
   /// Throws a [NotFoundException] if the subscription does not exist.
+  /// Throws a [ServiceException] if the RPC fails.
+  ///
+  /// See the [official documentation](https://cloud.google.com/pubsub/docs/reference/rpc/google.pubsub.v1#google.pubsub.v1.Subscriber.Acknowledge).
+  Future<void> acknowledgeNow(List<ReceivedMessage> messages) {
+    if (_isClosed) {
+      throw StateError('Cannot acknowledge messages on a closed Subscription.');
+    }
+    if (messages.isEmpty) return Future.value();
+    return pubsub.acknowledge(name, messages.map((m) => m.ackId).toList());
+  }
+
+  /// Acknowledges [message] in the background.
+  ///
+  /// The acknowledgment is buffered and sent in a batch according to
+  /// [AckSettings.batching] via a unary RPC with retries configured
+  /// by [AckSettings.retry].
+  ///
+  /// To ensure all buffered acknowledgments are delivered before application
+  /// shutdown, call and await [close].
+  ///
+  /// It is an error if called on a closed [Subscription].
+  ///
+  /// This is a non-blocking, fire-and-forget operation. If a background ACK
+  /// fails permanently, the message will eventually be redelivered by the
+  /// server after its ack deadline expires.
+  ///
+  /// See [acknowledgeNow] for an immediate, awaitable alternative.
+  void acknowledge(ReceivedMessage message) {
+    if (_isClosed) {
+      throw StateError('Cannot acknowledge messages on a closed Subscription.');
+    }
+    _ackBatcher.add(_AckRequest(message.ackId));
+  }
+
+  /// Modifies the ack deadline for [messages] synchronously.
+  ///
+  /// Bypasses background batching and immediately executes a unary RPC.
   ///
   /// It is an error if [ackDeadlineSeconds] is negative.
+  /// It is an error if called on a closed [Subscription].
+  /// Throws a [NotFoundException] if the subscription does not exist.
+  /// Throws a [ServiceException] if the RPC fails.
   ///
   /// See the [official documentation](https://cloud.google.com/pubsub/docs/reference/rpc/google.pubsub.v1#google.pubsub.v1.Subscriber.ModifyAckDeadline).
   Future<void> modifyAckDeadlineNow(
@@ -181,6 +288,10 @@ final class Subscription {
         'Must be non-negative',
       );
     }
+    if (_isClosed) {
+      throw StateError('Cannot modify ack deadline on a closed Subscription.');
+    }
+    if (messages.isEmpty) return Future.value();
     return pubsub.modifyAckDeadline(
       name,
       messages.map((m) => m.ackId).toList(),
@@ -188,13 +299,20 @@ final class Subscription {
     );
   }
 
-  /// Modifies the ack deadline for a single message in the background.
+  /// Modifies the ack deadline for [message] in the background.
   ///
-  /// This operation is "fire-and-forget" and does not wait for server
-  /// confirmation. If you require explicit confirmation, use
-  /// [modifyAckDeadlineNow].
+  /// The request is buffered and sent in a batch according to
+  /// [AckSettings.batching] via a unary RPC with retries configured
+  /// by [AckSettings.retry].
+  ///
+  /// To ensure all buffered deadline modifications are delivered before
+  /// application shutdown, call and await [close].
   ///
   /// It is an error if [ackDeadlineSeconds] is negative.
+  /// It is an error if called on a closed [Subscription].
+  ///
+  /// This is a non-blocking, fire-and-forget operation. See
+  /// [modifyAckDeadlineNow] for an immediate, awaitable alternative.
   void modifyAckDeadline(ReceivedMessage message, int ackDeadlineSeconds) {
     if (ackDeadlineSeconds < 0) {
       throw ArgumentError.value(
@@ -203,6 +321,27 @@ final class Subscription {
         'Must be non-negative',
       );
     }
-    unawaited(modifyAckDeadlineNow([message], ackDeadlineSeconds));
+    if (_isClosed) {
+      throw StateError('Cannot modify ack deadline on a closed Subscription.');
+    }
+    _modifyAckBatcher.add(
+      _ModifyAckDeadlineRequest(message.ackId, ackDeadlineSeconds),
+    );
+  }
+
+  /// Closes the subscription, flushing any pending acknowledgments and
+  /// deadline modifications and waiting for in-flight batches to complete.
+  ///
+  /// Calling and awaiting [close] during application shutdown ensures that all
+  /// buffered acknowledgments and deadline modifications are sent before the
+  /// process exits, preventing message redelivery.
+  ///
+  /// Once closed, calls to [acknowledge], [modifyAckDeadline], and [pull] will
+  /// throw [StateError].
+  Future<void> close() {
+    _isClosed = true;
+    return _closeFuture ??= () async {
+      await Future.wait([_ackBatcher.close(), _modifyAckBatcher.close()]);
+    }();
   }
 }

--- a/pkgs/google_cloud_pubsub/lib/src/topic.dart
+++ b/pkgs/google_cloud_pubsub/lib/src/topic.dart
@@ -12,7 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:async';
+
 import '../google_cloud_pubsub.dart';
+import 'batching.dart';
+import 'retry.dart';
+
+/// Settings for background batching and retrying of published messages.
+final class PublishSettings {
+  /// Settings controlling how requests are accumulated and flushed.
+  final BatchingSettings batching;
+
+  /// Settings controlling retries when flushing a batch over a unary RPC.
+  final RetrySettings retry;
+
+  PublishSettings({BatchingSettings? batching, RetrySettings? retry})
+    : batching = batching ?? BatchingSettings(),
+      retry = retry ?? RetrySettings();
+}
+
+final class _PublishRequest {
+  final Message message;
+  final Completer<String> completer;
+
+  _PublishRequest(this.message, this.completer);
+}
 
 /// A [Google Cloud Pub/Sub topic](https://cloud.google.com/pubsub/docs/overview#topics).
 final class Topic {
@@ -28,13 +52,25 @@ final class Topic {
   /// It has the format `projects/<project-id>/topics/<topic-id>`.
   final String name;
 
+  /// Settings for publishing messages.
+  final PublishSettings publishSettings;
+
+  late final Batcher<_PublishRequest> _batcher;
+  bool _isClosed = false;
+  Future<void>? _closeFuture;
+
   /// A topic with the given [topicId] in the client's project.
   ///
   /// It is an error if the constructed topic name is invalid (e.g. if [topicId]
   /// contains slashes).
-  Topic.unqualified(this.pubsub, String topicId)
-    : name = 'projects/${pubsub.projectId}/topics/$topicId' {
+  Topic.unqualified(
+    this.pubsub,
+    String topicId, {
+    PublishSettings? publishSettings,
+  }) : publishSettings = publishSettings ?? PublishSettings(),
+       name = 'projects/${pubsub.projectId}/topics/$topicId' {
     _validateName(name);
+    _initBatcher();
   }
 
   /// A topic with the given [name].
@@ -43,8 +79,57 @@ final class Topic {
   ///
   /// It is an error if [name] is not in the format
   /// `projects/<project-id>/topics/<topic-id>`.
-  Topic(this.pubsub, this.name) {
+  Topic(this.pubsub, this.name, {PublishSettings? publishSettings})
+    : publishSettings = publishSettings ?? PublishSettings() {
     _validateName(name);
+    _initBatcher();
+  }
+
+  void _initBatcher() {
+    _batcher = Batcher<_PublishRequest>(
+      settings: publishSettings.batching,
+      itemSize: (req) {
+        var size = req.message.data.length;
+        for (final entry in req.message.attributes.entries) {
+          size += entry.key.length + entry.value.length;
+        }
+        return size;
+      },
+      onBatch: _onBatch,
+    );
+  }
+
+  Future<void> _onBatch(List<_PublishRequest> batch) async {
+    try {
+      final messages = batch.map((e) => e.message).toList();
+      final messageIds = await runWithRetry(
+        () => pubsub.publishMessages(name, messages),
+        settings: publishSettings.retry,
+        isIdempotent: true,
+      );
+      for (var i = 0; i < batch.length; i++) {
+        if (i < messageIds.length) {
+          if (!batch[i].completer.isCompleted) {
+            batch[i].completer.complete(messageIds[i]);
+          }
+        } else {
+          if (!batch[i].completer.isCompleted) {
+            batch[i].completer.completeError(
+              StateError(
+                'Server returned fewer message IDs (${messageIds.length}) '
+                'than published messages (${batch.length}).',
+              ),
+            );
+          }
+        }
+      }
+    } catch (e, st) {
+      for (final item in batch) {
+        if (!item.completer.isCompleted) {
+          item.completer.completeError(e, st);
+        }
+      }
+    }
   }
 
   static void _validateName(String name) {
@@ -72,7 +157,10 @@ final class Topic {
   /// Returns a [Topic] instance representing the created topic.
   ///
   /// See the [official documentation](https://cloud.google.com/pubsub/docs/reference/rpc/google.pubsub.v1#google.pubsub.v1.Publisher.CreateTopic).
-  Future<Topic> create() => pubsub.createTopic(name);
+  Future<Topic> create() async {
+    await pubsub.createTopic(name);
+    return this;
+  }
 
   /// Deletes this topic on the server.
   ///
@@ -86,15 +174,44 @@ final class Topic {
   /// See the [official documentation](https://cloud.google.com/pubsub/docs/reference/rpc/google.pubsub.v1#google.pubsub.v1.Publisher.DeleteTopic).
   Future<void> delete() => pubsub.deleteTopic(name);
 
-  /// Adds one or more messages to the topic.
+  /// Adds a message to the topic.
   ///
+  /// The message is placed into a background buffer and published in a batch
+  /// according to [publishSettings] batching configuration. If transient
+  /// network errors occur during publishing, the batch is automatically
+  /// retried according to [publishSettings] retry configuration.
+  ///
+  /// To ensure all buffered messages are published before application shutdown,
+  /// call and await [close].
+  ///
+  /// It is an error if called on a closed [Topic].
   /// Throws a [NotFoundException] if the topic does not exist.
+  /// Throws a [ServiceException] if publishing fails after retries.
   ///
   /// [data] is the message content.
   /// [attributes] are optional attributes for the message.
   ///
   /// See the [official documentation](https://cloud.google.com/pubsub/docs/reference/rpc/google.pubsub.v1#google.pubsub.v1.Publisher.Publish).
-  // TODO(sigurdm): Support batch publishing (publishMany) for high-throughput.
-  Future<String> publish(List<int> data, {Map<String, String>? attributes}) =>
-      pubsub.publish(name, data, attributes: attributes);
+  Future<String> publish(List<int> data, {Map<String, String>? attributes}) {
+    if (_isClosed) {
+      throw StateError('Cannot publish to a closed Topic.');
+    }
+    final completer = Completer<String>();
+    _batcher.add(
+      _PublishRequest(Message(data: data, attributes: attributes), completer),
+    );
+    return completer.future;
+  }
+
+  /// Closes the topic, flushing any pending messages and waiting for in-flight
+  /// batches to complete.
+  ///
+  /// Calling and awaiting [close] during application shutdown ensures that all
+  /// buffered messages are published before the process exits.
+  ///
+  /// Once closed, calls to [publish] will throw [StateError].
+  Future<void> close() {
+    _isClosed = true;
+    return _closeFuture ??= _batcher.close();
+  }
 }

--- a/pkgs/google_cloud_pubsub/pubspec.yaml
+++ b/pkgs/google_cloud_pubsub/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
 resolution: workspace
 
 dependencies:
+  clock: ^1.1.0
   ffi: ^2.2.0
   fixnum: ^1.1.1
   google_cloud_rpc: ^0.6.0

--- a/pkgs/google_cloud_pubsub/test/batching_test.dart
+++ b/pkgs/google_cloud_pubsub/test/batching_test.dart
@@ -1,0 +1,264 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('vm')
+library;
+
+import 'dart:async';
+
+import 'package:google_cloud_pubsub/src/batching.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Batcher', () {
+    test('flushes when maxMessages is reached', () async {
+      final completer = Completer<List<int>>();
+      Batcher<int>(
+          settings: BatchingSettings(
+            maxMessages: 3,
+            maxDelay: const Duration(seconds: 1),
+          ),
+          itemSize: (i) => 1,
+          onBatch: (batch) async {
+            completer.complete(batch);
+          },
+        )
+        ..add(1)
+        ..add(2)
+        ..add(3);
+
+      final result = await completer.future;
+      expect(result, [1, 2, 3]);
+    });
+
+    test('flushes when maxBytes is reached', () async {
+      final completer = Completer<List<int>>();
+      Batcher<int>(
+          settings: BatchingSettings(
+            maxBytes: 10,
+            maxDelay: const Duration(seconds: 1),
+          ),
+          itemSize: (i) => i,
+          onBatch: (batch) async {
+            completer.complete(batch);
+          },
+        )
+        ..add(4)
+        ..add(6); // 4 + 6 = 10, which reaches maxBytes
+
+      final result = await completer.future;
+      expect(result, [4, 6]);
+    });
+
+    test('flushes after maxDelay', () async {
+      final completer = Completer<List<int>>();
+      Batcher<int>(
+          settings: BatchingSettings(
+            maxMessages: 10,
+            maxDelay: const Duration(milliseconds: 100),
+          ),
+          itemSize: (i) => 1,
+          onBatch: (batch) async {
+            completer.complete(batch);
+          },
+        )
+        ..add(1)
+        ..add(2);
+
+      final result = await completer.future;
+      expect(result, [1, 2]);
+    });
+
+    test('close flushes pending items and awaits in-flight batches', () async {
+      final inFlightCompleter = Completer<void>();
+      var batchStarted = false;
+      var batchCompleted = false;
+
+      final batcher = Batcher<int>(
+        settings: BatchingSettings(
+          maxMessages: 10,
+          maxDelay: const Duration(seconds: 10),
+        ),
+        itemSize: (i) => 1,
+        onBatch: (batch) async {
+          batchStarted = true;
+          await inFlightCompleter.future;
+          batchCompleted = true;
+        },
+      )..add(42);
+
+      var closeFinished = false;
+      final closeFuture = batcher.close().then((_) {
+        closeFinished = true;
+      });
+
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(batchStarted, isTrue);
+      expect(closeFinished, isFalse);
+
+      inFlightCompleter.complete();
+      await closeFuture;
+
+      expect(batchCompleted, isTrue);
+      expect(closeFinished, isTrue);
+    });
+
+    test('calling add after close throws StateError', () async {
+      final batcher = Batcher<int>(
+        settings: BatchingSettings(maxMessages: 10),
+        itemSize: (i) => 1,
+        onBatch: (_) async {},
+      );
+
+      await batcher.close();
+      expect(() => batcher.add(1), throwsStateError);
+    });
+
+    test('synchronous throws from onBatch are safely caught', () async {
+      var threw = false;
+      final batcher = Batcher<int>(
+        settings: BatchingSettings(
+          maxMessages: 1,
+          maxDelay: const Duration(milliseconds: 10),
+        ),
+        itemSize: (i) => 1,
+        onBatch: (batch) {
+          threw = true;
+          throw Exception('sync throw in onBatch');
+        },
+      );
+
+      // add(1) triggers immediate flush because maxMessages: 1.
+      // Should not throw synchronously from add.
+      expect(() => batcher.add(1), returnsNormally);
+      expect(threw, isTrue);
+
+      // close() should complete without unhandled exception
+      await expectLater(batcher.close(), completes);
+    });
+  });
+
+  group('BatchingSettings', () {
+    test('defaults are initialized correctly', () {
+      final settings = BatchingSettings();
+      expect(settings.maxMessages, equals(100));
+      expect(settings.maxBytes, equals(1024 * 1024));
+      expect(settings.maxDelay, equals(const Duration(milliseconds: 10)));
+    });
+
+    test('parameter validation throws ArgumentError', () {
+      expect(
+        () => BatchingSettings(maxMessages: 0),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => BatchingSettings(maxMessages: -1),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => BatchingSettings(maxBytes: 0),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => BatchingSettings(maxBytes: -10),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => BatchingSettings(maxDelay: Duration.zero),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => BatchingSettings(maxDelay: const Duration(milliseconds: -1)),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => BatchingSettings(maxDelay: const Duration(seconds: -10)),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('parameter validation error messages are harmonized', () {
+      expect(
+        () => BatchingSettings(maxMessages: 0),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            'Must be greater than zero',
+          ),
+        ),
+      );
+      expect(
+        () => BatchingSettings(maxMessages: -1),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            'Must be greater than zero',
+          ),
+        ),
+      );
+      expect(
+        () => BatchingSettings(maxBytes: 0),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            'Must be greater than zero',
+          ),
+        ),
+      );
+      expect(
+        () => BatchingSettings(maxBytes: -10),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            'Must be greater than zero',
+          ),
+        ),
+      );
+      expect(
+        () => BatchingSettings(maxDelay: Duration.zero),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            'Must be greater than zero',
+          ),
+        ),
+      );
+      expect(
+        () => BatchingSettings(maxDelay: const Duration(milliseconds: -1)),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            'Must be greater than zero',
+          ),
+        ),
+      );
+      expect(
+        () => BatchingSettings(maxDelay: const Duration(seconds: -10)),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            'Must be greater than zero',
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/pkgs/google_cloud_pubsub/test/lifecycle_test.dart
+++ b/pkgs/google_cloud_pubsub/test/lifecycle_test.dart
@@ -1,0 +1,579 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('vm')
+library;
+
+import 'dart:async';
+
+import 'package:google_cloud_pubsub/google_cloud_pubsub.dart';
+import 'package:google_cloud_pubsub/src/generated/google/pubsub/v1/pubsub.pbgrpc.dart'
+    as generated;
+import 'package:grpc/grpc.dart' as grpc;
+import 'package:protobuf/well_known_types/google/protobuf/empty.pb.dart'
+    as protobuf;
+import 'package:test/fake.dart';
+import 'package:test/test.dart';
+
+class FakeResponseFuture<T> extends Fake implements grpc.ResponseFuture<T> {
+  final Future<T> _future;
+
+  FakeResponseFuture(this._future);
+
+  @override
+  Future<S> then<S>(
+    FutureOr<S> Function(T value) onValue, {
+    Function? onError,
+  }) => _future.then(
+    onValue,
+    onError: (Object e, StackTrace s) {
+      if (onError != null) {
+        if (onError is FutureOr<S> Function(Object, StackTrace)) {
+          onError(e, s);
+        } else if (onError is FutureOr<S> Function(Object)) {
+          onError(e);
+        } else {
+          // ignore: avoid_dynamic_calls
+          (onError as dynamic)(e, s);
+        }
+      }
+    },
+  );
+
+  @override
+  Future<T> catchError(Function onError, {bool Function(Object)? test}) =>
+      _future.catchError(onError, test: test);
+
+  @override
+  Future<T> whenComplete(FutureOr<void> Function() action) =>
+      _future.whenComplete(action);
+}
+
+class FakePublisherClient extends Fake implements generated.PublisherClient {
+  Future<generated.PublishResponse> Function(generated.PublishRequest request)?
+  publishBehavior;
+  bool publishCalled = false;
+
+  @override
+  grpc.ResponseFuture<generated.PublishResponse> publish(
+    generated.PublishRequest request, {
+    grpc.CallOptions? options,
+  }) {
+    publishCalled = true;
+    final completer = Completer<generated.PublishResponse>();
+    if (publishBehavior case final publish?) {
+      publish(
+        request,
+      ).then(completer.complete).catchError(completer.completeError);
+    } else {
+      final response = generated.PublishResponse()
+        ..messageIds.addAll(
+          List.generate(request.messages.length, (i) => 'msg-$i'),
+        );
+      completer.complete(response);
+    }
+    return FakeResponseFuture(completer.future);
+  }
+
+  @override
+  grpc.ResponseFuture<generated.Topic> createTopic(
+    generated.Topic request, {
+    grpc.CallOptions? options,
+  }) => FakeResponseFuture(Future.value(request));
+}
+
+class FakeSubscriberClient extends Fake implements generated.SubscriberClient {
+  Future<void> Function(List<String> ackIds)? acknowledgeBehavior;
+  bool acknowledgeCalled = false;
+  List<String>? lastAckIds;
+
+  bool modifyAckDeadlineCalled = false;
+  List<String>? lastModifyAckDeadlineIds;
+  int? lastModifyAckDeadlineSeconds;
+
+  bool pullCalled = false;
+  int? lastMaxMessages;
+
+  @override
+  grpc.ResponseFuture<protobuf.Empty> acknowledge(
+    generated.AcknowledgeRequest request, {
+    grpc.CallOptions? options,
+  }) {
+    acknowledgeCalled = true;
+    lastAckIds = request.ackIds;
+    final completer = Completer<protobuf.Empty>();
+    if (acknowledgeBehavior case final ack?) {
+      ack(request.ackIds)
+          .then((_) => completer.complete(protobuf.Empty()))
+          .catchError(completer.completeError);
+    } else {
+      completer.complete(protobuf.Empty());
+    }
+    return FakeResponseFuture(completer.future);
+  }
+
+  @override
+  grpc.ResponseFuture<protobuf.Empty> modifyAckDeadline(
+    generated.ModifyAckDeadlineRequest request, {
+    grpc.CallOptions? options,
+  }) {
+    modifyAckDeadlineCalled = true;
+    lastModifyAckDeadlineIds = request.ackIds;
+    lastModifyAckDeadlineSeconds = request.ackDeadlineSeconds;
+    return FakeResponseFuture(Future.value(protobuf.Empty()));
+  }
+
+  @override
+  grpc.ResponseFuture<generated.PullResponse> pull(
+    generated.PullRequest request, {
+    grpc.CallOptions? options,
+  }) {
+    pullCalled = true;
+    lastMaxMessages = request.maxMessages;
+    return FakeResponseFuture(Future.value(generated.PullResponse()));
+  }
+
+  @override
+  grpc.ResponseFuture<generated.Subscription> createSubscription(
+    generated.Subscription request, {
+    grpc.CallOptions? options,
+  }) => FakeResponseFuture(Future.value(request));
+}
+
+class FakeClientChannel extends Fake implements grpc.ClientChannel {
+  @override
+  Future<void> shutdown() async {}
+}
+
+void main() {
+  group('Topic Lifecycle & Batcher', () {
+    late FakePublisherClient fakePublisher;
+    late PubSub client;
+
+    setUp(() {
+      fakePublisher = FakePublisherClient();
+      client = PubSub.testing(
+        projectId: 'test-project',
+        channel: FakeClientChannel(),
+        publisherClient: fakePublisher,
+      );
+    });
+
+    tearDown(() async {
+      await client.close();
+    });
+
+    test('Topic.close() awaits in-flight batches before completing', () async {
+      final publishCompleter = Completer<generated.PublishResponse>();
+      fakePublisher.publishBehavior = (request) async =>
+          publishCompleter.future;
+
+      final topic = client.topic(
+        'my-topic',
+        publishSettings: PublishSettings(
+          batching: BatchingSettings(
+            maxMessages: 10,
+            maxDelay: const Duration(seconds: 10),
+          ),
+        ),
+      );
+
+      final pubFuture = topic.publish([1, 2, 3]);
+
+      var closeCompleted = false;
+      final closeFuture = topic.close().then((_) {
+        closeCompleted = true;
+      });
+
+      // Allow flush to start the RPC
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(closeCompleted, isFalse);
+
+      // Complete the in-flight publish RPC
+      publishCompleter.complete(
+        generated.PublishResponse()..messageIds.add('id-123'),
+      );
+
+      final messageId = await pubFuture;
+      expect(messageId, equals('id-123'));
+
+      await closeFuture;
+      expect(closeCompleted, isTrue);
+    });
+
+    test('Topic.publish after close throws StateError', () async {
+      final topic = client.topic('my-topic');
+      await topic.close();
+
+      expect(() => topic.publish([1, 2, 3]), throwsStateError);
+    });
+
+    test('Topic._onBatch handles fewer message IDs without hanging', () async {
+      fakePublisher.publishBehavior =
+          // Backend returns only 1 message ID when 3 messages were sent
+          (request) async =>
+              generated.PublishResponse()..messageIds.add('id-only-one');
+
+      final topic = client.topic(
+        'my-topic',
+        publishSettings: PublishSettings(
+          batching: BatchingSettings(
+            maxMessages: 3,
+            maxDelay: const Duration(seconds: 10),
+          ),
+        ),
+      );
+
+      final f1 = topic.publish([1]);
+      final f2 = topic.publish([2]);
+      final f3 = topic.publish([3]);
+
+      // First should succeed
+      expect(await f1, equals('id-only-one'));
+
+      // Remaining should fail with StateError, not hang
+      await expectLater(f2, throwsStateError);
+      await expectLater(f3, throwsStateError);
+    });
+
+    test('Topic._onBatch completes all with error if backend fails', () async {
+      fakePublisher.publishBehavior = (request) async {
+        throw const grpc.GrpcError.notFound('Topic not found');
+      };
+
+      final topic = client.topic(
+        'my-topic',
+        publishSettings: PublishSettings(
+          batching: BatchingSettings(
+            maxMessages: 2,
+            maxDelay: const Duration(seconds: 10),
+          ),
+        ),
+      );
+
+      final f1 = topic.publish([1]);
+      final f2 = topic.publish([2]);
+
+      await expectLater(f1, throwsA(isA<NotFoundException>()));
+      await expectLater(f2, throwsA(isA<NotFoundException>()));
+    });
+
+    test(
+      'Topic._initBatcher calculates message size with attribute byte lengths',
+      () async {
+        final completer = Completer<void>();
+        fakePublisher.publishBehavior = (request) async {
+          completer.complete();
+          return generated.PublishResponse()
+            ..messageIds.addAll(
+              List.generate(request.messages.length, (i) => 'msg-$i'),
+            );
+        };
+
+        // Set maxBytes to 12. If attributes are included, 1 message flushes.
+        // Data = 5 bytes, key = 3 ("abc"), value = 4 ("1234") -> 12 bytes.
+        final topic = client.topic(
+          'my-topic',
+          publishSettings: PublishSettings(
+            batching: BatchingSettings(
+              maxBytes: 12,
+              maxDelay: const Duration(seconds: 10),
+            ),
+          ),
+        );
+
+        unawaited(topic.publish([1, 2, 3, 4, 5], attributes: {'abc': '1234'}));
+
+        await expectLater(
+          completer.future.timeout(const Duration(milliseconds: 500)),
+          completes,
+        );
+
+        await topic.close();
+      },
+    );
+
+    test(
+      'PubSub.publishMessages with empty list returns immediately',
+      () async {
+        final messageIds = await client.publishMessages(
+          'projects/test-project/topics/my-topic',
+          [],
+        );
+        expect(messageIds, isEmpty);
+        expect(fakePublisher.publishCalled, isFalse);
+      },
+    );
+
+    test('Topic.create() returns this and preserves publishSettings', () async {
+      final customSettings = PublishSettings(
+        batching: BatchingSettings(maxMessages: 42),
+      );
+      final topic = client.topic('my-topic', publishSettings: customSettings);
+      final created = await topic.create();
+      expect(identical(created, topic), isTrue);
+      expect(created.publishSettings, same(customSettings));
+      expect(created.publishSettings.batching.maxMessages, equals(42));
+    });
+  });
+
+  group('Subscription Lifecycle & Batcher', () {
+    late FakeSubscriberClient fakeSubscriber;
+    late PubSub client;
+
+    setUp(() {
+      fakeSubscriber = FakeSubscriberClient();
+      client = PubSub.testing(
+        projectId: 'test-project',
+        channel: FakeClientChannel(),
+        subscriberClient: fakeSubscriber,
+      );
+    });
+
+    tearDown(() async {
+      await client.close();
+    });
+
+    test(
+      'Subscription.close() awaits in-flight batches before completing',
+      () async {
+        final ackCompleter = Completer<void>();
+        fakeSubscriber.acknowledgeBehavior = (ackIds) async =>
+            ackCompleter.future;
+
+        final sub = client.subscription(
+          'my-sub',
+          ackSettings: AckSettings(
+            batching: BatchingSettings(
+              maxMessages: 10,
+              maxDelay: const Duration(seconds: 10),
+            ),
+          ),
+        );
+
+        final msg = ReceivedMessage(
+          ackId: 'ack-1',
+          messageId: 'msg-1',
+          publishTime: DateTime.now(),
+          message: Message(data: [1, 2, 3]),
+        );
+
+        sub.acknowledge(msg);
+
+        var closeCompleted = false;
+        final closeFuture = sub.close().then((_) {
+          closeCompleted = true;
+        });
+
+        // Batch starts on flush from close()
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        expect(fakeSubscriber.acknowledgeCalled, isTrue);
+        expect(closeCompleted, isFalse);
+
+        // Finish the ack RPC
+        ackCompleter.complete();
+        await closeFuture;
+
+        expect(closeCompleted, isTrue);
+      },
+    );
+
+    test('Subscription operations after close throw StateError', () async {
+      final sub = client.subscription('my-sub');
+      await sub.close();
+
+      final msg = ReceivedMessage(
+        ackId: 'ack-1',
+        messageId: 'msg-1',
+        publishTime: DateTime.now(),
+        message: Message(data: [1]),
+      );
+
+      expect(() => sub.acknowledge(msg), throwsStateError);
+      expect(() => sub.modifyAckDeadline(msg, 10), throwsStateError);
+      expect(() => sub.acknowledgeNow([msg]), throwsStateError);
+      expect(() => sub.modifyAckDeadlineNow([msg], 10), throwsStateError);
+      expect(sub.pull, throwsStateError);
+    });
+
+    test('Subscription.pull validation and closed check', () async {
+      final sub = client.subscription('my-sub');
+
+      expect(() => sub.pull(maxMessages: 0), throwsArgumentError);
+      expect(() => sub.pull(maxMessages: -1), throwsArgumentError);
+      expect(
+        () => client.pull(
+          'projects/test-project/subscriptions/my-sub',
+          maxMessages: 0,
+        ),
+        throwsArgumentError,
+      );
+
+      await sub.close();
+      expect(sub.pull, throwsStateError);
+    });
+
+    test(
+      'empty list no-ops for acknowledgeNow and modifyAckDeadlineNow',
+      () async {
+        final sub = client.subscription('my-sub');
+        await sub.acknowledgeNow([]);
+        expect(fakeSubscriber.acknowledgeCalled, isFalse);
+
+        await sub.modifyAckDeadlineNow([], 10);
+        expect(fakeSubscriber.modifyAckDeadlineCalled, isFalse);
+      },
+    );
+
+    test(
+      'Subscription.create() returns this and preserves ackSettings',
+      () async {
+        final customSettings = AckSettings(
+          batching: BatchingSettings(maxMessages: 42),
+        );
+        final sub = client.subscription('my-sub', ackSettings: customSettings);
+        final created = await sub.create(
+          topic: 'projects/test-project/topics/my-topic',
+        );
+        expect(identical(created, sub), isTrue);
+        expect(created.ackSettings, same(customSettings));
+        expect(created.ackSettings.batching.maxMessages, equals(42));
+      },
+    );
+  });
+
+  group('PubSub Client Empty List No-Ops & Parameter Validation', () {
+    late FakePublisherClient fakePublisher;
+    late FakeSubscriberClient fakeSubscriber;
+    late PubSub client;
+
+    setUp(() {
+      fakePublisher = FakePublisherClient();
+      fakeSubscriber = FakeSubscriberClient();
+      client = PubSub.testing(
+        projectId: 'test-project',
+        channel: FakeClientChannel(),
+        publisherClient: fakePublisher,
+        subscriberClient: fakeSubscriber,
+      );
+    });
+
+    tearDown(() async {
+      await client.close();
+    });
+
+    test(
+      'publishMessages with empty list returns empty without calling backend',
+      () async {
+        final result = await client.publishMessages(
+          'projects/test-project/topics/my-topic',
+          [],
+        );
+        expect(result, isEmpty);
+        expect(fakePublisher.publishCalled, isFalse);
+      },
+    );
+
+    test(
+      'acknowledge with empty list returns without calling backend',
+      () async {
+        await client.acknowledge(
+          'projects/test-project/subscriptions/my-sub',
+          [],
+        );
+        expect(fakeSubscriber.acknowledgeCalled, isFalse);
+      },
+    );
+
+    test(
+      'modifyAckDeadline with empty list returns without calling backend',
+      () async {
+        await client.modifyAckDeadline(
+          'projects/test-project/subscriptions/my-sub',
+          [],
+          10,
+        );
+        expect(fakeSubscriber.modifyAckDeadlineCalled, isFalse);
+      },
+    );
+
+    test('modifyAckDeadline validates ackDeadlineSeconds >= 0', () {
+      expect(
+        () => client.modifyAckDeadline(
+          'projects/test-project/subscriptions/my-sub',
+          ['ack-1'],
+          -1,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => client.modifyAckDeadline(
+          'projects/test-project/subscriptions/my-sub',
+          [],
+          -1,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test(
+      'streamingPull validates streamAckDeadlineSeconds between 10 and 600',
+      () {
+        expect(
+          () => client.streamingPull(
+            'projects/test-project/subscriptions/my-sub',
+            streamAckDeadlineSeconds: 9,
+          ),
+          throwsA(isA<ArgumentError>()),
+        );
+        expect(
+          () => client.streamingPull(
+            'projects/test-project/subscriptions/my-sub',
+            streamAckDeadlineSeconds: 601,
+          ),
+          throwsA(isA<ArgumentError>()),
+        );
+      },
+    );
+    test('pull validates maxMessages > 0', () {
+      expect(
+        () => client.pull(
+          'projects/test-project/subscriptions/my-sub',
+          maxMessages: 0,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => client.pull(
+          'projects/test-project/subscriptions/my-sub',
+          maxMessages: -1,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('PubSub.pull defaults to maxMessages 1', () async {
+      await client.pull('projects/test-project/subscriptions/my-sub');
+      expect(fakeSubscriber.pullCalled, isTrue);
+      expect(fakeSubscriber.lastMaxMessages, equals(1));
+    });
+
+    test('Subscription.pull defaults to maxMessages 1', () async {
+      final sub = client.subscription('my-sub');
+      await sub.pull();
+      expect(fakeSubscriber.pullCalled, isTrue);
+      expect(fakeSubscriber.lastMaxMessages, equals(1));
+    });
+  });
+}

--- a/pkgs/google_cloud_pubsub/test/retry_test.dart
+++ b/pkgs/google_cloud_pubsub/test/retry_test.dart
@@ -1,0 +1,537 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('vm')
+library;
+
+import 'dart:math';
+
+import 'package:clock/clock.dart';
+import 'package:google_cloud_pubsub/google_cloud_pubsub.dart';
+import 'package:google_cloud_pubsub/src/retry.dart';
+import 'package:google_cloud_rpc/rpc.dart';
+import 'package:grpc/grpc.dart' as grpc;
+import 'package:test/test.dart';
+
+void main() {
+  group('isRetryable', () {
+    test('ALREADY_EXISTS (gRPC code 6) must NOT be retried', () {
+      const error = grpc.GrpcError.custom(
+        grpc.StatusCode.alreadyExists,
+        'Already exists',
+      );
+      expect(isRetryable(error), isFalse);
+    });
+
+    test('ConflictException must NOT be retried', () {
+      final error = ConflictException('Already exists conflict');
+      expect(isRetryable(error), isFalse);
+    });
+
+    test('deterministic client errors are not retryable', () {
+      expect(isRetryable(NotFoundException('not found')), isFalse);
+      expect(isRetryable(ForbiddenException('forbidden')), isFalse);
+      expect(isRetryable(BadRequestException('bad request')), isFalse);
+      expect(isRetryable(UnauthorizedException('unauthorized')), isFalse);
+      expect(isRetryable(PreconditionFailedException('precondition')), isFalse);
+      expect(
+        isRetryable(
+          const grpc.GrpcError.custom(
+            grpc.StatusCode.invalidArgument,
+            'invalid argument',
+          ),
+        ),
+        isFalse,
+      );
+      expect(
+        isRetryable(
+          const grpc.GrpcError.custom(grpc.StatusCode.notFound, 'not found'),
+        ),
+        isFalse,
+      );
+      expect(
+        isRetryable(
+          const grpc.GrpcError.custom(
+            grpc.StatusCode.permissionDenied,
+            'permission denied',
+          ),
+        ),
+        isFalse,
+      );
+      expect(
+        isRetryable(
+          const grpc.GrpcError.custom(
+            grpc.StatusCode.unauthenticated,
+            'unauthenticated',
+          ),
+        ),
+        isFalse,
+      );
+      expect(
+        isRetryable(
+          const grpc.GrpcError.custom(
+            grpc.StatusCode.unimplemented,
+            'unimplemented',
+          ),
+        ),
+        isFalse,
+      );
+    });
+
+    test('transient errors are retryable', () {
+      expect(isRetryable(const grpc.GrpcError.aborted('aborted')), isTrue);
+      expect(
+        isRetryable(const grpc.GrpcError.unavailable('service unavailable')),
+        isTrue,
+      );
+      expect(
+        isRetryable(const grpc.GrpcError.deadlineExceeded('deadline exceeded')),
+        isTrue,
+      );
+      expect(
+        isRetryable(const grpc.GrpcError.internal('internal error')),
+        isTrue,
+      );
+      expect(
+        isRetryable(
+          const grpc.GrpcError.resourceExhausted('resource exhausted'),
+        ),
+        isTrue,
+      );
+      expect(isRetryable(const grpc.GrpcError.unknown('unknown')), isTrue);
+      expect(
+        isRetryable(ServiceUnavailableException('service unavailable')),
+        isTrue,
+      );
+      expect(isRetryable(GatewayTimeoutException('timeout')), isTrue);
+      expect(
+        isRetryable(TooManyRequestsException('too many requests')),
+        isTrue,
+      );
+      expect(
+        isRetryable(InternalServerErrorException('internal server error')),
+        isTrue,
+      );
+    });
+
+    test('non-Exception objects are not retryable', () {
+      expect(isRetryable(StateError('state error')), isFalse);
+      expect(isRetryable(ArgumentError('argument error')), isFalse);
+      expect(isRetryable('string error'), isFalse);
+    });
+
+    test('StatusCode.aborted is retryable for raw and mapped exceptions', () {
+      expect(isRetryable(const grpc.GrpcError.aborted('aborted')), isTrue);
+      expect(
+        isRetryable(
+          ConflictException(
+            'aborted',
+            status: Status(code: grpc.StatusCode.aborted, message: 'aborted'),
+          ),
+        ),
+        isTrue,
+      );
+      expect(
+        isRetryable(
+          ServiceException(
+            'aborted',
+            statusCode: 500,
+            status: Status(code: grpc.StatusCode.aborted, message: 'aborted'),
+          ),
+        ),
+        isTrue,
+      );
+      // Plain ConflictException without aborted is NOT retryable
+      expect(isRetryable(ConflictException('conflict')), isFalse);
+    });
+
+    test('BadGatewayException and RequestTimeoutException are retryable', () {
+      expect(isRetryable(BadGatewayException('bad gateway')), isTrue);
+      expect(isRetryable(RequestTimeoutException('request timeout')), isTrue);
+    });
+
+    test(
+      'StatusCode.dataLoss is NOT retryable for raw and mapped exceptions',
+      () {
+        expect(
+          isRetryable(
+            const grpc.GrpcError.custom(grpc.StatusCode.dataLoss, 'data loss'),
+          ),
+          isFalse,
+        );
+        expect(
+          isRetryable(
+            ServiceException(
+              'data loss',
+              statusCode: grpc.StatusCode.dataLoss,
+              status: Status(
+                code: grpc.StatusCode.dataLoss,
+                message: 'data loss',
+              ),
+            ),
+          ),
+          isFalse,
+        );
+        expect(
+          isRetryable(
+            InternalServerErrorException(
+              'data loss',
+              status: Status(
+                code: grpc.StatusCode.dataLoss,
+                message: 'data loss',
+              ),
+            ),
+          ),
+          isFalse,
+        );
+      },
+    );
+  });
+
+  group('RetrySettings', () {
+    test('defaults', () {
+      final settings = RetrySettings();
+      expect(settings.totalTimeout, equals(const Duration(minutes: 1)));
+      expect(settings.initialDelay, equals(const Duration(milliseconds: 100)));
+      expect(settings.delayMultiplier, equals(1.3));
+      expect(settings.maxDelay, equals(const Duration(seconds: 60)));
+      expect(settings.maxRetries, isNull);
+
+      final unlimited = settings.copyWith(totalTimeout: null);
+      expect(unlimited.totalTimeout, isNull);
+    });
+
+    test('parameter validation throws ArgumentError for invalid values', () {
+      expect(
+        () => RetrySettings(maxRetries: -1),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => RetrySettings(maxRetries: -10),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => RetrySettings(delayMultiplier: -1.0),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => RetrySettings(delayMultiplier: 0.0),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => RetrySettings(delayMultiplier: 0.5),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => RetrySettings(initialDelay: Duration.zero),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => RetrySettings(initialDelay: const Duration(seconds: -1)),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => RetrySettings(maxDelay: Duration.zero),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => RetrySettings(maxDelay: const Duration(seconds: -1)),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => RetrySettings(totalTimeout: Duration.zero),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => RetrySettings(totalTimeout: const Duration(seconds: -1)),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => RetrySettings(totalTimeout: const Duration(microseconds: -1)),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => RetrySettings(delayMultiplier: double.infinity),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => RetrySettings(delayMultiplier: double.nan),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => RetrySettings().copyWith(totalTimeout: 'invalid'),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => RetrySettings().copyWith(maxRetries: 'invalid'),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('valid parameter edge cases succeed', () {
+      final zeroRetries = RetrySettings(maxRetries: 0);
+      expect(zeroRetries.maxRetries, equals(0));
+
+      final minMultiplier = RetrySettings(delayMultiplier: 1.0);
+      expect(minMultiplier.delayMultiplier, equals(1.0));
+
+      final nullTimeout = RetrySettings(totalTimeout: null);
+      expect(nullTimeout.totalTimeout, isNull);
+    });
+
+    test('copyWith parameter validation throws ArgumentError', () {
+      final base = RetrySettings();
+
+      expect(
+        () => base.copyWith(maxRetries: -1),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => base.copyWith(maxRetries: -5),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => base.copyWith(maxRetries: 'invalid'),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => base.copyWith(delayMultiplier: -1.0),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => base.copyWith(delayMultiplier: 0.0),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => base.copyWith(delayMultiplier: 0.99),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => base.copyWith(delayMultiplier: double.infinity),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => base.copyWith(delayMultiplier: double.nan),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => base.copyWith(initialDelay: Duration.zero),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => base.copyWith(initialDelay: const Duration(milliseconds: -10)),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => base.copyWith(maxDelay: Duration.zero),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => base.copyWith(maxDelay: const Duration(seconds: -1)),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => base.copyWith(totalTimeout: Duration.zero),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => base.copyWith(totalTimeout: const Duration(seconds: -1)),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => base.copyWith(totalTimeout: const Duration(microseconds: -1)),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => base.copyWith(totalTimeout: 'invalid'),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      final updated = base.copyWith(
+        maxRetries: 0,
+        delayMultiplier: 1.0,
+        totalTimeout: null,
+      );
+      expect(updated.maxRetries, equals(0));
+      expect(updated.delayMultiplier, equals(1.0));
+      expect(updated.totalTimeout, isNull);
+    });
+  });
+
+  group('delaySequence and randomized jitter', () {
+    test('randomized jitter produces varied delays within ±20% bounds', () {
+      const initialDelay = Duration(milliseconds: 100);
+      const maxDelay = Duration(seconds: 10);
+      const multiplier = 2.0;
+
+      final delays = delaySequence(
+        maxRetries: 5,
+        totalTimeout: const Duration(minutes: 5),
+        initialDelay: initialDelay,
+        maxDelay: maxDelay,
+        delayMultiplier: multiplier,
+      ).toList();
+
+      expect(delays.length, equals(5));
+
+      for (var i = 0; i < delays.length; i++) {
+        final base = initialDelay * pow(multiplier, i);
+        final minBound = Duration(
+          microseconds: (base.inMicroseconds * 0.799).round(),
+        );
+        final maxBound = Duration(
+          microseconds: (base.inMicroseconds * 1.201).round(),
+        );
+        expect(
+          delays[i] >= minBound && delays[i] <= maxBound,
+          isTrue,
+          reason:
+              'Step $i delay ${delays[i]} should be between '
+              '$minBound and $maxBound',
+        );
+      }
+    });
+
+    test('multiple sequences produce varied delays due to randomness', () {
+      const initialDelay = Duration(milliseconds: 100);
+      const maxDelay = Duration(seconds: 10);
+
+      final seq1 = delaySequence(
+        maxRetries: 10,
+        initialDelay: initialDelay,
+        maxDelay: maxDelay,
+        delayMultiplier: 1.5,
+      ).toList();
+
+      final seq2 = delaySequence(
+        maxRetries: 10,
+        initialDelay: initialDelay,
+        maxDelay: maxDelay,
+        delayMultiplier: 1.5,
+      ).toList();
+
+      expect(seq1, isNot(equals(seq2)));
+    });
+
+    test('clamps to maxDelay with jitter applied to maxDelay', () {
+      const initialDelay = Duration(seconds: 1);
+      const maxDelay = Duration(seconds: 2);
+      const multiplier = 3.0;
+
+      final delays = delaySequence(
+        maxRetries: 5,
+        initialDelay: initialDelay,
+        maxDelay: maxDelay,
+        delayMultiplier: multiplier,
+      ).toList();
+
+      // Step 0: base 1s -> [800ms, 1200ms]
+      expect(delays[0].inMicroseconds, inInclusiveRange(800000, 1200000));
+
+      // Step 1: raw 3s >= max 2s -> base 2s -> [1600ms, 2400ms]
+      expect(delays[1].inMicroseconds, inInclusiveRange(1600000, 2400000));
+
+      // Step 2: raw 9s >= max 2s -> base 2s -> [1600ms, 2400ms]
+      expect(delays[2].inMicroseconds, inInclusiveRange(1600000, 2400000));
+    });
+
+    test('stops yielding after totalTimeout', () {
+      var currentTime = DateTime(2026, 1, 1, 0, 0, 0);
+      final testClock = Clock(() => currentTime);
+
+      final delays = delaySequence(
+        totalTimeout: const Duration(seconds: 5),
+        initialDelay: const Duration(seconds: 1),
+        maxDelay: const Duration(seconds: 1),
+        delayMultiplier: 1.0,
+        clock: testClock,
+      ).iterator;
+
+      var yieldedCount = 0;
+      while (delays.moveNext()) {
+        yieldedCount++;
+        currentTime = currentTime.add(const Duration(seconds: 2));
+      }
+
+      // At t=0: yields step 1, currentTime advances to 2s
+      // At t=2: yields step 2, currentTime advances to 4s
+      // At t=4: yields step 3, currentTime advances to 6s
+      // At t=6: 6s > 5s totalTimeout, breaks
+      expect(yieldedCount, equals(3));
+    });
+
+    test('reproducible jitter with seeded Random', () {
+      final rng1 = Random(42);
+      final rng2 = Random(42);
+
+      final delays1 = delaySequence(
+        maxRetries: 5,
+        initialDelay: const Duration(milliseconds: 100),
+        maxDelay: const Duration(seconds: 1),
+        delayMultiplier: 1.5,
+        random: rng1,
+      ).toList();
+
+      final delays2 = delaySequence(
+        maxRetries: 5,
+        initialDelay: const Duration(milliseconds: 100),
+        maxDelay: const Duration(seconds: 1),
+        delayMultiplier: 1.5,
+        random: rng2,
+      ).toList();
+
+      expect(delays1, equals(delays2));
+    });
+  });
+
+  group('runWithRetry', () {
+    test('non-retryable error throws immediately without retrying', () async {
+      var callCount = 0;
+      await expectLater(
+        () => runWithRetry(
+          () async {
+            callCount++;
+            throw const grpc.GrpcError.alreadyExists('Already exists');
+          },
+          settings: RetrySettings(maxRetries: 5),
+          isIdempotent: true,
+        ),
+        throwsA(isA<grpc.GrpcError>()),
+      );
+
+      expect(callCount, equals(1));
+    });
+
+    test('retryable error retries up to maxRetries', () async {
+      var callCount = 0;
+      await expectLater(
+        () => runWithRetry(
+          () async {
+            callCount++;
+            throw const grpc.GrpcError.unavailable('Unavailable');
+          },
+          settings: RetrySettings(
+            maxRetries: 3,
+            initialDelay: const Duration(milliseconds: 1),
+            maxDelay: const Duration(milliseconds: 5),
+          ),
+          isIdempotent: true,
+        ),
+        throwsA(isA<grpc.GrpcError>()),
+      );
+
+      expect(callCount, equals(4)); // 1 initial + 3 retries
+    });
+  });
+}

--- a/pkgs/google_cloud_pubsub/test/topic_test.dart
+++ b/pkgs/google_cloud_pubsub/test/topic_test.dart
@@ -1,0 +1,331 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('vm')
+library;
+
+import 'dart:async';
+
+import 'package:google_cloud_pubsub/google_cloud_pubsub.dart';
+import 'package:google_cloud_pubsub/src/generated/google/pubsub/v1/pubsub.pbgrpc.dart'
+    as generated;
+import 'package:grpc/grpc.dart' as grpc;
+import 'package:test/fake.dart';
+import 'package:test/test.dart';
+
+class FakeResponseFuture<T> extends Fake implements grpc.ResponseFuture<T> {
+  final Future<T> _future;
+  FakeResponseFuture(this._future);
+
+  @override
+  Future<S> then<S>(
+    FutureOr<S> Function(T value) onValue, {
+    Function? onError,
+  }) => _future.then(
+    onValue,
+    onError: (Object e, StackTrace s) {
+      if (onError != null) {
+        if (onError is FutureOr<S> Function(Object, StackTrace)) {
+          onError(e, s);
+        } else if (onError is FutureOr<S> Function(Object)) {
+          onError(e);
+        } else {
+          // ignore: avoid_dynamic_calls
+          (onError as dynamic)(e, s);
+        }
+      }
+    },
+  );
+}
+
+class FakePublisherClient extends Fake implements generated.PublisherClient {
+  Future<generated.PublishResponse> Function(generated.PublishRequest request)?
+  publishBehavior;
+  int publishCallCount = 0;
+  final List<generated.PublishRequest> recordedRequests = [];
+
+  @override
+  grpc.ResponseFuture<generated.PublishResponse> publish(
+    generated.PublishRequest request, {
+    grpc.CallOptions? options,
+  }) {
+    publishCallCount++;
+    recordedRequests.add(request);
+    final completer = Completer<generated.PublishResponse>();
+    if (publishBehavior case final behavior?) {
+      behavior(
+        request,
+      ).then(completer.complete).catchError(completer.completeError);
+    } else {
+      final response = generated.PublishResponse()
+        ..messageIds.addAll(
+          List.generate(request.messages.length, (i) => 'msg-$i'),
+        );
+      completer.complete(response);
+    }
+    return FakeResponseFuture(completer.future);
+  }
+
+  @override
+  grpc.ResponseFuture<generated.Topic> createTopic(
+    generated.Topic request, {
+    grpc.CallOptions? options,
+  }) => FakeResponseFuture(Future.value(request));
+}
+
+class FakeClientChannel extends Fake implements grpc.ClientChannel {
+  @override
+  Future<void> shutdown() async {}
+}
+
+void main() {
+  group('Topic', () {
+    late FakePublisherClient fakePublisher;
+    late PubSub client;
+
+    setUp(() {
+      fakePublisher = FakePublisherClient();
+      client = PubSub.testing(
+        projectId: 'test-project',
+        channel: FakeClientChannel(),
+        publisherClient: fakePublisher,
+      );
+    });
+
+    tearDown(() async {
+      await client.close();
+    });
+
+    test('close flushes pending messages and awaits in-flight batch', () async {
+      final inFlightCompleter = Completer<generated.PublishResponse>();
+      fakePublisher.publishBehavior = (req) => inFlightCompleter.future;
+
+      final topic = client.topic(
+        'test-topic',
+        publishSettings: PublishSettings(
+          batching: BatchingSettings(
+            maxMessages: 10,
+            maxDelay: const Duration(seconds: 10),
+          ),
+        ),
+      );
+
+      final publishFuture = topic.publish([1, 2, 3]);
+
+      var closeCompleted = false;
+      final closeFuture = topic.close().then((_) {
+        closeCompleted = true;
+      });
+
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(closeCompleted, isFalse);
+      expect(fakePublisher.publishCallCount, equals(1));
+
+      inFlightCompleter.complete(
+        generated.PublishResponse()..messageIds.add('id-1'),
+      );
+
+      final publishedId = await publishFuture;
+      expect(publishedId, equals('id-1'));
+
+      await closeFuture;
+      expect(closeCompleted, isTrue);
+    });
+
+    test('multiple concurrent calls to close() await same future', () async {
+      final inFlightCompleter = Completer<generated.PublishResponse>();
+      fakePublisher.publishBehavior = (req) => inFlightCompleter.future;
+
+      final topic = client.topic(
+        'test-topic',
+        publishSettings: PublishSettings(
+          batching: BatchingSettings(
+            maxMessages: 10,
+            maxDelay: const Duration(seconds: 10),
+          ),
+        ),
+      );
+
+      unawaited(topic.publish([1]));
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      var close1Done = false;
+      var close2Done = false;
+      final c1 = topic.close().then((_) => close1Done = true);
+      final c2 = topic.close().then((_) => close2Done = true);
+
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(close1Done, isFalse);
+      expect(close2Done, isFalse);
+
+      inFlightCompleter.complete(
+        generated.PublishResponse()..messageIds.add('id-1'),
+      );
+
+      await Future.wait([c1, c2]);
+      expect(close1Done, isTrue);
+      expect(close2Done, isTrue);
+    });
+
+    test('publish after close throws StateError', () async {
+      final topic = client.topic('test-topic');
+      await topic.close();
+
+      expect(() => topic.publish([1, 2, 3]), throwsStateError);
+    });
+
+    test('Topic._onBatch handles fewer message IDs than batch size safely '
+        'without hanging or StateError', () async {
+      // Backend returns only 1 message ID for 2 messages
+      fakePublisher.publishBehavior = (req) async =>
+          generated.PublishResponse()..messageIds.add('only-one-id');
+
+      final topic = client.topic(
+        'test-topic',
+        publishSettings: PublishSettings(
+          batching: BatchingSettings(
+            maxMessages: 2,
+            maxDelay: const Duration(seconds: 10),
+          ),
+        ),
+      );
+
+      final fut1 = topic.publish([1]);
+      final fut2 = topic.publish([2]);
+
+      expect(await fut1, equals('only-one-id'));
+
+      await expectLater(
+        fut2,
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains(
+              'Server returned fewer message IDs (1) '
+              'than published messages (2)',
+            ),
+          ),
+        ),
+      );
+
+      await topic.close();
+    });
+
+    test(
+      'Topic._onBatch completes all completers on backend failure',
+      () async {
+        fakePublisher.publishBehavior = (req) async {
+          throw const grpc.GrpcError.notFound('Topic does not exist');
+        };
+
+        final topic = client.topic(
+          'test-topic',
+          publishSettings: PublishSettings(
+            batching: BatchingSettings(
+              maxMessages: 2,
+              maxDelay: const Duration(seconds: 10),
+            ),
+          ),
+        );
+
+        final fut1 = topic.publish([1]);
+        final fut2 = topic.publish([2]);
+
+        await expectLater(fut1, throwsA(isA<NotFoundException>()));
+        await expectLater(fut2, throwsA(isA<NotFoundException>()));
+
+        await topic.close();
+      },
+    );
+
+    test(
+      'calculates message size including attribute key and value lengths',
+      () async {
+        // Configure maxBytes to 20.
+        // data length = 4.
+        // attribute 'k': 'v' length = 1 + 1 = 2.
+        // Total size per message = 6.
+        // 3 messages = 18 bytes (does not trigger flush).
+        // 4th message = 24 bytes >= 20 bytes (triggers flush!).
+        final topic = client.topic(
+          'test-topic',
+          publishSettings: PublishSettings(
+            batching: BatchingSettings(
+              maxBytes: 20,
+              maxMessages: 100,
+              maxDelay: const Duration(seconds: 10),
+            ),
+          ),
+        );
+
+        unawaited(topic.publish([1, 2, 3, 4], attributes: {'k': 'v'}));
+        unawaited(topic.publish([1, 2, 3, 4], attributes: {'k': 'v'}));
+        unawaited(topic.publish([1, 2, 3, 4], attributes: {'k': 'v'}));
+
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        expect(fakePublisher.publishCallCount, equals(0));
+
+        unawaited(topic.publish([1, 2, 3, 4], attributes: {'k': 'v'}));
+
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        expect(fakePublisher.publishCallCount, equals(1));
+        expect(fakePublisher.recordedRequests[0].messages.length, equals(4));
+
+        await topic.close();
+      },
+    );
+
+    test('Topic.create() returns this and preserves publishSettings', () async {
+      final customSettings = PublishSettings(
+        batching: BatchingSettings(maxMessages: 42),
+      );
+      final topic = client.topic('my-topic', publishSettings: customSettings);
+      final created = await topic.create();
+      expect(identical(created, topic), isTrue);
+      expect(created.publishSettings, same(customSettings));
+      expect(created.publishSettings.batching.maxMessages, equals(42));
+    });
+  });
+
+  group('Message and ReceivedMessage toString', () {
+    test('Message toString returns informative string', () {
+      final msg = Message(data: [1, 2, 3], attributes: {'env': 'test'});
+      expect(
+        msg.toString(),
+        equals('Message(data: 3 bytes, attributes: {env: test})'),
+      );
+    });
+
+    test('ReceivedMessage toString returns informative string', () {
+      final now = DateTime.now();
+      final rMsg = ReceivedMessage(
+        ackId: 'ack-123',
+        messageId: 'msg-456',
+        publishTime: now,
+        message: Message(data: [1, 2], attributes: {'a': 'b'}),
+      );
+      expect(
+        rMsg.toString(),
+        equals(
+          'ReceivedMessage('
+          'messageId: msg-456, '
+          'ackId: ack-123, '
+          'publishTime: $now, '
+          'message: Message(data: 2 bytes, attributes: {a: b}))',
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
This is **Part 2 of 3** in a stacked set of PRs:
1. **#292**: Core retry and batching infrastructure (`RetrySettings`, `Batcher`, `BatchingSettings`)
2. **#338 (this PR)**: Topic publishing batching & lifecycle management (`PublishSettings`, `Topic.publish`, `Topic.close`)
3. **#339**: Subscription batching, resilient parallel streaming pull, and lifecycle management (`AckSettings`, `Subscription.streamingPull`, `Subscription.close`)

---

### Key Features in Part 2
- **Topic Batching**: Added `PublishSettings` controlling background batching (`BatchingSettings`) and unary retry configuration (`RetrySettings`) for `Topic.publish`.
- **Accurate Byte Counting**: Computes payload and attribute key/value byte overhead when batching messages against byte limits.
- **Completer Safety**: Ensures all completers in a batch complete or fail exactly once even on mismatched server responses or backend errors.
- **Lifecycle Management**: Async `Topic.close()` that flushes pending batches and awaits in-flight RPCs, preventing subsequent publishes with `StateError`.
- **Instance Settings Preservation**: `Topic.create()` returns `this` rather than constructing a new default instance, preserving configured `publishSettings`.
- **String Representations**: Informative `Message.toString()` and `ReceivedMessage.toString()`.

TAG=agy
CONV=bc7c6164-e9cb-4a0f-b326-7752c814e1ce

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>