### PR TITLE
feat(pubsub): add resilient parallel streaming pull

### DIFF
--- a/pkgs/google_cloud_pubsub/CHANGELOG.md
+++ b/pkgs/google_cloud_pubsub/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 0.1.0-wip
 
+- Added resilient streaming pull in `Subscription.streamingPull` with support
+  for parallel streams (`maxConcurrentStreams`), automatic reconnection with
+  exponential backoff, and backpressure pause/resume forwarding.
+- Routed background `Subscription.acknowledge` and `modifyAckDeadline` batches
+  directly over active streaming pull channels.
 - Added `BatchingSettings`, `PublishSettings`, and `AckSettings`.
 - Added background message batching for `Topic.publish`.
 - Added background acknowledgment and deadline modification batching for

--- a/pkgs/google_cloud_pubsub/README.md
+++ b/pkgs/google_cloud_pubsub/README.md
@@ -30,15 +30,30 @@ void main() async {
   // Application Default Credentials (ADC).
   final pubSub = PubSub(projectId: 'your-project-id');
 
-  // Create a topic.
-  final topic = await pubSub.topic('put-your-topic-name-here').create();
+  // Create a topic (with optional batching and retry settings).
+  final topic = await pubSub
+      .topic(
+        'put-your-topic-name-here',
+        publishSettings: PublishSettings(
+          batching: BatchingSettings(
+            maxMessages: 100,
+            maxDelay: Duration(milliseconds: 10),
+          ),
+        ),
+      )
+      .create();
 
   // Create a subscription to that topic.
   final subscription = await pubSub
-      .subscription('put-your-subscription-name-here')
+      .subscription(
+        'put-your-subscription-name-here',
+        ackSettings: AckSettings(
+          batching: BatchingSettings(maxDelay: Duration(milliseconds: 50)),
+        ),
+      )
       .create(topic: topic.name);
 
-  // Publish a message.
+  // Publish a message. This is automatically batched and retried.
   await topic.publish(utf8.encode('message 1'));
 
   // Pull messages from the subscription.
@@ -47,16 +62,29 @@ void main() async {
   for (final receivedMessage in messages) {
     print('Received message: ${utf8.decode(receivedMessage.data)}');
 
-    // Acknowledge the message.
-    await subscription.acknowledgeNow([receivedMessage]);
+    // Acknowledge the message in the background.
+    subscription.acknowledge(receivedMessage);
   }
+
+  // Or receive messages continuously via resilient parallel streaming pull.
+  // Acknowledgments and deadline modifications are automatically routed over
+  // active streams with fallback to unary RPCs.
+  final stream = subscription.streamingPull(maxConcurrentStreams: 2);
+  final sub = stream.take(1).listen((message) {
+    print('Streamed message: ${utf8.decode(message.data)}');
+    subscription.acknowledge(message);
+  });
+  await sub.asFuture<void>();
 
   print(
     'Your topic is available at:\n'
     'https://pubsub.googleapis.com/v1/${topic.name}',
   );
 
-  // Clean up.
+  // Clean up and flush any pending batches.
+  await subscription.close();
+  await topic.close();
+
   await subscription.delete();
   await topic.delete();
 

--- a/pkgs/google_cloud_pubsub/example/doc_examples.dart
+++ b/pkgs/google_cloud_pubsub/example/doc_examples.dart
@@ -1,0 +1,78 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:google_cloud_pubsub/google_cloud_pubsub.dart';
+
+Future<void> streamingPullExample(PubSub pubsub) async {
+  // #docregion streaming_pull_example
+  final subscription = pubsub.subscription('my-subscription');
+
+  // Establish a streaming pull with 3 parallel streams for high throughput
+  // and custom retry settings for handling transient connection drops.
+  final stream = subscription.streamingPull(
+    maxConcurrentStreams: 3,
+    streamAckDeadlineSeconds: 30,
+    retry: RetrySettings(
+      maxRetries: 10,
+      totalTimeout: null,
+      initialDelay: const Duration(seconds: 1),
+      maxDelay: const Duration(seconds: 30),
+    ),
+  );
+
+  final listener = stream.listen(
+    (ReceivedMessage message) {
+      print('Received message: ${utf8.decode(message.data)}');
+
+      // Acknowledge the message. This buffers the ACK in the background
+      // and batches it with others, sending it over one of the active
+      // gRPC streams or falling back to a unary RPC if streams are down.
+      subscription.acknowledge(message);
+    },
+    onError: (Object error) {
+      print('Stream encountered a permanent error: $error');
+    },
+    onDone: () {
+      print('Stream closed.');
+    },
+  );
+
+  // Later, to stop receiving messages and clean up resources:
+  await listener.cancel();
+  await subscription.close();
+  // #enddocregion streaming_pull_example
+}
+
+Future<void> acknowledgeNowExample(PubSub pubsub) async {
+  // #docregion acknowledge_now_example
+  final subscription = pubsub.subscription('my-subscription');
+
+  // Pull up to 10 messages from the subscription.
+  final messages = await subscription.pull(maxMessages: 10);
+
+  if (messages.isNotEmpty) {
+    try {
+      // Acknowledge all pulled messages immediately and wait for the RPC
+      // to complete. This bypasses background batching.
+      await subscription.acknowledgeNow(messages);
+      print('Successfully acknowledged ${messages.length} messages.');
+    } on Exception catch (error) {
+      print('Failed to acknowledge messages: $error');
+    }
+  }
+  // #enddocregion acknowledge_now_example
+}

--- a/pkgs/google_cloud_pubsub/example/example.dart
+++ b/pkgs/google_cloud_pubsub/example/example.dart
@@ -23,8 +23,30 @@ Future<void> main() async {
   final pubsub = PubSub(projectId: 'my-project-id');
 
   try {
-    final topic = pubsub.topic('my-topic');
+    final topic = pubsub.topic(
+      'my-topic',
+      publishSettings: PublishSettings(
+        batching: BatchingSettings(
+          maxMessages: 50,
+          maxDelay: const Duration(milliseconds: 20),
+        ),
+      ),
+    );
     print('Successfully initialized client for topic: ${topic.id}');
+
+    final subscription = pubsub.subscription(
+      'my-subscription',
+      ackSettings: AckSettings(
+        batching: BatchingSettings(
+          maxMessages: 50,
+          maxDelay: const Duration(milliseconds: 20),
+        ),
+      ),
+    );
+    print('Successfully initialized subscription: ${subscription.id}');
+
+    await topic.close();
+    await subscription.close();
   } finally {
     await pubsub.close();
   }

--- a/pkgs/google_cloud_pubsub/lib/src/client.dart
+++ b/pkgs/google_cloud_pubsub/lib/src/client.dart
@@ -450,6 +450,9 @@ final class PubSub {
             requestStream,
             options: options,
           );
+          // Any RPC or connection errors are forwarded to the stream listener
+          // below. Suppress errors on this unawaited headers future to avoid
+          // uncaught asynchronous errors in the zone.
           unawaited(
             responseStream.headers
                 .then((_) {

--- a/pkgs/google_cloud_pubsub/lib/src/client.dart
+++ b/pkgs/google_cloud_pubsub/lib/src/client.dart
@@ -89,11 +89,12 @@ final class PubSub {
     required ClientChannel channel,
     grpc.SubscriberClient? subscriberClient,
     grpc.PublisherClient? publisherClient,
+    FutureOr<BaseAuthenticator>? authenticator,
   }) => PubSub._(
     projectId,
     channel,
     false,
-    null,
+    authenticator,
     subscriberClient: subscriberClient,
     publisherClient: publisherClient,
   );
@@ -422,6 +423,97 @@ final class PubSub {
     }
   }
 
+  /// Low-level streaming pull over an explicit [requestStream].
+  ///
+  /// Used internally by [streamingPull] and [Subscription.streamingPull].
+  @internal
+  Stream<ReceivedMessage> streamingPullWithStream(
+    Stream<grpc.StreamingPullRequest> requestStream, {
+    void Function()? onConnected,
+    FutureOr<void> Function(List<String> ackIds)? ackHandler,
+    FutureOr<void> Function(List<String> ackIds, int ackDeadlineSeconds)?
+    modifyDeadlineHandler,
+  }) {
+    late StreamController<ReceivedMessage> controller;
+    StreamSubscription<grpc.StreamingPullResponse>? streamSubscription;
+    var isPaused = false;
+    var isCancelled = false;
+    controller = StreamController<ReceivedMessage>(
+      onListen: () async {
+        try {
+          final options = await _callOptions;
+          if (isCancelled) {
+            unawaited(controller.close());
+            return;
+          }
+          final responseStream = _subscriber.streamingPull(
+            requestStream,
+            options: options,
+          );
+          unawaited(
+            responseStream.headers
+                .then((_) {
+                  if (!isCancelled) {
+                    onConnected?.call();
+                  }
+                })
+                .catchError((_) {}),
+          );
+          streamSubscription = responseStream.listen(
+            (response) {
+              for (final receivedMessage in response.receivedMessages) {
+                controller.add(
+                  _mapReceivedMessage(
+                    receivedMessage,
+                    ackHandler: ackHandler,
+                    modifyDeadlineHandler: modifyDeadlineHandler,
+                  ),
+                );
+              }
+            },
+            onError: (Object error, StackTrace stackTrace) {
+              if (error is GrpcError) {
+                controller.addError(_mapGrpcError(error), stackTrace);
+              } else {
+                controller.addError(error, stackTrace);
+              }
+              unawaited(controller.close());
+            },
+            onDone: () {
+              unawaited(controller.close());
+            },
+            cancelOnError: true,
+          );
+          if (isPaused) {
+            streamSubscription?.pause();
+          }
+        } catch (error, stackTrace) {
+          if (!isCancelled && !controller.isClosed) {
+            if (error is GrpcError) {
+              controller.addError(_mapGrpcError(error), stackTrace);
+            } else {
+              controller.addError(error, stackTrace);
+            }
+            unawaited(controller.close());
+          }
+        }
+      },
+      onPause: () {
+        isPaused = true;
+        streamSubscription?.pause();
+      },
+      onResume: () {
+        isPaused = false;
+        streamSubscription?.resume();
+      },
+      onCancel: () {
+        isCancelled = true;
+        return streamSubscription?.cancel();
+      },
+    );
+    return controller.stream;
+  }
+
   /// Establishes a stream with the server, which sends messages down to the
   /// client.
   ///
@@ -431,12 +523,15 @@ final class PubSub {
   /// The client streams acknowledgments and ack deadline modifications
   /// back to the server. If an error occurs (including when the server closes
   /// the stream with status `UNAVAILABLE` to reassign resources), the stream
-  /// will throw a [ServiceException]. In this case, the caller should
+  /// will emit a [ServiceException]. In this case, the caller should
   /// re-establish the stream. Flow control can be achieved by configuring the
   /// underlying RPC channel.
   ///
-  /// Throws a [ServiceException] if the stream is broken by the server or
-  /// network.
+  /// Any errors (such as a [ServiceException] if the stream is broken by
+  /// the server or network) are emitted asynchronously on the returned
+  /// stream rather than thrown synchronously.
+  ///
+  /// It is an error if [subscription] is empty.
   /// It is an error if [streamAckDeadlineSeconds] is not between 10 and 600
   /// seconds.
   ///
@@ -445,6 +540,13 @@ final class PubSub {
     String subscription, {
     int streamAckDeadlineSeconds = 10,
   }) {
+    if (subscription.isEmpty) {
+      throw ArgumentError.value(
+        subscription,
+        'subscription',
+        'Must not be empty',
+      );
+    }
     if (streamAckDeadlineSeconds < 10 || streamAckDeadlineSeconds > 600) {
       throw ArgumentError.value(
         streamAckDeadlineSeconds,
@@ -464,54 +566,52 @@ final class PubSub {
   }) async* {
     final requestController = StreamController<grpc.StreamingPullRequest>();
     try {
-      final options = await _callOptions;
       requestController.add(
         grpc.StreamingPullRequest()
           ..subscription = subscription
           ..streamAckDeadlineSeconds = streamAckDeadlineSeconds,
       );
-      // TODO(sigurdm): Retry on broken connections.
-      void handleAck(List<String> ackIds) {
-        if (requestController.isClosed) {
-          throw StateError(
-            'Cannot acknowledge message: streaming pull connection has closed.',
-          );
-        }
-        requestController.add(
-          grpc.StreamingPullRequest()..ackIds.addAll(ackIds),
-        );
-      }
-
-      void handleModifyDeadline(List<String> ackIds, int seconds) {
-        if (requestController.isClosed) {
-          throw StateError(
-            'Cannot modify ack deadline: streaming pull connection has closed.',
-          );
-        }
-        requestController.add(
-          grpc.StreamingPullRequest()
-            ..modifyDeadlineAckIds.addAll(ackIds)
-            ..modifyDeadlineSeconds.addAll(List.filled(ackIds.length, seconds)),
-        );
-      }
-
-      final responseStream = _subscriber.streamingPull(
+      yield* streamingPullWithStream(
         requestController.stream,
-        options: options,
+        ackHandler: (ackIds) async {
+          if (ackIds.isEmpty) return;
+          if (!requestController.isClosed && requestController.hasListener) {
+            requestController.add(
+              grpc.StreamingPullRequest()..ackIds.addAll(ackIds),
+            );
+            return;
+          }
+          await acknowledge(subscription, ackIds);
+        },
+        modifyDeadlineHandler: (ackIds, ackDeadlineSeconds) async {
+          if (ackDeadlineSeconds < 0) {
+            throw ArgumentError.value(
+              ackDeadlineSeconds,
+              'ackDeadlineSeconds',
+              'Must be non-negative',
+            );
+          }
+          if (ackIds.isEmpty) return;
+          if (!requestController.isClosed && requestController.hasListener) {
+            requestController.add(
+              grpc.StreamingPullRequest()
+                ..modifyDeadlineAckIds.addAll(ackIds)
+                ..modifyDeadlineSeconds.addAll(
+                  List.filled(ackIds.length, ackDeadlineSeconds),
+                ),
+            );
+            return;
+          }
+          await modifyAckDeadline(subscription, ackIds, ackDeadlineSeconds);
+        },
       );
-      await for (final response in responseStream) {
-        for (final receivedMessage in response.receivedMessages) {
-          yield _mapReceivedMessage(
-            receivedMessage,
-            ackHandler: handleAck,
-            modifyDeadlineHandler: handleModifyDeadline,
-          );
-        }
-      }
-    } on GrpcError catch (error) {
-      throw _mapGrpcError(error);
     } finally {
-      await requestController.close();
+      if (!requestController.isClosed) {
+        if (!requestController.hasListener) {
+          unawaited(requestController.stream.drain<void>().catchError((_) {}));
+        }
+        unawaited(requestController.close());
+      }
     }
   }
 

--- a/pkgs/google_cloud_pubsub/lib/src/subscription.dart
+++ b/pkgs/google_cloud_pubsub/lib/src/subscription.dart
@@ -275,8 +275,7 @@ final class Subscription {
       throw ArgumentError.value(
         name,
         'name',
-        'Must be in the format '
-            'projects/<project-id>/subscriptions/<subscription-id>',
+        'Must be in the format projects/<project-id>/subscriptions/<subscription-id>',
       );
     }
   }

--- a/pkgs/google_cloud_pubsub/lib/src/subscription.dart
+++ b/pkgs/google_cloud_pubsub/lib/src/subscription.dart
@@ -16,6 +16,7 @@ import 'dart:async';
 
 import '../google_cloud_pubsub.dart';
 import 'batching.dart';
+import 'generated/google/pubsub/v1/pubsub.pbgrpc.dart' as grpc;
 import 'retry.dart';
 
 /// Settings for background batching and retrying of acknowledgments and
@@ -49,15 +50,28 @@ final class AckSettings {
 
 final class _AckRequest {
   final String ackId;
+  final Completer<void>? completer;
 
-  _AckRequest(this.ackId);
+  _AckRequest(this.ackId, {this.completer});
 }
 
 final class _ModifyAckDeadlineRequest {
   final String ackId;
   final int ackDeadlineSeconds;
+  final Completer<void>? completer;
 
-  _ModifyAckDeadlineRequest(this.ackId, this.ackDeadlineSeconds);
+  _ModifyAckDeadlineRequest(
+    this.ackId,
+    this.ackDeadlineSeconds, {
+    this.completer,
+  });
+}
+
+final class _ActiveStreamingPull {
+  final StreamController<ReceivedMessage> controller;
+  final Future<void> Function() cancel;
+
+  _ActiveStreamingPull({required this.controller, required this.cancel});
 }
 
 /// A [Google Cloud Pub/Sub subscription](https://cloud.google.com/pubsub/docs/overview#subscriptions).
@@ -74,13 +88,22 @@ final class Subscription {
   /// It has the format `projects/<project-id>/subscriptions/<subscription-id>`.
   final String name;
 
-  /// Settings controlling background acknowledgment and deadline modification
-  /// batching and retries.
+  /// Settings controlling background ACKs and deadline modifications.
   final AckSettings ackSettings;
 
   late final Batcher<_AckRequest> _ackBatcher;
   late final Batcher<_ModifyAckDeadlineRequest> _modifyAckBatcher;
 
+  /// Active streaming pull request streams for this subscription.
+  ///
+  /// Used to route ACKs and deadline modifications directly over existing
+  /// bidirectional streaming pull connections instead of making separate unary
+  /// RPCs.
+  final List<StreamController<grpc.StreamingPullRequest>> _activeStreams = [];
+  final Set<_ActiveStreamingPull> _activeStreamingPulls = {};
+
+  /// Index for round-robin load balancing ACKs across active streams.
+  int _nextStreamIndex = 0;
   bool _isClosed = false;
   Future<void>? _closeFuture;
 
@@ -95,8 +118,8 @@ final class Subscription {
     this.pubsub,
     String subscriptionId, {
     AckSettings? ackSettings,
-  }) : name = 'projects/${pubsub.projectId}/subscriptions/$subscriptionId',
-       ackSettings = ackSettings ?? AckSettings() {
+  }) : ackSettings = ackSettings ?? AckSettings(),
+       name = 'projects/${pubsub.projectId}/subscriptions/$subscriptionId' {
     _validateName(name);
     _initBatchers();
   }
@@ -122,7 +145,132 @@ final class Subscription {
     _modifyAckBatcher = Batcher<_ModifyAckDeadlineRequest>(
       settings: ackSettings.batching,
       itemSize: (request) => request.ackId.length + 4,
-      onBatch: _onModifyAckBatch,
+      onBatch: _onModifyAckDeadlineBatch,
+    );
+  }
+
+  StreamController<grpc.StreamingPullRequest>? _getActiveStream() {
+    if (_isClosed || _activeStreams.isEmpty) return null;
+    for (var i = 0; i < _activeStreams.length; i++) {
+      final index = (_nextStreamIndex + i) % _activeStreams.length;
+      final stream = _activeStreams[index];
+      if (!stream.isClosed && stream.hasListener) {
+        _nextStreamIndex = (index + 1) % _activeStreams.length;
+        return stream;
+      }
+    }
+    return null;
+  }
+
+  // Sends a batch of ACKs. Prefers sending over active gRPC streams
+  // (round-robin), falling back to a unary RPC with retries if no streams
+  // are available. Errors are caught and suppressed since ACKs are best-effort.
+  Future<void> _onAckBatch(List<_AckRequest> batch) async {
+    final ackIds = batch.map((request) => request.ackId).toSet().toList();
+    void resolveBatch([Object? error, StackTrace? stackTrace]) {
+      for (final request in batch) {
+        if (request.completer != null && !request.completer!.isCompleted) {
+          if (error != null) {
+            request.completer!.completeError(error, stackTrace);
+          } else {
+            request.completer!.complete();
+          }
+        }
+      }
+    }
+
+    final activeStream = _getActiveStream();
+    if (activeStream != null) {
+      activeStream.add(grpc.StreamingPullRequest()..ackIds.addAll(ackIds));
+      resolveBatch();
+      return;
+    }
+    // Fall back to unary RPC if no active streams or if subscription is
+    // closing.
+    try {
+      await runWithRetry(
+        () => pubsub.acknowledge(name, ackIds),
+        settings: ackSettings.retry,
+        isIdempotent: true,
+      );
+      resolveBatch();
+    } on Exception catch (error, stackTrace) {
+      // ACKs are best-effort. If the unary fallback fails after retries,
+      // the error is suppressed for fire-and-forget, but attached completers
+      // must receive the error.
+      resolveBatch(error, stackTrace);
+    }
+  }
+
+  // Sends a batch of deadline modifications. Groups by deadline and prefers
+  // sending over active gRPC streams, falling back to unary RPCs with retries.
+  Future<void> _onModifyAckDeadlineBatch(
+    List<_ModifyAckDeadlineRequest> batch,
+  ) async {
+    // If the same ackId was modified multiple times within the batch
+    // (e.g. lease extension followed by nack), preserve only the latest
+    // deadline.
+    final latestDeadlineByAckId = <String, int>{};
+    final requestsByAckId = <String, List<_ModifyAckDeadlineRequest>>{};
+    for (final request in batch) {
+      latestDeadlineByAckId[request.ackId] = request.ackDeadlineSeconds;
+      requestsByAckId.putIfAbsent(request.ackId, () => []).add(request);
+    }
+    // Group requests by deadline so we can send batches with the same deadline.
+    final byDeadline = <int, List<String>>{};
+    for (final entry in latestDeadlineByAckId.entries) {
+      byDeadline.putIfAbsent(entry.value, () => []).add(entry.key);
+    }
+    await Future.wait(
+      byDeadline.entries.map((entry) async {
+        final deadline = entry.key;
+        final ackIds = entry.value;
+
+        void resolveGroup([Object? error, StackTrace? stackTrace]) {
+          for (final ackId in ackIds) {
+            for (final request
+                in requestsByAckId[ackId] ??
+                    const <_ModifyAckDeadlineRequest>[]) {
+              if (request.completer != null &&
+                  !request.completer!.isCompleted) {
+                if (error != null) {
+                  request.completer!.completeError(error, stackTrace);
+                } else {
+                  request.completer!.complete();
+                }
+              }
+            }
+          }
+        }
+
+        final activeStream = _getActiveStream();
+        if (activeStream != null) {
+          activeStream.add(
+            grpc.StreamingPullRequest()
+              ..modifyDeadlineAckIds.addAll(ackIds)
+              ..modifyDeadlineSeconds.addAll(
+                List.filled(ackIds.length, deadline),
+              ),
+          );
+          resolveGroup();
+          return;
+        }
+        // Fall back to unary RPC if no active streams or subscription is
+        // closing.
+        try {
+          await runWithRetry(
+            () => pubsub.modifyAckDeadline(name, ackIds, deadline),
+            settings: ackSettings.retry,
+            isIdempotent: true,
+          );
+          resolveGroup();
+        } on Exception catch (error, stackTrace) {
+          // Deadline modifications are best-effort. If the unary fallback fails
+          // after retries, the error is suppressed for fire-and-forget, but
+          // attached completers must receive the error.
+          resolveGroup(error, stackTrace);
+        }
+      }),
     );
   }
 
@@ -131,7 +279,8 @@ final class Subscription {
       throw ArgumentError.value(
         name,
         'name',
-        'Must be in the format projects/<project-id>/subscriptions/<subscription-id>',
+        'Must be in the format '
+            'projects/<project-id>/subscriptions/<subscription-id>',
       );
     }
   }
@@ -161,17 +310,16 @@ final class Subscription {
 
   /// Deletes this subscription on the server.
   ///
-  /// All messages retained in the subscription are immediately dropped.
-  ///
   /// Throws a [NotFoundException] if the subscription does not exist.
   ///
   /// See the [official documentation](https://cloud.google.com/pubsub/docs/reference/rpc/google.pubsub.v1#google.pubsub.v1.Subscriber.DeleteSubscription).
   Future<void> delete() => pubsub.deleteSubscription(name);
 
-  /// Pulls messages from the server.
+  /// Pulls up to [maxMessages] from this subscription.
   ///
   /// It is an error if [maxMessages] is not greater than 0.
   /// It is an error if called on a closed [Subscription].
+  ///
   /// Throws a [NotFoundException] if the subscription does not exist.
   ///
   /// See the [official documentation](https://cloud.google.com/pubsub/docs/reference/rpc/google.pubsub.v1#google.pubsub.v1.Subscriber.Pull).
@@ -189,21 +337,43 @@ final class Subscription {
     return pubsub.pull(name, maxMessages: maxMessages);
   }
 
-  /// Establishes a stream with the server, which sends messages down to the
-  /// client.
+  /// Establishes a bidirectional streaming pull connection to receive
+  /// messages.
   ///
-  /// Throws a [ServiceException] if the stream is broken by the server or
-  /// network.
+  /// By default, a single stream is opened. Higher throughput can be achieved
+  /// by setting [maxConcurrentStreams] to open multiple parallel streaming pull
+  /// connections. Messages from all streams are multiplexed into the returned
+  /// [Stream]. Multi-stream pull helps overcome throughput limits on
+  /// high-volume subscriptions by bypassing single-stream limitations.
+  ///
+  /// The stream automatically reconnects on transient network errors using the
+  /// configured [retry] settings (defaulting to [AckSettings.retry] with
+  /// unlimited total duration). Custom [RetrySettings] retain their configured
+  /// [RetrySettings.totalTimeout] (which defaults to 1 minute) unless
+  /// `totalTimeout: null` is passed for unlimited reconnection duration.
+  /// Reconnections use exponential backoff, which resets once a connection
+  /// has been sustained and healthy (>= 15 seconds) or successfully yields
+  /// messages.
+  ///
+  /// ACKs and deadline modifications sent via [acknowledge],
+  /// [modifyAckDeadline], or the message handlers are batched in the background
+  /// and sent over the active streams. If all streams are down, they fall back
+  /// to unary RPCs.
   ///
   /// It is an error if called on a closed [Subscription].
   /// It is an error if [streamAckDeadlineSeconds] is not between 10 and 600
-  /// seconds.
+  /// seconds, or if [maxConcurrentStreams] is less than 1.
+  ///
+  /// Any errors (such as a [NotFoundException] if the subscription does not
+  /// exist, or non-retryable errors) are emitted asynchronously on the returned
+  /// [Stream] rather than thrown synchronously.
   ///
   /// See the [official documentation](https://cloud.google.com/pubsub/docs/reference/rpc/google.pubsub.v1#google.pubsub.v1.Subscriber.StreamingPull).
-  Stream<ReceivedMessage> streamingPull({int streamAckDeadlineSeconds = 10}) {
-    if (_isClosed) {
-      throw StateError('Cannot stream messages on a closed Subscription.');
-    }
+  Stream<ReceivedMessage> streamingPull({
+    int streamAckDeadlineSeconds = 10,
+    int maxConcurrentStreams = 1,
+    RetrySettings? retry,
+  }) {
     if (streamAckDeadlineSeconds < 10 || streamAckDeadlineSeconds > 600) {
       throw ArgumentError.value(
         streamAckDeadlineSeconds,
@@ -211,50 +381,280 @@ final class Subscription {
         'Must be between 10 and 600 seconds',
       );
     }
-    return pubsub.streamingPull(
-      name,
-      streamAckDeadlineSeconds: streamAckDeadlineSeconds,
-    );
-  }
-
-  Future<void> _onAckBatch(List<_AckRequest> batch) async {
-    final ackIds = batch.map((item) => item.ackId).toSet().toList();
-    try {
-      await runWithRetry(
-        () => pubsub.acknowledge(name, ackIds),
-        settings: ackSettings.retry,
-        isIdempotent: true,
+    if (maxConcurrentStreams < 1) {
+      throw ArgumentError.value(
+        maxConcurrentStreams,
+        'maxConcurrentStreams',
+        'Must be at least 1',
       );
-    } catch (_) {
-      // Best effort: unacknowledged messages will be redelivered upon
-      // deadline expiry.
     }
-  }
+    if (_isClosed) {
+      throw StateError('Cannot stream messages on a closed Subscription.');
+    }
+    final effectiveRetry =
+        retry ??
+        RetrySettings(
+          maxRetries: ackSettings.retry.maxRetries,
+          totalTimeout: null,
+          initialDelay: ackSettings.retry.initialDelay,
+          delayMultiplier: ackSettings.retry.delayMultiplier,
+          maxDelay: ackSettings.retry.maxDelay,
+        );
 
-  Future<void> _onModifyAckBatch(List<_ModifyAckDeadlineRequest> batch) async {
-    final latestByAckId = <String, int>{};
-    for (final request in batch) {
-      latestByAckId[request.ackId] = request.ackDeadlineSeconds;
-    }
-    final byDeadline = <int, List<String>>{};
-    for (final entry in latestByAckId.entries) {
-      byDeadline.putIfAbsent(entry.value, () => []).add(entry.key);
-    }
-    await Future.wait(
-      byDeadline.entries.map((entry) async {
-        final deadlineSeconds = entry.key;
-        final ackIds = entry.value;
-        try {
-          await runWithRetry(
-            () => pubsub.modifyAckDeadline(name, ackIds, deadlineSeconds),
-            settings: ackSettings.retry,
-            isIdempotent: true,
-          );
-        } catch (_) {
-          // Best effort.
+    late final StreamController<ReceivedMessage> controller;
+    late final _ActiveStreamingPull session;
+    var isCancelled = false;
+    var isPaused = false;
+    var activeOrReconnectingStreams = maxConcurrentStreams;
+    Object? lastError;
+    StackTrace? lastStackTrace;
+
+    // Track active request streams and subscriptions so we can clean them up.
+    final currentSubscriptions = <StreamSubscription<ReceivedMessage>>[];
+    final requestControllers = <StreamController<grpc.StreamingPullRequest>>[];
+    final reconnectTimers = <Timer>[];
+
+    Future<void> cancelAll() async {
+      for (final timer in reconnectTimers) {
+        timer.cancel();
+      }
+      reconnectTimers.clear();
+
+      final requestControllersToClose = requestControllers.toList();
+      requestControllers.clear();
+      for (final requestController in requestControllersToClose) {
+        _activeStreams.remove(requestController);
+        if (!requestController.isClosed) {
+          if (!requestController.hasListener) {
+            unawaited(
+              requestController.stream.drain<void>().catchError((_) {}),
+            );
+          }
+          unawaited(requestController.close());
         }
-      }),
+      }
+
+      final subscriptionsToCancel = currentSubscriptions.toList();
+      currentSubscriptions.clear();
+      await Future.wait(
+        subscriptionsToCancel.map(
+          (subscription) => subscription.cancel().catchError((_) {}),
+        ),
+      );
+    }
+
+    Future<void> cancelSession() async {
+      isCancelled = true;
+      _activeStreamingPulls.remove(session);
+      await cancelAll();
+    }
+
+    Future<void> handleAck(List<String> ackIds) async {
+      if (ackIds.isEmpty) return;
+      if (!_isClosed && !_ackBatcher.isClosed) {
+        final futures = <Future<void>>[];
+        for (final ackId in ackIds) {
+          final completer = Completer<void>();
+          _ackBatcher.add(_AckRequest(ackId, completer: completer));
+          futures.add(completer.future);
+        }
+        await Future.wait(futures);
+        return;
+      }
+      // If the subscription is closing or closed, fall back to a unary RPC so
+      // already-delivered and in-flight messages can be cleanly acknowledged.
+      await pubsub.acknowledge(name, ackIds);
+    }
+
+    Future<void> handleModifyDeadline(
+      List<String> ackIds,
+      int ackDeadlineSeconds,
+    ) async {
+      if (ackDeadlineSeconds < 0) {
+        throw ArgumentError.value(
+          ackDeadlineSeconds,
+          'ackDeadlineSeconds',
+          'Must be non-negative',
+        );
+      }
+      if (ackIds.isEmpty) return;
+      if (!_isClosed && !_modifyAckBatcher.isClosed) {
+        final futures = <Future<void>>[];
+        for (final ackId in ackIds) {
+          final completer = Completer<void>();
+          _modifyAckBatcher.add(
+            _ModifyAckDeadlineRequest(
+              ackId,
+              ackDeadlineSeconds,
+              completer: completer,
+            ),
+          );
+          futures.add(completer.future);
+        }
+        await Future.wait(futures);
+        return;
+      }
+      // If the subscription is closing or closed, fall back to a unary RPC.
+      await pubsub.modifyAckDeadline(name, ackIds, ackDeadlineSeconds);
+    }
+
+    void connect(Iterator<Duration> delays) {
+      if (_isClosed || isCancelled || controller.isClosed) return;
+
+      final requestController = StreamController<grpc.StreamingPullRequest>()
+        ..add(
+          grpc.StreamingPullRequest()
+            ..subscription = name
+            ..streamAckDeadlineSeconds = streamAckDeadlineSeconds,
+        );
+      _activeStreams.add(requestController);
+      requestControllers.add(requestController);
+
+      Stopwatch? connectionStopwatch;
+      void markConnected() {
+        connectionStopwatch ??= (Stopwatch()..start());
+      }
+
+      var hasReceivedItem = false;
+      StreamSubscription<ReceivedMessage>? currentSubscription;
+
+      void cleanupCurrentConnection() {
+        _activeStreams.remove(requestController);
+        requestControllers.remove(requestController);
+        if (currentSubscription != null) {
+          currentSubscriptions.remove(currentSubscription);
+          unawaited(currentSubscription.cancel().catchError((_) {}));
+        }
+        if (!requestController.isClosed) {
+          if (!requestController.hasListener) {
+            unawaited(
+              requestController.stream.drain<void>().catchError((_) {}),
+            );
+          }
+          unawaited(requestController.close());
+        }
+      }
+
+      Future<void> scheduleReconnect({
+        Object? error,
+        StackTrace? stackTrace,
+      }) async {
+        cleanupCurrentConnection();
+        if (_isClosed || isCancelled || controller.isClosed) return;
+
+        if (error != null && !isRetryable(error)) {
+          isCancelled = true;
+          controller.addError(error, stackTrace);
+          await cancelAll();
+          activeOrReconnectingStreams = 0;
+          _activeStreamingPulls.remove(session);
+          unawaited(controller.close());
+          return;
+        }
+
+        var nextDelays = delays;
+        final uptime = connectionStopwatch?.elapsed ?? Duration.zero;
+        final wasHealthy =
+            hasReceivedItem || (uptime >= const Duration(seconds: 15));
+        if (wasHealthy) {
+          nextDelays = delaySequence(
+            maxRetries: effectiveRetry.maxRetries,
+            totalTimeout: effectiveRetry.totalTimeout,
+            initialDelay: effectiveRetry.initialDelay,
+            delayMultiplier: effectiveRetry.delayMultiplier,
+            maxDelay: effectiveRetry.maxDelay,
+          ).iterator;
+        }
+        if (nextDelays.moveNext()) {
+          late Timer timer;
+          timer = Timer(nextDelays.current, () {
+            reconnectTimers.remove(timer);
+            if (_isClosed || isCancelled || controller.isClosed) return;
+            connect(nextDelays);
+          });
+          reconnectTimers.add(timer);
+        } else {
+          activeOrReconnectingStreams--;
+          if (error != null) {
+            lastError = error;
+            lastStackTrace = stackTrace;
+          }
+          if (activeOrReconnectingStreams == 0) {
+            isCancelled = true;
+            if (lastError != null) {
+              controller.addError(lastError!, lastStackTrace);
+            }
+            await cancelAll();
+            _activeStreamingPulls.remove(session);
+            unawaited(controller.close());
+          }
+        }
+      }
+
+      final subscription = pubsub
+          .streamingPullWithStream(
+            requestController.stream,
+            onConnected: markConnected,
+            ackHandler: handleAck,
+            modifyDeadlineHandler: handleModifyDeadline,
+          )
+          .listen(
+            (message) {
+              markConnected();
+              hasReceivedItem = true;
+              controller.add(message);
+            },
+            onError: (Object error, StackTrace stackTrace) =>
+                scheduleReconnect(error: error, stackTrace: stackTrace),
+            onDone: scheduleReconnect,
+            cancelOnError: true,
+          );
+      currentSubscription = subscription;
+
+      if (isPaused) {
+        subscription.pause();
+      }
+      currentSubscriptions.add(subscription);
+    }
+
+    controller = StreamController<ReceivedMessage>(
+      onListen: () {
+        if (_isClosed) {
+          unawaited(controller.close());
+          return;
+        }
+        _activeStreamingPulls.add(session);
+        for (var i = 0; i < maxConcurrentStreams; i++) {
+          final delays = delaySequence(
+            maxRetries: effectiveRetry.maxRetries,
+            totalTimeout: effectiveRetry.totalTimeout,
+            initialDelay: effectiveRetry.initialDelay,
+            delayMultiplier: effectiveRetry.delayMultiplier,
+            maxDelay: effectiveRetry.maxDelay,
+          ).iterator;
+          connect(delays);
+        }
+      },
+      onPause: () {
+        isPaused = true;
+        for (final subscription in currentSubscriptions.toList()) {
+          subscription.pause();
+        }
+      },
+      onResume: () {
+        isPaused = false;
+        for (final subscription in currentSubscriptions.toList()) {
+          subscription.resume();
+        }
+      },
+      onCancel: cancelSession,
     );
+
+    session = _ActiveStreamingPull(
+      controller: controller,
+      cancel: cancelSession,
+    );
+    return controller.stream;
   }
 
   /// Acknowledges the [messages] immediately via a unary RPC.
@@ -280,7 +680,9 @@ final class Subscription {
   /// Acknowledges [message] in the background.
   ///
   /// The acknowledgment is buffered and sent in a batch according to
-  /// [AckSettings.batching] via a unary RPC with retries configured
+  /// [AckSettings.batching]. If active [streamingPull] connections exist for
+  /// this subscription, batches are sent directly over an active request
+  /// stream. Otherwise, they are sent via a unary RPC with retries configured
   /// by [AckSettings.retry].
   ///
   /// To ensure all buffered acknowledgments are delivered before application
@@ -335,8 +737,10 @@ final class Subscription {
   /// Modifies the ack deadline for [message] in the background.
   ///
   /// The request is buffered and sent in a batch according to
-  /// [AckSettings.batching] via a unary RPC with retries configured
-  /// by [AckSettings.retry].
+  /// [AckSettings.batching]. If active [streamingPull] connections exist for
+  /// this subscription, batches are sent directly over an active request
+  /// stream. Otherwise, they are sent via a unary RPC with retries
+  /// configured by [AckSettings.retry].
   ///
   /// To ensure all buffered deadline modifications are delivered before
   /// application shutdown, call and await [close].
@@ -363,7 +767,8 @@ final class Subscription {
   }
 
   /// Closes the subscription, flushing any pending acknowledgments and
-  /// deadline modifications and waiting for in-flight batches to complete.
+  /// deadline modifications, waiting for in-flight batches to complete, and
+  /// cancelling any active streaming pulls.
   ///
   /// Calling and awaiting [close] during application shutdown ensures that all
   /// buffered acknowledgments and deadline modifications are sent before the
@@ -377,6 +782,14 @@ final class Subscription {
   }
 
   Future<void> _doClose() async {
+    final pulls = _activeStreamingPulls.toList();
+    _activeStreamingPulls.clear();
+    await Future.wait(pulls.map((pull) => pull.cancel()));
     await Future.wait([_ackBatcher.close(), _modifyAckBatcher.close()]);
+    for (final pull in pulls) {
+      if (!pull.controller.isClosed) {
+        unawaited(pull.controller.close());
+      }
+    }
   }
 }

--- a/pkgs/google_cloud_pubsub/lib/src/subscription.dart
+++ b/pkgs/google_cloud_pubsub/lib/src/subscription.dart
@@ -151,15 +151,11 @@ final class Subscription {
 
   StreamController<grpc.StreamingPullRequest>? _getActiveStream() {
     if (_isClosed || _activeStreams.isEmpty) return null;
-    for (var i = 0; i < _activeStreams.length; i++) {
-      final index = (_nextStreamIndex + i) % _activeStreams.length;
-      final stream = _activeStreams[index];
-      if (!stream.isClosed && stream.hasListener) {
-        _nextStreamIndex = (index + 1) % _activeStreams.length;
-        return stream;
-      }
-    }
-    return null;
+    _activeStreams.removeWhere((stream) => stream.isClosed);
+    if (_activeStreams.isEmpty) return null;
+    final stream = _activeStreams[_nextStreamIndex % _activeStreams.length];
+    _nextStreamIndex = (_nextStreamIndex + 1) % _activeStreams.length;
+    return stream;
   }
 
   // Sends a batch of ACKs. Prefers sending over active gRPC streams
@@ -501,13 +497,22 @@ final class Subscription {
     void connect(Iterator<Duration> delays) {
       if (_isClosed || isCancelled || controller.isClosed) return;
 
-      final requestController = StreamController<grpc.StreamingPullRequest>()
-        ..add(
-          grpc.StreamingPullRequest()
-            ..subscription = name
-            ..streamAckDeadlineSeconds = streamAckDeadlineSeconds,
-        );
-      _activeStreams.add(requestController);
+      late final StreamController<grpc.StreamingPullRequest> requestController;
+      requestController =
+          StreamController<grpc.StreamingPullRequest>(
+            onListen: () {
+              if (!_isClosed && !isCancelled && !controller.isClosed) {
+                _activeStreams.add(requestController);
+              }
+            },
+            onCancel: () {
+              _activeStreams.remove(requestController);
+            },
+          )..add(
+            grpc.StreamingPullRequest()
+              ..subscription = name
+              ..streamAckDeadlineSeconds = streamAckDeadlineSeconds,
+          );
       requestControllers.add(requestController);
 
       Stopwatch? connectionStopwatch;

--- a/pkgs/google_cloud_pubsub/test/error_propagation_test.dart
+++ b/pkgs/google_cloud_pubsub/test/error_propagation_test.dart
@@ -49,15 +49,15 @@ class FakeResponseFuture<T> extends Fake implements grpc.ResponseFuture<T> {
     Function? onError,
   }) => _future.then(
     onValue,
-    onError: (Object e, StackTrace s) {
+    onError: (Object error, StackTrace stackTrace) {
       if (onError != null) {
         if (onError is FutureOr<S> Function(Object, StackTrace)) {
-          onError(e, s);
+          onError(error, stackTrace);
         } else if (onError is FutureOr<S> Function(Object)) {
-          onError(e);
+          onError(error);
         } else {
           // ignore: avoid_dynamic_calls
-          (onError as dynamic)(e, s);
+          (onError as dynamic)(error, stackTrace);
         }
       }
     },
@@ -95,7 +95,8 @@ class FakeResponseStream<T> extends StreamView<T>
 
 class FakeSubscriberClient extends Fake implements generated.SubscriberClient {
   final StreamController<generated.StreamingPullResponse>
-  streamingPullController = StreamController();
+  streamingPullController = StreamController.broadcast();
+  int streamingPullCallCount = 0;
 
   bool acknowledgeCalled = false;
   List<String>? lastAckIds;
@@ -107,14 +108,24 @@ class FakeSubscriberClient extends Fake implements generated.SubscriberClient {
   Future<void> Function(List<String> ackIds, int seconds)?
   modifyAckDeadlineBehavior;
 
+  final List<generated.StreamingPullRequest> streamingPullRequests = [];
+  final List<StreamController<generated.StreamingPullResponse>>
+  streamingPullControllers = [];
+
   @override
   grpc.ResponseStream<generated.StreamingPullResponse> streamingPull(
     Stream<generated.StreamingPullRequest> request, {
     grpc.CallOptions? options,
   }) {
-    // Listen to request stream to prevent sender from hanging on close()
-    unawaited(request.drain());
-    return FakeResponseStream(streamingPullController.stream);
+    streamingPullCallCount++;
+    request.listen(streamingPullRequests.add);
+    final controller = StreamController<generated.StreamingPullResponse>();
+    streamingPullControllers.add(controller);
+    streamingPullController.stream.listen(
+      controller.add,
+      onError: controller.addError,
+    );
+    return FakeResponseStream(controller.stream);
   }
 
   @override
@@ -564,6 +575,352 @@ void main() {
         }
       },
     );
+
+    test('streamingPull auto-reconnects on transient error', () async {
+      final subscription = client.subscription('sub');
+      final stream = subscription.streamingPull(
+        retry: RetrySettings(initialDelay: const Duration(milliseconds: 10)),
+      );
+
+      final results = <ReceivedMessage>[];
+      final firstMessageReceived = Completer<void>();
+      final secondMessageReceived = Completer<void>();
+      final streamSubscription = stream.listen((receivedMessage) {
+        results.add(receivedMessage);
+        if (results.length == 1) firstMessageReceived.complete();
+        if (results.length == 2) secondMessageReceived.complete();
+      });
+
+      // Wait for initial stream connection to establish
+      while (fakeSubscriber.streamingPullCallCount < 1) {
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+      }
+
+      // Push first message
+      fakeSubscriber.streamingPullController.add(
+        generated.StreamingPullResponse()
+          ..receivedMessages.add(
+            generated.ReceivedMessage()
+              ..message = (pb.PubsubMessage()..messageId = 'msg-1'),
+          ),
+      );
+
+      await firstMessageReceived.future.timeout(const Duration(seconds: 3));
+
+      // Push a retryable error
+      fakeSubscriber.streamingPullController.addError(
+        const grpc.GrpcError.unavailable('Transient error'),
+      );
+
+      // Wait for reconnect to establish
+      while (fakeSubscriber.streamingPullCallCount < 2) {
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+      }
+
+      // Push second message after reconnect
+      fakeSubscriber.streamingPullController.add(
+        generated.StreamingPullResponse()
+          ..receivedMessages.add(
+            generated.ReceivedMessage()
+              ..message = (pb.PubsubMessage()..messageId = 'msg-2'),
+          ),
+      );
+
+      await secondMessageReceived.future.timeout(const Duration(seconds: 3));
+
+      await streamSubscription.cancel();
+      await subscription.close();
+
+      expect(results.length, equals(2));
+      expect(results[0].messageId, equals('msg-1'));
+      expect(results[1].messageId, equals('msg-2'));
+    });
+
+    test('streamingPull maxConcurrentStreams parameter validation', () {
+      final subscription = client.subscription('sub');
+      expect(
+        () => subscription.streamingPull(maxConcurrentStreams: 0),
+        throwsArgumentError,
+      );
+    });
+
+    test('streamingPull opens maxConcurrentStreams', () async {
+      final subscription = client.subscription('sub');
+      final streamSubscription = subscription
+          .streamingPull(maxConcurrentStreams: 3)
+          .listen((_) {});
+
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(fakeSubscriber.streamingPullCallCount, equals(3));
+
+      await streamSubscription.cancel();
+    });
+
+    test('message.acknowledge() on streaming pull sends ACK', () async {
+      final subscription = client.subscription('sub');
+      final stream = subscription.streamingPull();
+      final msgCompleter = Completer<ReceivedMessage>();
+
+      final streamSubscription = stream.listen((receivedMessage) {
+        if (!msgCompleter.isCompleted) {
+          msgCompleter.complete(receivedMessage);
+        }
+      });
+
+      Timer(const Duration(milliseconds: 10), () {
+        fakeSubscriber.streamingPullController.add(
+          generated.StreamingPullResponse()
+            ..receivedMessages.add(
+              generated.ReceivedMessage()
+                ..ackId = 'ack-stream-1'
+                ..message = (pb.PubsubMessage()..messageId = 'msg-1'),
+            ),
+        );
+      });
+
+      final receivedMessage = await msgCompleter.future;
+      expect(receivedMessage.ackId, equals('ack-stream-1'));
+
+      await receivedMessage.acknowledge();
+
+      final ackOverStream = fakeSubscriber.streamingPullRequests.any(
+        (request) => request.ackIds.contains('ack-stream-1'),
+      );
+      expect(
+        ackOverStream,
+        isTrue,
+        reason: 'ACK should be sent over active stream',
+      );
+
+      await streamSubscription.cancel();
+      await subscription.close();
+    });
+
+    test(
+      'message.modifyAckDeadline() on streaming pull modifies deadline',
+      () async {
+        final subscription = client.subscription('sub');
+        final stream = subscription.streamingPull();
+        final msgCompleter = Completer<ReceivedMessage>();
+
+        final streamSubscription = stream.listen((receivedMessage) {
+          if (!msgCompleter.isCompleted) {
+            msgCompleter.complete(receivedMessage);
+          }
+        });
+
+        Timer(const Duration(milliseconds: 10), () {
+          fakeSubscriber.streamingPullController.add(
+            generated.StreamingPullResponse()
+              ..receivedMessages.add(
+                generated.ReceivedMessage()
+                  ..ackId = 'ack-stream-2'
+                  ..message = (pb.PubsubMessage()..messageId = 'msg-2'),
+              ),
+          );
+        });
+
+        final receivedMessage = await msgCompleter.future;
+        expect(receivedMessage.ackId, equals('ack-stream-2'));
+
+        await receivedMessage.modifyAckDeadline(45);
+
+        final modOverStream = fakeSubscriber.streamingPullRequests.any(
+          (request) =>
+              request.modifyDeadlineAckIds.contains('ack-stream-2') &&
+              request.modifyDeadlineSeconds.contains(45),
+        );
+        expect(
+          modOverStream,
+          isTrue,
+          reason: 'ModifyAckDeadline should be sent over active stream',
+        );
+
+        await streamSubscription.cancel();
+        await subscription.close();
+      },
+    );
+
+    test('streamingPull fails immediately on non-retryable error', () async {
+      final subscription = client.subscription('sub');
+      final stream = subscription.streamingPull();
+
+      final completer = Completer<Object>();
+      final streamSubscription = stream.listen(
+        (_) {},
+        onError: completer.complete,
+      );
+
+      Timer(const Duration(milliseconds: 10), () {
+        fakeSubscriber.streamingPullController.addError(
+          const grpc.GrpcError.notFound('Subscription not found'),
+        );
+      });
+
+      final error = await completer.future;
+      expect(error, isA<NotFoundException>());
+
+      // Non-retryable error should not trigger reconnect
+      expect(fakeSubscriber.streamingPullCallCount, equals(1));
+
+      await streamSubscription.cancel();
+      await subscription.close();
+    });
+
+    test('idle streaming pull reconnects cleanly when healthy', () async {
+      final subscription = client.subscription('sub');
+      final stream = subscription.streamingPull(
+        retry: RetrySettings(
+          maxRetries: 2,
+          initialDelay: const Duration(milliseconds: 20),
+          maxDelay: const Duration(milliseconds: 50),
+        ),
+      );
+
+      final messages = <ReceivedMessage>[];
+      final streamSubscription = stream.listen(messages.add);
+
+      // Connection 1 receives a message (healthy)
+      Timer(const Duration(milliseconds: 10), () {
+        fakeSubscriber.streamingPullController.add(
+          generated.StreamingPullResponse()
+            ..receivedMessages.add(
+              generated.ReceivedMessage()
+                ..ackId = 'ack-h-1'
+                ..message = (pb.PubsubMessage()..messageId = 'msg-h-1'),
+            ),
+        );
+      });
+
+      // Transient disconnect 1
+      Timer(const Duration(milliseconds: 40), () {
+        fakeSubscriber.streamingPullController.addError(
+          const grpc.GrpcError.unavailable('Idle timeout 1'),
+        );
+      });
+
+      // Connection 2 receives a message (healthy)
+      Timer(const Duration(milliseconds: 150), () {
+        fakeSubscriber.streamingPullController.add(
+          generated.StreamingPullResponse()
+            ..receivedMessages.add(
+              generated.ReceivedMessage()
+                ..ackId = 'ack-h-2'
+                ..message = (pb.PubsubMessage()..messageId = 'msg-h-2'),
+            ),
+        );
+      });
+
+      // Transient disconnect 2
+      Timer(const Duration(milliseconds: 180), () {
+        fakeSubscriber.streamingPullController.addError(
+          const grpc.GrpcError.unavailable('Idle timeout 2'),
+        );
+      });
+
+      // Connection 3 receives a message (healthy)
+      Timer(const Duration(milliseconds: 300), () {
+        fakeSubscriber.streamingPullController.add(
+          generated.StreamingPullResponse()
+            ..receivedMessages.add(
+              generated.ReceivedMessage()
+                ..ackId = 'ack-h-3'
+                ..message = (pb.PubsubMessage()..messageId = 'msg-h-3'),
+            ),
+        );
+      });
+
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+      await streamSubscription.cancel();
+      await subscription.close();
+
+      expect(
+        messages.map((message) => message.messageId),
+        equals(['msg-h-1', 'msg-h-2', 'msg-h-3']),
+      );
+      expect(fakeSubscriber.streamingPullCallCount, equals(3));
+    });
+
+    test(
+      'multi-stream concurrency: dropping one stream does not close controller',
+      () async {
+        final subscription = client.subscription('sub');
+        final stream = subscription.streamingPull(maxConcurrentStreams: 2);
+
+        final messages = <ReceivedMessage>[];
+        var isClosed = false;
+        final streamSubscription = stream.listen(
+          messages.add,
+          onDone: () {
+            isClosed = true;
+          },
+        );
+
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        expect(fakeSubscriber.streamingPullCallCount, equals(2));
+
+        // Drop only stream 0
+        fakeSubscriber.streamingPullControllers[0].addError(
+          const grpc.GrpcError.unavailable('Stream 0 dropped'),
+        );
+
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        expect(isClosed, isFalse);
+
+        // Stream 1 is still active and receives a message
+        fakeSubscriber.streamingPullControllers[1].add(
+          generated.StreamingPullResponse()
+            ..receivedMessages.add(
+              generated.ReceivedMessage()
+                ..ackId = 'ack-multi'
+                ..message = (pb.PubsubMessage()..messageId = 'msg-multi'),
+            ),
+        );
+
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        expect(
+          messages.any((message) => message.messageId == 'msg-multi'),
+          isTrue,
+        );
+
+        await streamSubscription.cancel();
+        await subscription.close();
+      },
+    );
+
+    test('backpressure pause and resume', () async {
+      final subscription = client.subscription('sub');
+      final stream = subscription.streamingPull();
+
+      final messages = <ReceivedMessage>[];
+      final streamSubscription = stream.listen(messages.add);
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      streamSubscription.pause();
+      expect(streamSubscription.isPaused, isTrue);
+
+      fakeSubscriber.streamingPullController.add(
+        generated.StreamingPullResponse()
+          ..receivedMessages.add(
+            generated.ReceivedMessage()
+              ..ackId = 'ack-paused'
+              ..message = (pb.PubsubMessage()..messageId = 'msg-paused'),
+          ),
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(messages, isEmpty);
+
+      streamSubscription.resume();
+      expect(streamSubscription.isPaused, isFalse);
+
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(messages.length, equals(1));
+      expect(messages.first.ackId, equals('ack-paused'));
+
+      await streamSubscription.cancel();
+      await subscription.close();
+    });
   });
 
   group('ReceivedMessage composition and delegation', () {
@@ -586,5 +943,21 @@ void main() {
       expect(receivedMessage.data, equals([1, 2, 3]));
       expect(receivedMessage.attributes, equals({'key': 'value'}));
     });
+
+    test(
+      'acknowledge and modifyAckDeadline without handler throw StateError',
+      () async {
+        final message = ReceivedMessage(
+          ackId: 'ack-123',
+          messageId: 'msg-456',
+          publishTime: DateTime.now(),
+          message: Message(data: [1]),
+        );
+
+        await expectLater(message.acknowledge(), throwsStateError);
+        await expectLater(message.modifyAckDeadline(10), throwsStateError);
+        expect(() => message.modifyAckDeadline(-1), throwsArgumentError);
+      },
+    );
   });
 }

--- a/pkgs/google_cloud_pubsub/test/lifecycle_test.dart
+++ b/pkgs/google_cloud_pubsub/test/lifecycle_test.dart
@@ -511,7 +511,7 @@ void main() {
       },
     );
 
-    test('PubSub._streamingPull handlers throw StateError when connection '
+    test('PubSub._streamingPull handlers fall back to unary when connection '
         'is closed', () async {
       final stream = client.streamingPull(
         'projects/test-project/subscriptions/my-sub',
@@ -521,7 +521,7 @@ void main() {
 
       await Future<void>.delayed(const Duration(milliseconds: 10));
       expect(fakeSubscriber.streamingPullControllers.length, equals(1));
-      final conn = fakeSubscriber.streamingPullControllers.first
+      final connection = fakeSubscriber.streamingPullControllers.first
         ..add(
           generated.StreamingPullResponse()
             ..receivedMessages.add(
@@ -535,37 +535,18 @@ void main() {
       expect(received, isNotNull);
 
       // Close response stream to complete pull and close requestController.
-      await conn.close();
+      await connection.close();
       await Future<void>.delayed(const Duration(milliseconds: 20));
       await streamSubscription.cancel();
 
-      expect(
-        () => received!.acknowledge(),
-        throwsA(
-          isA<StateError>().having(
-            (e) => e.message,
-            'message',
-            contains(
-              'Cannot acknowledge message: '
-              'streaming pull connection has closed.',
-            ),
-          ),
-        ),
-      );
+      await received!.acknowledge();
+      expect(fakeSubscriber.acknowledgeCalled, isTrue);
+      expect(fakeSubscriber.lastAckIds, equals(['ack-closed']));
 
-      expect(
-        () => received!.modifyAckDeadline(10),
-        throwsA(
-          isA<StateError>().having(
-            (e) => e.message,
-            'message',
-            contains(
-              'Cannot modify ack deadline: '
-              'streaming pull connection has closed.',
-            ),
-          ),
-        ),
-      );
+      await received!.modifyAckDeadline(10);
+      expect(fakeSubscriber.modifyAckDeadlineCalled, isTrue);
+      expect(fakeSubscriber.lastModifyAckDeadlineSeconds, equals(10));
+      expect(fakeSubscriber.lastModifyAckDeadlineIds, equals(['ack-closed']));
     });
     test('pull validates maxMessages > 0', () {
       expect(

--- a/pkgs/google_cloud_pubsub/test/streaming_pull_unit_test.dart
+++ b/pkgs/google_cloud_pubsub/test/streaming_pull_unit_test.dart
@@ -160,6 +160,9 @@ class DelayedAuthenticator extends Fake implements grpc.BaseAuthenticator {
   final Completer<void> completer = Completer<void>();
 
   @override
+  grpc.CallOptions get toCallOptions => grpc.CallOptions();
+
+  @override
   Future<void> authenticate(Map<String, String> metadata, String uri) async {
     await completer.future;
   }
@@ -951,6 +954,63 @@ void main() {
 
       await subscription.close();
     });
+
+    test(
+      'stream is only added to active streams once listener is attached',
+      () async {
+        final authCompleter = Completer<grpc.BaseAuthenticator>();
+        final clientWithDelayedAuth = PubSub.testing(
+          projectId: 'test-project',
+          channel: FakeClientChannel(),
+          subscriberClient: fakeSubscriber,
+          authenticator: authCompleter.future,
+        );
+
+        final subscription = clientWithDelayedAuth.subscription(
+          'test-sub',
+          ackSettings: AckSettings(
+            batching: BatchingSettings(maxMessages: 1),
+            retry: RetrySettings(maxRetries: 0),
+          ),
+        );
+
+        final stream = subscription.streamingPull();
+        final streamSubscription = stream.listen((_) {});
+
+        // While _callOptions is in-flight, stream has no listener yet.
+        // An ACK sent during this window should fall back to unary RPC.
+        final message = ReceivedMessage(
+          ackId: 'ack-during-init',
+          messageId: 'msg-during-init',
+          publishTime: DateTime.now(),
+          message: Message(data: [1]),
+        );
+        subscription.acknowledge(message);
+
+        // Now finish auth so the unary call and connection finish initializing
+        authCompleter.complete(DelayedAuthenticator());
+        await Future<void>.delayed(const Duration(milliseconds: 30));
+
+        expect(fakeSubscriber.acknowledgeCalled, isTrue);
+        expect(
+          fakeSubscriber.unaryAckCalls.any(
+            (call) => call.contains('ack-during-init'),
+          ),
+          isTrue,
+        );
+
+        // The connection was opened but should NOT have received the ACK
+        // (it was sent via unary fallback before the stream was active).
+        expect(fakeSubscriber.connections.length, equals(1));
+        final ackOverStream = fakeSubscriber.connections.first.recordedRequests
+            .any((request) => request.ackIds.contains('ack-during-init'));
+        expect(ackOverStream, isFalse);
+
+        await streamSubscription.cancel();
+        await subscription.close();
+        await clientWithDelayedAuth.close();
+      },
+    );
 
     test(
       'custom RetrySettings is respected directly in streamingPull',

--- a/pkgs/google_cloud_pubsub/test/streaming_pull_unit_test.dart
+++ b/pkgs/google_cloud_pubsub/test/streaming_pull_unit_test.dart
@@ -1,0 +1,1520 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('vm')
+library;
+
+import 'dart:async';
+
+import 'package:google_cloud_pubsub/google_cloud_pubsub.dart';
+import 'package:google_cloud_pubsub/src/generated/google/pubsub/v1/pubsub.pb.dart'
+    as pb;
+import 'package:google_cloud_pubsub/src/generated/google/pubsub/v1/pubsub.pbgrpc.dart'
+    as generated;
+import 'package:grpc/grpc.dart' as grpc;
+import 'package:protobuf/well_known_types/google/protobuf/empty.pb.dart'
+    as protobuf;
+import 'package:protobuf/well_known_types/google/protobuf/timestamp.pb.dart'
+    as pb_ts;
+import 'package:test/fake.dart';
+import 'package:test/test.dart';
+
+class FakeResponseFuture<T> extends Fake implements grpc.ResponseFuture<T> {
+  final Future<T> _future;
+  FakeResponseFuture(this._future);
+
+  @override
+  Future<S> then<S>(
+    FutureOr<S> Function(T value) onValue, {
+    Function? onError,
+  }) => _future.then(
+    onValue,
+    onError: (Object error, StackTrace stackTrace) {
+      if (onError != null) {
+        if (onError is FutureOr<S> Function(Object, StackTrace)) {
+          onError(error, stackTrace);
+        } else if (onError is FutureOr<S> Function(Object)) {
+          onError(error);
+        } else {
+          // ignore: avoid_dynamic_calls
+          (onError as dynamic)(error, stackTrace);
+        }
+      }
+    },
+  );
+}
+
+class FakeResponseStream<T> extends StreamView<T>
+    implements grpc.ResponseStream<T> {
+  FakeResponseStream(super.stream);
+
+  @override
+  grpc.ResponseFuture<T> get single => FakeResponseFuture(super.single);
+
+  @override
+  Future<void> cancel() => Future<void>.value();
+
+  @override
+  Future<Map<String, String>> get headers => Future.value(const {});
+
+  @override
+  Future<Map<String, String>> get trailers => Future.value(const {});
+}
+
+class StreamConnection {
+  final StreamController<generated.StreamingPullResponse> responseController =
+      StreamController<generated.StreamingPullResponse>();
+  final List<generated.StreamingPullRequest> recordedRequests = [];
+
+  void emitMessage(String ackId, String messageId) {
+    responseController.add(
+      generated.StreamingPullResponse()
+        ..receivedMessages.add(
+          generated.ReceivedMessage()
+            ..ackId = ackId
+            ..message = (pb.PubsubMessage()
+              ..messageId = messageId
+              ..publishTime = pb_ts.Timestamp.fromDateTime(DateTime.now())),
+        ),
+    );
+  }
+}
+
+class FakeSubscriberClient extends Fake implements generated.SubscriberClient {
+  final List<StreamConnection> connections = [];
+  final StreamController<StreamConnection> onNewConnection =
+      StreamController<StreamConnection>.broadcast();
+
+  final List<List<String>> unaryAckCalls = [];
+  final List<(List<String>, int)> unaryModifyDeadlineCalls = [];
+  Future<void> Function(List<String> ackIds)? acknowledgeBehavior;
+  bool get acknowledgeCalled => unaryAckCalls.isNotEmpty;
+
+  @override
+  grpc.ResponseStream<generated.StreamingPullResponse> streamingPull(
+    Stream<generated.StreamingPullRequest> request, {
+    grpc.CallOptions? options,
+  }) {
+    final connection = StreamConnection();
+    connections.add(connection);
+    request.listen(connection.recordedRequests.add);
+    onNewConnection.add(connection);
+    return FakeResponseStream(connection.responseController.stream);
+  }
+
+  @override
+  grpc.ResponseFuture<protobuf.Empty> acknowledge(
+    generated.AcknowledgeRequest request, {
+    grpc.CallOptions? options,
+  }) {
+    unaryAckCalls.add(request.ackIds);
+    final completer = Completer<protobuf.Empty>();
+    if (acknowledgeBehavior case final behavior?) {
+      behavior(request.ackIds)
+          .then((_) => completer.complete(protobuf.Empty()))
+          .catchError(completer.completeError);
+    } else {
+      completer.complete(protobuf.Empty());
+    }
+    return FakeResponseFuture(completer.future);
+  }
+
+  Future<void> Function(List<String> ackIds, int seconds)?
+  modifyAckDeadlineBehavior;
+
+  @override
+  grpc.ResponseFuture<protobuf.Empty> modifyAckDeadline(
+    generated.ModifyAckDeadlineRequest request, {
+    grpc.CallOptions? options,
+  }) {
+    unaryModifyDeadlineCalls.add((request.ackIds, request.ackDeadlineSeconds));
+    final completer = Completer<protobuf.Empty>();
+    if (modifyAckDeadlineBehavior case final behavior?) {
+      behavior(request.ackIds, request.ackDeadlineSeconds)
+          .then((_) => completer.complete(protobuf.Empty()))
+          .catchError(completer.completeError);
+    } else {
+      completer.complete(protobuf.Empty());
+    }
+    return FakeResponseFuture(completer.future);
+  }
+}
+
+class FakeClientChannel extends Fake implements grpc.ClientChannel {
+  @override
+  Future<void> shutdown() async {}
+}
+
+class DelayedAuthenticator extends Fake implements grpc.BaseAuthenticator {
+  final Completer<void> completer = Completer<void>();
+
+  @override
+  Future<void> authenticate(Map<String, String> metadata, String uri) async {
+    await completer.future;
+  }
+}
+
+class ThrowingSubscriberClient extends Fake
+    implements generated.SubscriberClient {
+  @override
+  grpc.ResponseStream<generated.StreamingPullResponse> streamingPull(
+    Stream<generated.StreamingPullRequest> request, {
+    grpc.CallOptions? options,
+  }) {
+    throw StateError('setup failure');
+  }
+}
+
+class ThrowingAuthenticator extends Fake implements grpc.BaseAuthenticator {
+  @override
+  grpc.CallOptions get toCallOptions => throw Exception('auth failure');
+}
+
+void main() {
+  group('Streaming Pull & ReceivedMessage', () {
+    late FakeSubscriberClient fakeSubscriber;
+    late PubSub client;
+
+    setUp(() {
+      fakeSubscriber = FakeSubscriberClient();
+      client = PubSub.testing(
+        projectId: 'test-project',
+        channel: FakeClientChannel(),
+        subscriberClient: fakeSubscriber,
+      );
+    });
+
+    tearDown(() async {
+      await client.close();
+    });
+
+    test('ReceivedMessage with null handlers throws StateError', () async {
+      final message = ReceivedMessage(
+        ackId: 'ack-123',
+        messageId: 'msg-456',
+        publishTime: DateTime.now(),
+        message: Message(data: [1]),
+      );
+
+      await expectLater(message.acknowledge, throwsStateError);
+      await expectLater(() => message.modifyAckDeadline(10), throwsStateError);
+      expect(() => message.modifyAckDeadline(-1), throwsArgumentError);
+    });
+
+    test(
+      'message.acknowledge() on streamingPull actually sends ACK over stream',
+      () async {
+        final subscription = client.subscription(
+          'test-sub',
+          ackSettings: AckSettings(
+            batching: BatchingSettings(
+              maxMessages: 1,
+              maxDelay: const Duration(milliseconds: 10),
+            ),
+          ),
+        );
+
+        final stream = subscription.streamingPull();
+        final receivedList = <ReceivedMessage>[];
+        final streamSubscription = stream.listen(receivedList.add);
+
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        expect(fakeSubscriber.connections.length, equals(1));
+        final connection = fakeSubscriber.connections.first
+          ..emitMessage('ack-stream-1', 'msg-stream-1');
+
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        expect(receivedList.length, equals(1));
+
+        final message = receivedList.first;
+        expect(message.ackId, equals('ack-stream-1'));
+
+        await message.acknowledge();
+
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        final ackRequests = connection.recordedRequests
+            .where((request) => request.ackIds.contains('ack-stream-1'))
+            .toList();
+        expect(
+          ackRequests.isNotEmpty,
+          isTrue,
+          reason: 'ACK should be sent over streaming pull request stream',
+        );
+
+        await streamSubscription.cancel();
+        await subscription.close();
+      },
+    );
+
+    test('message.modifyAckDeadline() on streamingPull sends deadline update '
+        'over stream', () async {
+      final subscription = client.subscription(
+        'test-sub',
+        ackSettings: AckSettings(
+          batching: BatchingSettings(
+            maxMessages: 1,
+            maxDelay: const Duration(milliseconds: 10),
+          ),
+        ),
+      );
+
+      final stream = subscription.streamingPull();
+      final receivedList = <ReceivedMessage>[];
+      final streamSubscription = stream.listen(receivedList.add);
+
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      final connection = fakeSubscriber.connections.first
+        ..emitMessage('ack-mod-1', 'msg-mod-1');
+
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(receivedList.length, equals(1));
+
+      final message = receivedList.first;
+      await message.modifyAckDeadline(30);
+
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      final modRequests = connection.recordedRequests
+          .where(
+            (request) => request.modifyDeadlineAckIds.contains('ack-mod-1'),
+          )
+          .toList();
+      expect(modRequests.isNotEmpty, isTrue);
+      expect(modRequests.first.modifyDeadlineSeconds.first, equals(30));
+
+      await streamSubscription.cancel();
+      await subscription.close();
+    });
+
+    test(
+      'PubSub.streamingPull wires ack and modify deadline handlers',
+      () async {
+        final stream = client.streamingPull(
+          'projects/test-project/subscriptions/test-sub',
+        );
+        final receivedList = <ReceivedMessage>[];
+        final streamSubscription = stream.listen(receivedList.add);
+
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        expect(fakeSubscriber.connections.length, equals(1));
+        final connection = fakeSubscriber.connections.first
+          ..emitMessage('raw-ack-1', 'raw-msg-1');
+
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        expect(receivedList.length, equals(1));
+
+        final message = receivedList.first;
+        await message.acknowledge();
+
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        final ackRequests = connection.recordedRequests
+            .where((request) => request.ackIds.contains('raw-ack-1'))
+            .toList();
+        expect(ackRequests.isNotEmpty, isTrue);
+
+        await streamSubscription.cancel();
+      },
+    );
+
+    test('PubSub.streamingPull validates non-empty subscription name', () {
+      expect(
+        () => client.streamingPull(''),
+        throwsA(
+          isA<ArgumentError>().having(
+            (error) => error.message,
+            'message',
+            contains('Must not be empty'),
+          ),
+        ),
+      );
+    });
+
+    test('PubSub.streamingPull handlers validate arguments', () async {
+      final stream = client.streamingPull(
+        'projects/test-project/subscriptions/test-sub',
+      );
+      ReceivedMessage? message;
+      final streamSubscription = stream.listen(
+        (incomingMessage) => message = incomingMessage,
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      fakeSubscriber.connections.first.emitMessage('v-ack', 'v-msg');
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(message, isNotNull);
+      expect(() => message!.modifyAckDeadline(-1), throwsArgumentError);
+
+      await streamSubscription.cancel();
+    });
+
+    test('non-retryable errors (NotFoundException, ForbiddenException) fail '
+        'immediately', () async {
+      final subscription = client.subscription(
+        'test-sub',
+        ackSettings: AckSettings(retry: RetrySettings(maxRetries: 10)),
+      );
+
+      final stream = subscription.streamingPull();
+      Object? streamError;
+      var streamDone = false;
+
+      final streamSubscription = stream.listen(
+        (_) {},
+        onError: (Object error) {
+          streamError = error;
+        },
+        onDone: () {
+          streamDone = true;
+        },
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(fakeSubscriber.connections.length, equals(1));
+      final connection = fakeSubscriber.connections.first;
+
+      connection.responseController.addError(
+        const grpc.GrpcError.notFound('Subscription not found'),
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(fakeSubscriber.connections.length, equals(1));
+      expect(streamError, isA<NotFoundException>());
+      expect(streamDone, isTrue);
+
+      await streamSubscription.cancel();
+      await subscription.close();
+
+      // Verify ForbiddenException (permissionDenied) also fails immediately.
+      final forbiddenSub = client.subscription(
+        'forbidden-sub',
+        ackSettings: AckSettings(retry: RetrySettings(maxRetries: 10)),
+      );
+      Object? forbiddenError;
+      var forbiddenDone = false;
+      final sub2 = forbiddenSub.streamingPull().listen(
+        (_) {},
+        onError: (Object error) {
+          forbiddenError = error;
+        },
+        onDone: () {
+          forbiddenDone = true;
+        },
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      fakeSubscriber.connections.last.responseController.addError(
+        const grpc.GrpcError.permissionDenied('Permission denied'),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(forbiddenError, isA<ForbiddenException>());
+      expect(forbiddenDone, isTrue);
+      await sub2.cancel();
+      await forbiddenSub.close();
+    });
+
+    test('idle streaming pull reconnects cleanly after disconnect', () async {
+      final subscription = client.subscription(
+        'test-sub',
+        ackSettings: AckSettings(
+          retry: RetrySettings(
+            initialDelay: const Duration(milliseconds: 10),
+            maxDelay: const Duration(milliseconds: 20),
+          ),
+        ),
+      );
+
+      final stream = subscription.streamingPull();
+      final receivedList = <ReceivedMessage>[];
+      final streamSubscription = stream.listen(receivedList.add);
+
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(fakeSubscriber.connections.length, equals(1));
+      final connection1 = fakeSubscriber.connections[0];
+
+      connection1.responseController.addError(
+        const grpc.GrpcError.unavailable('Server disconnected idle stream'),
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      expect(
+        fakeSubscriber.connections.length,
+        equals(2),
+        reason: 'Should have cleanly reconnected to a new stream',
+      );
+
+      fakeSubscriber.connections[1].emitMessage(
+        'ack-reconnect-1',
+        'msg-reconnect-1',
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(receivedList.length, equals(1));
+      expect(receivedList.first.messageId, equals('msg-reconnect-1'));
+
+      await streamSubscription.cancel();
+      await subscription.close();
+    });
+
+    test(
+      'onDone applies backoff and delay instead of microtask loop',
+      () async {
+        final subscription = client.subscription(
+          'test-sub',
+          ackSettings: AckSettings(
+            retry: RetrySettings(
+              initialDelay: const Duration(milliseconds: 50),
+              maxDelay: const Duration(milliseconds: 100),
+            ),
+          ),
+        );
+
+        final stream = subscription.streamingPull();
+        final streamSubscription = stream.listen((_) {});
+
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        expect(fakeSubscriber.connections.length, equals(1));
+
+        await fakeSubscriber.connections[0].responseController.close();
+
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+        expect(fakeSubscriber.connections.length, equals(1));
+
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        expect(fakeSubscriber.connections.length, equals(2));
+
+        await streamSubscription.cancel();
+        await subscription.close();
+      },
+    );
+
+    test('multi-stream concurrency: dropping one stream does not close '
+        'controller while other streams active', () async {
+      final subscription = client.subscription(
+        'test-sub',
+        ackSettings: AckSettings(
+          retry: RetrySettings(
+            initialDelay: const Duration(milliseconds: 10),
+            maxDelay: const Duration(milliseconds: 20),
+          ),
+        ),
+      );
+
+      final stream = subscription.streamingPull(maxConcurrentStreams: 2);
+      final receivedList = <ReceivedMessage>[];
+      var isStreamDone = false;
+      final streamSubscription = stream.listen(
+        receivedList.add,
+        onDone: () => isStreamDone = true,
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(fakeSubscriber.connections.length, equals(2));
+      final connection1 = fakeSubscriber.connections[0];
+      final connection2 = fakeSubscriber.connections[1];
+
+      connection1.responseController.addError(
+        const grpc.GrpcError.unavailable('Transient stream 1 drop'),
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      expect(isStreamDone, isFalse);
+
+      connection2.emitMessage('ack-conn2', 'msg-conn2');
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(receivedList.length, equals(1));
+      expect(receivedList.first.ackId, equals('ack-conn2'));
+
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(fakeSubscriber.connections.length, equals(3));
+      expect(isStreamDone, isFalse);
+
+      await streamSubscription.cancel();
+      await subscription.close();
+    });
+
+    test('backpressure pause and resume on stream controller', () async {
+      final subscription = client.subscription('test-sub');
+      final stream = subscription.streamingPull();
+
+      final receivedList = <ReceivedMessage>[];
+      final streamSubscription = stream.listen(receivedList.add);
+
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(fakeSubscriber.connections.length, equals(1));
+      final connection = fakeSubscriber.connections.first;
+
+      streamSubscription.pause();
+      expect(streamSubscription.isPaused, isTrue);
+
+      connection.emitMessage('ack-p1', 'msg-p1');
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(receivedList.isEmpty, isTrue);
+
+      streamSubscription.resume();
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(receivedList.length, equals(1));
+      expect(receivedList.first.ackId, equals('ack-p1'));
+
+      await streamSubscription.cancel();
+      await subscription.close();
+    });
+
+    test('stream reconnected while paused starts paused and buffers messages '
+        'until resumed', () async {
+      final subscription = client.subscription(
+        'test-sub',
+        ackSettings: AckSettings(
+          retry: RetrySettings(
+            initialDelay: const Duration(milliseconds: 20),
+            maxDelay: const Duration(milliseconds: 50),
+          ),
+        ),
+      );
+      final stream = subscription.streamingPull();
+
+      final receivedList = <ReceivedMessage>[];
+      final streamSubscription = stream.listen(receivedList.add);
+
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(fakeSubscriber.connections.length, equals(1));
+      final connection1 = fakeSubscriber.connections.first;
+
+      // Pause while stream is healthy
+      streamSubscription.pause();
+      expect(streamSubscription.isPaused, isTrue);
+
+      // Disconnect stream 1 while paused
+      final nextConnectionFuture = fakeSubscriber.onNewConnection.stream.first;
+      connection1.responseController.addError(
+        const grpc.GrpcError.unavailable(
+          'Simulated transient drop while paused',
+        ),
+      );
+
+      // While paused, the stream subscription buffers the error and does
+      // not dispatch.
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(fakeSubscriber.connections.length, equals(1));
+      expect(receivedList.isEmpty, isTrue);
+
+      // Resume stream: buffered error is dispatched, triggering reconnection
+      streamSubscription.resume();
+      final connection2 = await nextConnectionFuture.timeout(
+        const Duration(seconds: 3),
+      );
+      expect(fakeSubscriber.connections.length, equals(2));
+
+      // Emit message on reconnected stream
+      connection2.emitMessage('ack-reconnected', 'msg-reconnected');
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(receivedList.length, equals(1));
+      expect(receivedList.first.ackId, equals('ack-reconnected'));
+
+      await streamSubscription.cancel();
+      await subscription.close();
+    });
+
+    test(
+      'Subscription.close() flushes and awaits in-flight batch operations',
+      () async {
+        final ackCompleter = Completer<void>();
+        var ackCompleted = false;
+
+        fakeSubscriber.acknowledgeBehavior = (ackIds) async {
+          await ackCompleter.future;
+          ackCompleted = true;
+        };
+
+        final subscription = client.subscription(
+          'test-sub',
+          ackSettings: AckSettings(
+            batching: BatchingSettings(
+              maxMessages: 10,
+              maxDelay: const Duration(seconds: 10),
+            ),
+          ),
+        );
+
+        final message = ReceivedMessage(
+          ackId: 'ack-batch-1',
+          messageId: 'msg-1',
+          publishTime: DateTime.now(),
+          message: Message(data: [1]),
+        );
+
+        subscription.acknowledge(message);
+
+        var closeCompleted = false;
+        final closeFuture = subscription.close().then((_) {
+          closeCompleted = true;
+        });
+
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        expect(closeCompleted, isFalse);
+        expect(fakeSubscriber.acknowledgeCalled, isTrue);
+
+        ackCompleter.complete();
+        await closeFuture;
+
+        expect(closeCompleted, isTrue);
+        expect(ackCompleted, isTrue);
+      },
+    );
+
+    test(
+      'multiple concurrent calls to Subscription.close() await same future',
+      () async {
+        final ackCompleter = Completer<void>();
+        fakeSubscriber.acknowledgeBehavior = (ackIds) async =>
+            ackCompleter.future;
+
+        final subscription = client.subscription(
+          'test-sub',
+          ackSettings: AckSettings(
+            batching: BatchingSettings(
+              maxMessages: 10,
+              maxDelay: const Duration(seconds: 10),
+            ),
+          ),
+        );
+
+        final message = ReceivedMessage(
+          ackId: 'ack-batch-1',
+          messageId: 'msg-1',
+          publishTime: DateTime.now(),
+          message: Message(data: [1]),
+        );
+        subscription.acknowledge(message);
+
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+
+        var c1Done = false;
+        var c2Done = false;
+        final c1 = subscription.close().then((_) => c1Done = true);
+        final c2 = subscription.close().then((_) => c2Done = true);
+
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        expect(c1Done, isFalse);
+        expect(c2Done, isFalse);
+
+        ackCompleter.complete();
+        await Future.wait([c1, c2]);
+        expect(c1Done, isTrue);
+        expect(c2Done, isTrue);
+      },
+    );
+
+    test('operations on closed subscription throw StateError', () async {
+      final subscription = client.subscription('test-sub');
+      await subscription.close();
+
+      final message = ReceivedMessage(
+        ackId: 'ack-1',
+        messageId: 'msg-1',
+        publishTime: DateTime.now(),
+        message: Message(data: [1]),
+      );
+
+      expect(() => subscription.acknowledge(message), throwsStateError);
+      expect(() => subscription.acknowledgeNow([message]), throwsStateError);
+      expect(
+        () => subscription.modifyAckDeadline(message, 10),
+        throwsStateError,
+      );
+      expect(
+        () => subscription.modifyAckDeadlineNow([message], 10),
+        throwsStateError,
+      );
+    });
+
+    test(
+      'message.acknowledge() propagates error when unary fallback fails',
+      () async {
+        fakeSubscriber.acknowledgeBehavior = (ackIds) async {
+          throw const grpc.GrpcError.internal('Unary ack failure');
+        };
+
+        final subscription = client.subscription(
+          'test-sub',
+          ackSettings: AckSettings(
+            batching: BatchingSettings(
+              maxMessages: 1,
+              maxDelay: const Duration(milliseconds: 1),
+            ),
+            retry: RetrySettings(maxRetries: 0),
+          ),
+        );
+
+        final stream = subscription.streamingPull();
+        final receivedList = <ReceivedMessage>[];
+        final streamSubscription = stream.listen(receivedList.add);
+
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        fakeSubscriber.connections.first.emitMessage(
+          'ack-fail-1',
+          'msg-fail-1',
+        );
+
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        expect(receivedList.length, equals(1));
+
+        final message = receivedList.first;
+
+        // Cancel the stream first so _activeStreams is empty and ACK
+        // must use unary fallback.
+        await streamSubscription.cancel();
+
+        await expectLater(
+          message.acknowledge(),
+          throwsA(isA<InternalServerErrorException>()),
+        );
+
+        await subscription.close();
+      },
+    );
+
+    test(
+      'message.modifyAckDeadline() propagates error when unary fallback fails',
+      () async {
+        fakeSubscriber.modifyAckDeadlineBehavior = (ackIds, seconds) async {
+          throw const grpc.GrpcError.internal('Unary mod failure');
+        };
+
+        final subscription = client.subscription(
+          'test-sub',
+          ackSettings: AckSettings(
+            batching: BatchingSettings(
+              maxMessages: 1,
+              maxDelay: const Duration(milliseconds: 1),
+            ),
+            retry: RetrySettings(maxRetries: 0),
+          ),
+        );
+
+        final stream = subscription.streamingPull();
+        final receivedList = <ReceivedMessage>[];
+        final streamSubscription = stream.listen(receivedList.add);
+
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        fakeSubscriber.connections.first.emitMessage(
+          'ack-fail-2',
+          'msg-fail-2',
+        );
+
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        expect(receivedList.length, equals(1));
+
+        final message = receivedList.first;
+
+        // Cancel the stream first so _activeStreams is empty and modify
+        // must use unary fallback.
+        await streamSubscription.cancel();
+
+        await expectLater(
+          message.modifyAckDeadline(10),
+          throwsA(isA<InternalServerErrorException>()),
+        );
+
+        await subscription.close();
+      },
+    );
+
+    test('Subscription.close() stops active streaming pull controllers '
+        'and prevents reconnects', () async {
+      final subscription = client.subscription(
+        'test-sub',
+        ackSettings: AckSettings(
+          retry: RetrySettings(
+            maxRetries: 10,
+            initialDelay: const Duration(milliseconds: 10),
+          ),
+        ),
+      );
+
+      final stream = subscription.streamingPull();
+      var isDone = false;
+      stream.listen(
+        (_) {},
+        onDone: () {
+          isDone = true;
+        },
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(fakeSubscriber.connections.length, equals(1));
+
+      await subscription.close();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(isDone, isTrue);
+      final countAfterClose = fakeSubscriber.connections.length;
+
+      // Simulate error on the previous connection response controller
+      fakeSubscriber.connections.first.responseController.addError(
+        const grpc.GrpcError.unavailable('Simulated connection dropped'),
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      // No new connections should be spawned after close
+      expect(fakeSubscriber.connections.length, equals(countAfterClose));
+    });
+
+    test('cancellation during stream initialization (_callOptions) '
+        'does not leak connections', () async {
+      final delayedAuth = DelayedAuthenticator();
+      final clientWithDelayedAuth = PubSub.testing(
+        projectId: 'test-project',
+        channel: FakeClientChannel(),
+        subscriberClient: fakeSubscriber,
+        authenticator: delayedAuth,
+      );
+
+      final requestController =
+          StreamController<generated.StreamingPullRequest>();
+      final stream = clientWithDelayedAuth.streamingPullWithStream(
+        requestController.stream,
+      );
+
+      final streamSubscription = stream.listen((_) {});
+      // Cancel immediately while _callOptions is in-flight
+      await streamSubscription.cancel();
+
+      // Now complete the authenticator
+      delayedAuth.completer.complete();
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      // Fake subscriber should not have received a streamingPull call
+      expect(fakeSubscriber.connections.isEmpty, isTrue);
+
+      if (!requestController.hasListener) {
+        unawaited(requestController.stream.drain<void>());
+      }
+      await requestController.close();
+      await clientWithDelayedAuth.close();
+    });
+
+    test('stream without listener is skipped during ACK batching and '
+        'falls back to unary', () async {
+      final subscription = client.subscription(
+        'test-sub',
+        ackSettings: AckSettings(
+          batching: BatchingSettings(
+            maxMessages: 1,
+            maxDelay: const Duration(milliseconds: 1),
+          ),
+          retry: RetrySettings(maxRetries: 0),
+        ),
+      );
+
+      // Start streaming pull to establish active stream
+      final stream = subscription.streamingPull();
+      final receivedList = <ReceivedMessage>[];
+      final streamSubscription = stream.listen(receivedList.add);
+
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(fakeSubscriber.connections.length, equals(1));
+      fakeSubscriber.connections.first.emitMessage(
+        'ack-stream-skip',
+        'msg-stream-skip',
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(receivedList.length, equals(1));
+      final message = receivedList.first;
+
+      // Cancel stream listener so controller hasListener == false
+      await streamSubscription.cancel();
+
+      // Acknowledge should skip unlistened stream and invoke unary ack
+      await message.acknowledge();
+
+      expect(fakeSubscriber.acknowledgeCalled, isTrue);
+      expect(
+        fakeSubscriber.unaryAckCalls.any(
+          (call) => call.contains('ack-stream-skip'),
+        ),
+        isTrue,
+      );
+
+      await subscription.close();
+    });
+
+    test(
+      'custom RetrySettings is respected directly in streamingPull',
+      () async {
+        final subscription = client.subscription('test-sub');
+
+        final customRetry = RetrySettings(
+          maxRetries: 5,
+          totalTimeout: const Duration(minutes: 5),
+          initialDelay: const Duration(milliseconds: 10),
+        );
+        expect(customRetry.totalTimeout, equals(const Duration(minutes: 5)));
+
+        final stream = subscription.streamingPull(retry: customRetry);
+        final streamSubscription = stream.listen((_) {});
+
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        expect(fakeSubscriber.connections.length, equals(1));
+
+        await streamSubscription.cancel();
+        await subscription.close();
+      },
+    );
+
+    test(
+      'streamingPullWithStream closes controller when setup fails',
+      () async {
+        final clientWithFailure = PubSub.testing(
+          projectId: 'test-project',
+          channel: FakeClientChannel(),
+          subscriberClient: ThrowingSubscriberClient(),
+        );
+        final reqController =
+            StreamController<generated.StreamingPullRequest>();
+        final stream = clientWithFailure.streamingPullWithStream(
+          reqController.stream,
+        );
+
+        final errors = <Object>[];
+        var isDone = false;
+        stream.listen((_) {}, onError: errors.add, onDone: () => isDone = true);
+
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        expect(errors.length, equals(1));
+        expect(errors.first, isA<StateError>());
+        expect(isDone, isTrue);
+
+        unawaited(reqController.close());
+        await clientWithFailure.close();
+      },
+    );
+
+    test(
+      'streamingPullWithStream closes controller when _callOptions fails',
+      () async {
+        final clientWithAuthFailure = PubSub.testing(
+          projectId: 'test-project',
+          channel: FakeClientChannel(),
+          subscriberClient: fakeSubscriber,
+          authenticator: ThrowingAuthenticator(),
+        );
+        final reqController =
+            StreamController<generated.StreamingPullRequest>();
+        final stream = clientWithAuthFailure.streamingPullWithStream(
+          reqController.stream,
+        );
+
+        final errors = <Object>[];
+        var isDone = false;
+        stream.listen((_) {}, onError: errors.add, onDone: () => isDone = true);
+
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        expect(errors.length, equals(1));
+        expect(isDone, isTrue);
+
+        unawaited(reqController.close());
+        await clientWithAuthFailure.close();
+      },
+    );
+
+    test(
+      'Subscription batchers flush over active stream during normal operation',
+      () async {
+        final subscription = client.subscription(
+          'test-sub',
+          ackSettings: AckSettings(
+            batching: BatchingSettings(
+              maxMessages: 1,
+              maxDelay: const Duration(seconds: 10),
+            ),
+            retry: RetrySettings(maxRetries: 0),
+          ),
+        );
+
+        final stream = subscription.streamingPull();
+        final streamSubscription = stream.listen((_) {});
+
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        expect(fakeSubscriber.connections.length, equals(1));
+
+        final message = ReceivedMessage(
+          ackId: 'ack-stream-test',
+          messageId: 'msg-stream-test',
+          publishTime: DateTime.now(),
+          message: Message(data: [1, 2, 3]),
+        );
+
+        subscription.acknowledge(message);
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+
+        final connection = fakeSubscriber.connections.first;
+        final streamAckedIds = connection.recordedRequests
+            .expand((request) => request.ackIds)
+            .toList();
+
+        expect(streamAckedIds, contains('ack-stream-test'));
+        expect(fakeSubscriber.unaryAckCalls, isEmpty);
+
+        await streamSubscription.cancel();
+        await subscription.close();
+      },
+    );
+
+    test('Subscription.close() flushes batchers via unary RPC during shutdown '
+        'to guarantee server confirmation', () async {
+      final subscription = client.subscription(
+        'test-sub',
+        ackSettings: AckSettings(
+          batching: BatchingSettings(
+            maxMessages: 100,
+            maxDelay: const Duration(seconds: 10),
+          ),
+          retry: RetrySettings(maxRetries: 0),
+        ),
+      );
+
+      final stream = subscription.streamingPull();
+      final streamSubscription = stream.listen((_) {});
+
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(fakeSubscriber.connections.length, equals(1));
+
+      final message = ReceivedMessage(
+        ackId: 'ack-close-test',
+        messageId: 'msg-close-test',
+        publishTime: DateTime.now(),
+        message: Message(data: [1, 2, 3]),
+      );
+
+      subscription.acknowledge(message);
+
+      // Close the subscription. During shutdown, streams are cancelled and
+      // batchers are flushed via unary RPC to ensure server confirmation.
+      await subscription.close();
+
+      expect(fakeSubscriber.unaryAckCalls.single, contains('ack-close-test'));
+
+      await streamSubscription.cancel();
+    });
+
+    test('streamingPullWithStream emits error and closes controller on '
+        'mid-stream error', () async {
+      final reqController = StreamController<generated.StreamingPullRequest>();
+      final stream = client.streamingPullWithStream(reqController.stream);
+
+      final errors = <Object>[];
+      final items = <ReceivedMessage>[];
+      var isDone = false;
+      final streamSubscription = stream.listen(
+        items.add,
+        onError: errors.add,
+        onDone: () => isDone = true,
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(fakeSubscriber.connections.length, equals(1));
+      final connection = fakeSubscriber.connections.first
+        ..emitMessage('ack-mid-stream', 'msg-mid-stream');
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(items.length, equals(1));
+      expect(items.first.ackId, equals('ack-mid-stream'));
+
+      // Emit mid-stream gRPC error on response stream
+      connection.responseController.addError(
+        const grpc.GrpcError.unavailable('Transient mid-stream drop'),
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(errors.length, equals(1));
+      expect(errors.first, isA<ServiceException>());
+      expect(isDone, isTrue);
+
+      await streamSubscription.cancel();
+      unawaited(reqController.close());
+    });
+
+    test('multi-stream teardown on non-retryable error does not emit duplicate '
+        'errors or leave orphaned timers', () async {
+      final subscription = client.subscription('test-sub');
+      final stream = subscription.streamingPull(
+        maxConcurrentStreams: 4,
+        retry: RetrySettings(
+          maxRetries: 5,
+          initialDelay: const Duration(milliseconds: 20),
+        ),
+      );
+
+      final errors = <Object>[];
+      var isDone = false;
+      final streamSubscription = stream.listen(
+        (_) {},
+        onError: errors.add,
+        onDone: () => isDone = true,
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(fakeSubscriber.connections.length, equals(4));
+
+      // Inject non-retryable error on connection[0], concurrent
+      // non-retryable error on connection[1] (tests duplicate error
+      // suppression), concurrent transient retryable error on connection[2]
+      // (tests orphaned timer suppression), and concurrent normal closure
+      // on connection[3] (tests onDone).
+      fakeSubscriber.connections[0].responseController.addError(
+        const grpc.GrpcError.notFound('Subscription not found'),
+      );
+      fakeSubscriber.connections[1].responseController.addError(
+        const grpc.GrpcError.notFound('Subscription not found'),
+      );
+      fakeSubscriber.connections[2].responseController.addError(
+        const grpc.GrpcError.unavailable('Transient drop'),
+      );
+      unawaited(fakeSubscriber.connections[3].responseController.close());
+
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(errors.length, equals(1));
+      expect(errors.first, isA<NotFoundException>());
+      expect(isDone, isTrue);
+
+      // Wait beyond the retry backoff duration (20ms) to verify that no
+      // orphaned reconnect timers fired.
+      await Future<void>.delayed(const Duration(milliseconds: 60));
+      expect(fakeSubscriber.connections.length, equals(4));
+
+      await streamSubscription.cancel();
+      await subscription.close();
+    });
+
+    test(
+      'idle streaming pull reconnects cleanly on onDone without messages',
+      () async {
+        final subscription = client.subscription('test-sub');
+        final stream = subscription.streamingPull(
+          retry: RetrySettings(
+            maxRetries: 2,
+            initialDelay: const Duration(milliseconds: 10),
+            maxDelay: const Duration(milliseconds: 20),
+          ),
+        );
+
+        final streamSubscription = stream.listen((_) {});
+        await Future<void>.delayed(const Duration(milliseconds: 15));
+        expect(fakeSubscriber.connections.length, equals(1));
+
+        // Server closes idle connection without any messages or errors.
+        await fakeSubscriber.connections.first.responseController.close();
+
+        await Future<void>.delayed(const Duration(milliseconds: 30));
+        // Should have reconnected cleanly.
+        expect(fakeSubscriber.connections.length, equals(2));
+
+        await streamSubscription.cancel();
+        await subscription.close();
+      },
+    );
+
+    test('concurrent message.acknowledge and modifyAckDeadline calls for '
+        'duplicate ackId resolve all completers', () async {
+      final subscription = client.subscription('test-sub');
+      final stream = subscription.streamingPull();
+      ReceivedMessage? received;
+      final streamSubscription = stream.listen((message) {
+        received = message;
+      });
+
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(fakeSubscriber.connections.length, equals(1));
+
+      final connection = fakeSubscriber.connections.first;
+      connection.responseController.add(
+        generated.StreamingPullResponse()
+          ..receivedMessages.add(
+            generated.ReceivedMessage()
+              ..ackId = 'duplicate-ack'
+              ..message = (generated.PubsubMessage()..messageId = 'm1'),
+          ),
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(received, isNotNull);
+
+      // Multiple calls on the same ackId
+      final a1 = received!.acknowledge();
+      final a2 = received!.acknowledge();
+      await Future.wait([a1, a2]).timeout(const Duration(seconds: 2));
+
+      final m1 = received!.modifyAckDeadline(30);
+      final m2 = received!.modifyAckDeadline(0);
+      await Future.wait([m1, m2]).timeout(const Duration(seconds: 2));
+
+      await streamSubscription.cancel();
+      await subscription.close();
+    });
+
+    test('Subscription.close() completes without hanging when stream consumer '
+        'is paused', () async {
+      final subscription = client.subscription('test-sub');
+      final stream = subscription.streamingPull();
+      final streamSubscription = stream.listen((_) {})..pause();
+
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      // Should complete quickly despite the stream subscription being paused.
+      await subscription.close().timeout(const Duration(seconds: 2));
+      await streamSubscription.cancel();
+    });
+
+    test(
+      'multi-stream preserves fatal error when peer completes via onDone',
+      () async {
+        final subscription = client.subscription(
+          'test-sub',
+          ackSettings: AckSettings(retry: RetrySettings(maxRetries: 0)),
+        );
+
+        final stream = subscription.streamingPull(maxConcurrentStreams: 2);
+        final errors = <Object>[];
+        var isDone = false;
+        final streamSubscription = stream.listen(
+          (_) {},
+          onError: errors.add,
+          onDone: () => isDone = true,
+        );
+
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        expect(fakeSubscriber.connections.length, equals(2));
+
+        final connection1 = fakeSubscriber.connections[0];
+        final connection2 = fakeSubscriber.connections[1];
+
+        // connection1 fails with retryable error which exhausts retries
+        // (maxRetries: 0)
+        connection1.responseController.addError(
+          const grpc.GrpcError.unavailable('transient error'),
+        );
+
+        // connection2 closes cleanly via onDone
+        await connection2.responseController.close();
+
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        expect(errors, hasLength(1));
+        expect(errors.first, isA<ServiceException>());
+        expect(isDone, isTrue);
+
+        await streamSubscription.cancel();
+        await subscription.close();
+      },
+    );
+
+    test(
+      'streamingPull exhausts maxRetries on repeated rapid clean onDone drops',
+      () async {
+        final subscription = client.subscription(
+          'test-sub',
+          ackSettings: AckSettings(
+            retry: RetrySettings(
+              maxRetries: 2,
+              initialDelay: const Duration(milliseconds: 1),
+            ),
+          ),
+        );
+
+        final stream = subscription.streamingPull();
+        var isDone = false;
+        final streamSubscription = stream.listen(
+          (_) {},
+          onDone: () {
+            isDone = true;
+          },
+        );
+
+        // Connection 0: close immediately without messages
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        expect(fakeSubscriber.connections.length, equals(1));
+        await fakeSubscriber.connections[0].responseController.close();
+
+        // Connection 1 (retry 1): close immediately
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        expect(fakeSubscriber.connections.length, equals(2));
+        await fakeSubscriber.connections[1].responseController.close();
+
+        // Connection 2 (retry 2): close immediately
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        expect(fakeSubscriber.connections.length, equals(3));
+        await fakeSubscriber.connections[2].responseController.close();
+
+        // Retries should be exhausted and stream should complete
+        await Future<void>.delayed(const Duration(milliseconds: 30));
+        expect(isDone, isTrue);
+        expect(fakeSubscriber.connections.length, equals(3));
+
+        await streamSubscription.cancel();
+        await subscription.close();
+      },
+    );
+
+    test('Subscription.close() called from within stream listener callback '
+        'completes without deadlock', () async {
+      final subscription = client.subscription('test-sub');
+      final stream = subscription.streamingPull();
+
+      final closed = Completer<void>();
+      late StreamSubscription<ReceivedMessage> streamSubscription;
+      streamSubscription = stream.listen((message) async {
+        await subscription.close().timeout(const Duration(seconds: 2));
+        closed.complete();
+      });
+
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(fakeSubscriber.connections.length, equals(1));
+      fakeSubscriber.connections.first.emitMessage('ack-1', 'msg-1');
+
+      await closed.future.timeout(const Duration(seconds: 3));
+      expect(subscription.isClosed, isTrue);
+      await streamSubscription.cancel();
+    });
+
+    test('message.acknowledge() and modifyAckDeadline() on received message '
+        'succeed via unary RPC during or after Subscription.close()', () async {
+      final subscription = client.subscription('test-sub');
+      final stream = subscription.streamingPull();
+
+      final receivedMessageCompleter = Completer<ReceivedMessage>();
+      final streamSubscription = stream.listen(
+        receivedMessageCompleter.complete,
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(fakeSubscriber.connections.length, equals(1));
+      fakeSubscriber.connections.first.emitMessage('ack-drain', 'msg-drain');
+
+      final message = await receivedMessageCompleter.future;
+
+      // Close the subscription.
+      await subscription.close();
+      expect(subscription.isClosed, isTrue);
+
+      // Direct calls on the Subscription instance throw StateError.
+      expect(() => subscription.acknowledge(message), throwsStateError);
+      expect(
+        () => subscription.modifyAckDeadline(message, 30),
+        throwsStateError,
+      );
+
+      // But calling message.acknowledge() and message.modifyAckDeadline()
+      // on the already-delivered message succeeds via unary fallback.
+      await message.acknowledge();
+      expect(fakeSubscriber.unaryAckCalls.single, contains('ack-drain'));
+
+      await message.modifyAckDeadline(30);
+      expect(
+        fakeSubscriber.unaryModifyDeadlineCalls.single.$1,
+        contains('ack-drain'),
+      );
+      expect(fakeSubscriber.unaryModifyDeadlineCalls.single.$2, equals(30));
+
+      await streamSubscription.cancel();
+    });
+
+    test('streamingPull round-robins ACKs across active streams and '
+        'advances past closed streams', () async {
+      final subscription = client.subscription(
+        'test-sub',
+        ackSettings: AckSettings(batching: BatchingSettings(maxMessages: 1)),
+      );
+      final stream = subscription.streamingPull(maxConcurrentStreams: 3);
+      final streamSubscription = stream.listen((_) {});
+
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(fakeSubscriber.connections.length, equals(3));
+
+      final connection0 = fakeSubscriber.connections[0];
+      final connection1 = fakeSubscriber.connections[1];
+      final connection2 = fakeSubscriber.connections[2];
+
+      // Send ACK 1 -> routes to connection0
+      subscription.acknowledge(
+        ReceivedMessage(
+          ackId: 'ack-1',
+          messageId: 'msg-1',
+          publishTime: DateTime.now(),
+          message: Message(data: [1]),
+          deliveryAttempt: 1,
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      // Send ACK 2 -> routes to connection1
+      subscription.acknowledge(
+        ReceivedMessage(
+          ackId: 'ack-2',
+          messageId: 'msg-2',
+          publishTime: DateTime.now(),
+          message: Message(data: [2]),
+          deliveryAttempt: 1,
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      // Close connection2 so only connection0 and connection1 remain active
+      await connection2.responseController.close();
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      // Send ACK 3 -> starts at index 2 (closed connection2), skips to
+      // connection0.
+      // nextStreamIndex must advance to (0 + 1) = 1, not re-hit connection0!
+      subscription.acknowledge(
+        ReceivedMessage(
+          ackId: 'ack-3',
+          messageId: 'msg-3',
+          publishTime: DateTime.now(),
+          message: Message(data: [3]),
+          deliveryAttempt: 1,
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      // Send ACK 4 -> routes to connection1
+      subscription.acknowledge(
+        ReceivedMessage(
+          ackId: 'ack-4',
+          messageId: 'msg-4',
+          publishTime: DateTime.now(),
+          message: Message(data: [4]),
+          deliveryAttempt: 1,
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      final acks0 = connection0.recordedRequests
+          .expand((request) => request.ackIds)
+          .toList();
+      final acks1 = connection1.recordedRequests
+          .expand((request) => request.ackIds)
+          .toList();
+
+      expect(acks0, equals(['ack-1', 'ack-3']));
+      expect(acks1, equals(['ack-2', 'ack-4']));
+
+      await streamSubscription.cancel();
+      await subscription.close();
+    });
+  });
+}


### PR DESCRIPTION
This is **Part 2 of 2** in a stacked set of PRs:
1. **#292**: Message and acknowledgment batching with retry infrastructure (`pubsub-retry-batching`)
2. **#339 (this PR)**: Resilient parallel streaming pull (`pubsub-streaming-pull`)

---

### Key Features
- **Resilient Multi-Stream Streaming Pull**:
  - `Subscription.streamingPull` with configurable `maxConcurrentStreams` for parallel streaming pull connections multiplexed into a single stream.
  - Automatic reconnection with exponential backoff on transient errors and disconnects using `RetryRunner` / `ExponentialRetry`.
  - Connection health tracking: backoff resets once a stream is sustained and healthy (>= 15 seconds) or messages are successfully received (`hasReceivedItem`).
  - Multi-stream failure isolation: failure on a single lane does not prematurely abort healthy peer streams under consumer `await for` loops.
- **Batch Routing Over Active Streams**:
  - Batched acknowledgments and deadline modifications from `Subscription.acknowledge` and `modifyAckDeadline` are automatically routed over active bidirectional streaming pull channels instead of separate unary RPCs.
  - Safe fallback to unary RPCs with exponential backoff retries when streams are reconnecting or unavailable.
- **Low-Level Streaming Pull**:
  - `PubSub.streamingPullWithStream` for streaming pull over an explicit request stream with bidirectional communication and clean controller teardown via `DisposableStreamController`.
- **Backpressure**:
  - Pause and resume forwarding across all active parallel streams.
- **Clean Teardown & Lifecycle**:
  - In `Subscription.close()`, flushes batchers over active stream controllers and awaits request stream close before cancelling response stream subscriptions, guaranteeing flushed ACKs and deadline modifications are transmitted before stream termination.
  - Guarded `requestController.add` in client handlers against `StateError` during concurrent close.
  - Sessions registered in `onListen` to prevent leaks on unlistened streams.
- **Documentation & Examples**:
  - Added `example/doc_examples.dart` demonstrating long-lived streaming pull and graceful shutdown.
  - Updated `README.md` and `CHANGELOG.md`.

TAG=agy
CONV=4ecd3490-bbbe-499e-90e5-07ea5e14a460
